### PR TITLE
Adding 33px marginBottom to docs h2 Dividers 

### DIFF
--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -37,7 +37,7 @@ const mdxComponents = {
           <a className={classNames(linkStyle['spectrum-Link'], docStyles['anchor'])} href={`#${props.id}`}>#</a>
         </span>
       </h2>
-      <Divider />
+      <Divider UNSAFE_style={{'margin-bottom': '33px'}} />
     </>
   ),
   h3: ({children, ...props}) => (

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -37,7 +37,7 @@ const mdxComponents = {
           <a className={classNames(linkStyle['spectrum-Link'], docStyles['anchor'])} href={`#${props.id}`}>#</a>
         </span>
       </h2>
-      <Divider UNSAFE_style={{'margin-bottom': '33px'}} />
+      <Divider marginBottom="33px" />
     </>
   ),
   h3: ({children, ...props}) => (

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -104,7 +104,7 @@ article h2 {
 }
 
 article h2 + hr {
-  margin-bottom: 33px;
+  margin-bottom: 33px !important;
 }
 
 .example {

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -104,7 +104,7 @@ article h2 {
 }
 
 article h2 + hr {
-  margin-bottom: 33px !important;
+  margin-bottom: 33px;
 }
 
 .example {


### PR DESCRIPTION
The margin after the Dividers in the docs are no longer being applied due to https://github.com/adobe-private/react-spectrum-v3/pull/219/files#diff-d8e11efd03c2819ee9dcbff951997962R40. To fix, I added the 33px from https://github.com/adobe-private/react-spectrum-v3/blob/46eb66cbe0fd197d458d4ef93f3c4961667dbf64/packages/dev/docs/src/docs.css#L107 to the h2 Divider in Layout as a override 