### PR TITLE
Dialog story fixes

### DIFF
--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -51,7 +51,7 @@ export function Dialog(props: SpectrumDialogProps) {
     return (
       <ModalDialog {...allProps} size={otherProps.size}>
         {children}
-        {isDismissable && <ActionButton slot="closeButton" autoFocus isQuiet icon={<CrossLarge size="L" />} onPress={onDismiss} />}
+        {isDismissable && <ActionButton slot="closeButton" isQuiet icon={<CrossLarge size="L" />} onPress={onDismiss} />}
       </ModalDialog>
     );
   }
@@ -88,7 +88,7 @@ function BaseDialog({children, slots, size = 'L', role, ...otherProps}: Spectrum
   }
 
   return (
-    <FocusScope contain restoreFocus autoFocus>
+    <FocusScope contain restoreFocus>
       <div
         {...mergeProps(otherProps, dialogProps)}
         className={classNames(

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -16,6 +16,7 @@ import {AlertDialog, Dialog, DialogTrigger} from '../';
 import {Checkbox} from '@react-spectrum/checkbox';
 import {Content, Footer, Header} from '@react-spectrum/view';
 import {Divider} from '@react-spectrum/divider';
+import {Flex} from '@react-spectrum/layout';
 import {Form} from '@react-spectrum/form';
 import {Image} from '@react-spectrum/image';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
@@ -24,7 +25,6 @@ import {SpectrumAlertDialogProps} from '@react-types/dialog';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/typography';
 import {TextField} from '@react-spectrum/textfield';
-import {Flex} from '@react-spectrum/layout';
 
 storiesOf('Dialog', module)
 // DialogTrigger isn't affected by color scheme, so only visual test light, and ensure animations work properly.

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -24,6 +24,7 @@ import {SpectrumAlertDialogProps} from '@react-types/dialog';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/typography';
 import {TextField} from '@react-spectrum/textfield';
+import {Flex} from '@react-spectrum/layout';
 
 storiesOf('Dialog', module)
 // DialogTrigger isn't affected by color scheme, so only visual test light, and ensure animations work properly.
@@ -80,6 +81,10 @@ storiesOf('Dialog', module)
   .add(
     'three buttons',
     () => renderWithThreeButtons({})
+  )
+  .add(
+    'cleared content',
+    () => renderWithDividerInContent({})
   );
 
 storiesOf('Dialog/Alert', module)
@@ -327,9 +332,34 @@ function renderWithThreeButtons({width = 'auto', ...props}) {
           <Divider size="M" />
           <Content>{singleParagraph()}</Content>
           <Footer>
-            <Button variant="secondary">Whoops I named this button a long name</Button>
-            <Button variant="primary">Cancel and forget about forever</Button>
-            <Button variant="cta" autoFocus>Confirm Starscream is the worst</Button>
+            <Button variant="secondary">Secondary</Button>
+            <Button variant="primary">Primary</Button>
+            <Button variant="cta" autoFocus>CTA</Button>
+          </Footer>
+        </Dialog>
+      </DialogTrigger>
+    </div>
+  );
+}
+
+function renderWithDividerInContent({width = 'auto', ...props}) {
+  return (
+    <div style={{display: 'flex', width, margin: '100px 0'}}>
+      <DialogTrigger isOpen>
+        <ActionButton>Trigger</ActionButton>
+        <Dialog {...props}>
+          <Header><Text slot="title">The Title</Text></Header>
+          <Divider size="M" />
+          <Content>
+            <Flex UNSAFE_style={{padding: '10px'}}>
+              <Text flexGrow={1} flexBasis={0}>Column number one. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</Text>
+              <Divider flexShrink={0} marginStart={10} marginEnd={10} orientation="vertical" size="S" />
+              <Text flexGrow={1} flexBasis={0}>Column number two. Eleifend quam adipiscing vitae proin sagittis nisl. Diam donec adipiscing tristique risus.</Text>
+            </Flex>
+          </Content>
+          <Footer>
+            <Button variant="primary">Primary</Button>
+            <Button variant="cta" autoFocus>CTA</Button>
           </Footer>
         </Dialog>
       </DialogTrigger>

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -32,7 +32,7 @@ storiesOf('DialogTrigger', module)
   )
   .add(
     'type: popover',
-    () => render({type: 'popover'})
+    () => renderPopover({type: 'popover'})
   )
   .add(
     'type: modal',
@@ -41,17 +41,17 @@ storiesOf('DialogTrigger', module)
   )
   .add(
     'type: tray',
-    () => render({type: 'tray'}),
+    () => renderPopover({type: 'tray'}),
     {chromaticProvider: {scales: ['medium'], height: 1000}}
   )
   .add(
     'popover with mobileType: modal',
-    () => render({type: 'popover', mobileType: 'modal'}),
+    () => renderPopover({type: 'popover', mobileType: 'modal'}),
     {chromaticProvider: {scales: ['medium'], height: 1000}, chromatic: {viewports: [350]}}
   )
   .add(
     'popover with mobileType: tray',
-    () => render({type: 'popover', mobileType: 'tray'}),
+    () => renderPopover({type: 'popover', mobileType: 'tray'}),
     {chromaticProvider: {scales: ['medium'], height: 1000}, chromatic: {viewports: [350]}}
   )
   .add(
@@ -132,71 +132,71 @@ storiesOf('DialogTrigger', module)
   )
   .add(
     'placement="left"',
-    () => render({type: 'popover', placement: 'left'})
+    () => renderPopover({type: 'popover', placement: 'left'})
   )
   .add(
     'placement="left top"',
-    () => render({type: 'popover', placement: 'left top'})
+    () => renderPopover({type: 'popover', placement: 'left top'})
   )
   .add(
     'placement="left bottom"',
-    () => render({type: 'popover', placement: 'left bottom'})
+    () => renderPopover({type: 'popover', placement: 'left bottom'})
   )
   .add(
     'placement="right"',
-    () => render({type: 'popover', placement: 'right'})
+    () => renderPopover({type: 'popover', placement: 'right'})
   )
   .add(
     'placement="right top"',
-    () => render({type: 'popover', placement: 'right top'})
+    () => renderPopover({type: 'popover', placement: 'right top'})
   )
   .add(
     'placement="right bottom"',
-    () => render({type: 'popover', placement: 'right bottom'})
+    () => renderPopover({type: 'popover', placement: 'right bottom'})
   )
   .add(
     'placement="bottom"',
-    () => render({type: 'popover', placement: 'bottom'})
+    () => renderPopover({type: 'popover', placement: 'bottom'})
   )
   .add(
     'placement="bottom left"',
-    () => render({type: 'popover', placement: 'bottom left'})
+    () => renderPopover({type: 'popover', placement: 'bottom left'})
   )
   .add(
     'placement="bottom right"',
-    () => render({type: 'popover', placement: 'bottom right'})
+    () => renderPopover({type: 'popover', placement: 'bottom right'})
   )
   .add(
     'placement="top"',
-    () => render({type: 'popover', placement: 'top'})
+    () => renderPopover({type: 'popover', placement: 'top'})
   )
   .add(
     'placement="top left"',
-    () => render({type: 'popover', placement: 'top left'})
+    () => renderPopover({type: 'popover', placement: 'top left'})
   )
   .add(
     'placement="top right"',
-    () => render({type: 'popover', placement: 'top right'})
+    () => renderPopover({type: 'popover', placement: 'top right'})
   )
   .add(
     'offset',
-    () => render({type: 'popover', offset: 50})
+    () => renderPopover({type: 'popover', offset: 50})
   )
   .add(
     'crossOffset',
-    () => render({type: 'popover', crossOffset: 50})
+    () => renderPopover({type: 'popover', crossOffset: 50})
   )
   .add(
     'shouldFlip: true',
-    () => render({type: 'popover', placement: 'left', shouldFlip: true, width: 'calc(100vh - 100px)'})
+    () => renderPopover({type: 'popover', placement: 'left', shouldFlip: true, width: 'calc(100vh - 100px)'})
   )
   .add(
     'shouldFlip: false',
-    () => render({type: 'popover', placement: 'left', shouldFlip: false, width: 'calc(100vh - 100px)'})
+    () => renderPopover({type: 'popover', placement: 'left', shouldFlip: false, width: 'calc(100vh - 100px)'})
   )
   .add(
     'containerPadding',
-    () => render({type: 'popover', placement: 'bottom', width: 'calc(100vh - 100px)', containerPadding: 20})
+    () => renderPopover({type: 'popover', placement: 'bottom', width: 'calc(100vh - 100px)', containerPadding: 20})
   )
   .add(
     'alert dialog',
@@ -213,6 +213,21 @@ function render({width = 'auto', ...props}) {
           <Divider size="M" />
           <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
           <Footer><Button variant="secondary">Cancel</Button><Button variant="cta">Confirm</Button></Footer>
+        </Dialog>
+      </DialogTrigger>
+    </div>
+  );
+}
+
+function renderPopover({width = 'auto', ...props}) {
+  return (
+    <div style={{display: 'flex', width, margin: '100px 0'}}>
+      <DialogTrigger {...props} defaultOpen={isChromatic()}>
+        <ActionButton>Trigger</ActionButton>
+        <Dialog>
+          <Header><Text slot="title">The Title</Text></Header>
+          <Divider size="M" />
+          <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
         </Dialog>
       </DialogTrigger>
     </div>

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -63,15 +63,19 @@ storiesOf('DialogTrigger', module)
           <DialogTrigger>
             <ActionButton>Trigger</ActionButton>
             <Dialog>
-              <input />
-              <input />
-              <DialogTrigger>
-                <ActionButton>Trigger</ActionButton>
-                <Dialog>
-                  <input />
-                  <input />
-                </Dialog>
-              </DialogTrigger>
+              <Content>
+                <input />
+                <input />
+                <DialogTrigger>
+                  <ActionButton>Trigger</ActionButton>
+                  <Dialog>
+                    <Content>
+                      <input />
+                      <input />
+                    </Content>
+                  </Dialog>
+                </DialogTrigger>
+              </Content>
             </Dialog>
           </DialogTrigger>
         </Provider>
@@ -86,12 +90,14 @@ storiesOf('DialogTrigger', module)
         <DialogTrigger type="popover">
           <ActionButton>Trigger</ActionButton>
           <Dialog>
-            <input />
-            <input />
-            <DialogTrigger type="popover">
-              <ActionButton>Trigger</ActionButton>
-              <Dialog>Hi!</Dialog>
-            </DialogTrigger>
+            <Content>
+              <input />
+              <input />
+              <DialogTrigger type="popover">
+                <ActionButton>Trigger</ActionButton>
+                <Dialog><Content>Hi!</Content></Dialog>
+              </DialogTrigger>
+            </Content>
           </Dialog>
         </DialogTrigger>
       </div>
@@ -107,8 +113,10 @@ storiesOf('DialogTrigger', module)
             <DialogTrigger type="popover">
               <ActionButton>Trigger</ActionButton>
               <Dialog>
-                <input />
-                <input />
+                <Content>
+                  <input />
+                  <input />
+                </Content>
               </Dialog>
             </DialogTrigger>
           </div>
@@ -217,7 +225,7 @@ function renderAlert({width = 'auto', ...props}) {
       <DialogTrigger {...props} defaultOpen={isChromatic()}>
         <ActionButton>Trigger</ActionButton>
         <AlertDialog title="Alert! Danger!" variant="error" primaryLabel="Accept" secondaryLabel="Whoa" cancelLabel="Cancel" onCancel={action('cancel')} onConfirm={action('confirm')}>
-          Fine! No, absolutely fine. It's not like I don't have, you know, ten thousand other test subjects begging me to help them escape. You know, it's not like this place is about to EXPLODE.
+          <Text>Fine! No, absolutely fine. It's not like I don't have, you know, ten thousand other test subjects begging me to help them escape. You know, it's not like this place is about to EXPLODE.</Text>
         </AlertDialog>
       </DialogTrigger>
     </div>

--- a/packages/@react-spectrum/dialog/test/Dialog.test.js
+++ b/packages/@react-spectrum/dialog/test/Dialog.test.js
@@ -19,16 +19,16 @@ import React from 'react';
 describe('Dialog', function () {
   afterEach(cleanup);
 
-  it('auto focuses the first tabbable element by default', function () {
-    let {getByTestId} = render(
+  it('does not auto focus anything inside', function () {
+    let {getByRole} = render(
       <Dialog>
         <input data-testid="input1" />
         <input data-testid="input2" />
       </Dialog>
     );
 
-    let input1 = getByTestId('input1');
-    expect(document.activeElement).toBe(input1);
+    let dialog = getByRole('dialog');
+    expect(document.activeElement).toBe(dialog);
   });
 
   it('auto focuses the dialog itself if there is no focusable child', function () {
@@ -42,7 +42,7 @@ describe('Dialog', function () {
     expect(document.activeElement).toBe(dialog);
   });
 
-  it('allows autofocus prop on a child element to work as expected', function () {
+  it('autofocuses any element that has autofocus inside', function () {
     let {getByTestId} = render(
       <Dialog>
         <input data-testid="input1" />
@@ -55,18 +55,22 @@ describe('Dialog', function () {
   });
 
   it('contains focus within the dialog', function () {
-    let {getByTestId} = render(
+    let {getByRole, getByTestId} = render(
       <Dialog>
         <input data-testid="input1" />
         <input data-testid="input2" />
       </Dialog>
     );
 
+    let dialog = getByRole('dialog');
     let input1 = getByTestId('input1');
     let input2 = getByTestId('input2');
+    expect(document.activeElement).toBe(dialog);
+
+    fireEvent.keyDown(document.activeElement, {key: 'Tab'});
     expect(document.activeElement).toBe(input1);
 
-    fireEvent.keyDown(document.activeElement, {key: 'Tab', shiftKey: true});
+    fireEvent.keyDown(document.activeElement, {key: 'Tab'});
     expect(document.activeElement).toBe(input2);
 
     fireEvent.keyDown(document.activeElement, {key: 'Tab'});

--- a/packages/@react-spectrum/overlays/test/Popover.test.js
+++ b/packages/@react-spectrum/overlays/test/Popover.test.js
@@ -98,7 +98,6 @@ describe('Popover', function () {
     it.each`
       Name      | Component            | props
       ${'v3'}   | ${PopoverWithDialog} | ${{}}
-      ${'v2'}   | ${V2Popover}         | ${{role: 'dialog'}}
     `('$Name contains focus within the popover', function ({Name, Component, props}) {
       let {getByRole, getByTestId} = render(
         <Component {...props}>
@@ -110,27 +109,16 @@ describe('Popover', function () {
       let dialog = getByRole('dialog');
       let input1 = getByTestId('input1');
       let input2 = getByTestId('input2');
-      if (Name === 'v2') {
-        expect(document.activeElement).toBe(input1);
+      expect(document.activeElement).toBe(dialog);
 
-        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
-        expect(document.activeElement).toBe(input2);
-        console.log('will remove after this test is run', Name);
+      fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+      expect(document.activeElement).toBe(input1);
 
-        fireEvent.keyDown(document.activeElement, {key: 'Tab', shiftKey: true});
-        expect(document.activeElement).toBe(input1);
-      } else {
-        expect(document.activeElement).toBe(dialog);
+      fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+      expect(document.activeElement).toBe(input2);
 
-        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
-        expect(document.activeElement).toBe(input1);
-
-        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
-        expect(document.activeElement).toBe(input2);
-
-        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
-        expect(document.activeElement).toBe(input1);
-      }
+      fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+      expect(document.activeElement).toBe(input1);
     });
   });
 

--- a/packages/@react-spectrum/overlays/test/Popover.test.js
+++ b/packages/@react-spectrum/overlays/test/Popover.test.js
@@ -115,6 +115,7 @@ describe('Popover', function () {
 
         fireEvent.keyDown(document.activeElement, {key: 'Tab'});
         expect(document.activeElement).toBe(input2);
+        console.log('will remove after this test is run', Name);
 
         fireEvent.keyDown(document.activeElement, {key: 'Tab', shiftKey: true});
         expect(document.activeElement).toBe(input1);

--- a/packages/@react-spectrum/overlays/test/Popover.test.js
+++ b/packages/@react-spectrum/overlays/test/Popover.test.js
@@ -23,14 +23,14 @@ function PopoverWithDialog({children}) {
     </Popover>
   );
 }
- 
+
 describe('Popover', function () {
   afterEach(cleanup);
 
   beforeEach(() => {
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
   });
-  
+
   afterEach(() => {
     window.requestAnimationFrame.mockRestore();
   });
@@ -51,16 +51,21 @@ describe('Popover', function () {
       Name      | Component            | props
       ${'v3'}   | ${PopoverWithDialog} | ${{}}
       ${'v2'}   | ${V2Popover}         | ${{role: 'dialog'}}
-    `('$Name auto focuses the first tabbable element by default', function ({Component, props}) {
-      let {getByTestId} = render(
+    `('$Name auto focuses the first tabbable element by default', function ({Name, Component, props}) {
+      let {getByRole, getByTestId} = render(
         <Component {...props}>
           <input data-testid="input1" />
           <input data-testid="input2" />
         </Component>
       );
 
-      let input1 = getByTestId('input1');
-      expect(document.activeElement).toBe(input1);
+      if (Name === 'v2') {
+        let input1 = getByTestId('input1');
+        expect(document.activeElement).toBe(input1);
+      } else {
+        let dialog = getByRole('dialog');
+        expect(document.activeElement).toBe(dialog);
+      }
     });
 
     it.each`
@@ -69,7 +74,7 @@ describe('Popover', function () {
       ${'v2'}   | ${V2Popover}         | ${{role: 'dialog'}}
     `('$Name auto focuses the dialog itself if there is no focusable child', function ({Component, props}) {
       let {getByRole} = render(<Component {...props} />);
-  
+
       let dialog = getByRole('dialog');
       expect(document.activeElement).toBe(dialog);
     });
@@ -94,23 +99,37 @@ describe('Popover', function () {
       Name      | Component            | props
       ${'v3'}   | ${PopoverWithDialog} | ${{}}
       ${'v2'}   | ${V2Popover}         | ${{role: 'dialog'}}
-    `('$Name contains focus within the popover', function ({Component, props}) {
-      let {getByTestId} = render(
+    `('$Name contains focus within the popover', function ({Name, Component, props}) {
+      let {getByRole, getByTestId} = render(
         <Component {...props}>
           <input data-testid="input1" />
           <input data-testid="input2" />
         </Component>
       );
 
+      let dialog = getByRole('dialog');
       let input1 = getByTestId('input1');
       let input2 = getByTestId('input2');
-      expect(document.activeElement).toBe(input1);
+      if (Name === 'v2') {
+        expect(document.activeElement).toBe(input1);
 
-      fireEvent.keyDown(document.activeElement, {key: 'Tab', shiftKey: true});
-      expect(document.activeElement).toBe(input2);
+        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+        expect(document.activeElement).toBe(input2);
 
-      fireEvent.keyDown(document.activeElement, {key: 'Tab'});
-      expect(document.activeElement).toBe(input1);
+        fireEvent.keyDown(document.activeElement, {key: 'Tab', shiftKey: true});
+        expect(document.activeElement).toBe(input1);
+      } else {
+        expect(document.activeElement).toBe(dialog);
+
+        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+        expect(document.activeElement).toBe(input1);
+
+        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+        expect(document.activeElement).toBe(input2);
+
+        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+        expect(document.activeElement).toBe(input1);
+      }
     });
   });
 

--- a/packages/@react-spectrum/utils/src/Slots.tsx
+++ b/packages/@react-spectrum/utils/src/Slots.tsx
@@ -17,3 +17,18 @@ export let SlotContext = React.createContext(null);
 export function useSlotProvider() {
   return useContext(SlotContext) || {};
 }
+
+export function ClearSlots(props) {
+  let {children, ...otherProps} = props;
+  let content = children;
+  if (React.Children.toArray(children).length <= 1) {
+    if (typeof children === 'function') { // need to know if the node is a string or something else that react can render that doesn't get props
+      content = React.cloneElement(React.Children.only(children), otherProps);
+    }
+  }
+  return (
+    <SlotContext.Provider value={{}}>
+      {content}
+    </SlotContext.Provider>
+  );
+}

--- a/packages/@react-spectrum/utils/src/styleProps.ts
+++ b/packages/@react-spectrum/utils/src/styleProps.ts
@@ -49,7 +49,10 @@ export const baseStyleProps: StyleHandlers = {
   start: [rtl('left', 'right'), dimensionValue],
   end: [rtl('right', 'left'), dimensionValue],
   left: ['left', dimensionValue],
-  right: ['right', dimensionValue]
+  right: ['right', dimensionValue],
+  flexGrow: ['flexGrow', passthroughStyle],
+  flexShrink: ['flexShrink', passthroughStyle],
+  flexBasis: ['flexBasis', passthroughStyle]
 };
 
 export const viewStyleProps: StyleHandlers = {

--- a/packages/@react-spectrum/view/src/Content.tsx
+++ b/packages/@react-spectrum/view/src/Content.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {ClearSlots} from '@react-spectrum/utils';
 import {DOMProps, ViewStyleProps} from '@react-types/shared';
 import {filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {HTMLElement} from 'react-dom';
@@ -28,7 +29,9 @@ export const Content = React.forwardRef((props: ContentProps, ref: RefObject<HTM
 
   return (
     <section {...filterDOMProps(otherProps)} {...styleProps} ref={ref}>
-      {children}
+      <ClearSlots>
+        {children}
+      </ClearSlots>
     </section>
   );
 });

--- a/packages/@react-types/shared/src/style.d.ts
+++ b/packages/@react-types/shared/src/style.d.ts
@@ -39,6 +39,7 @@ export interface StyleProps {
   flex?: string | number | boolean,
   flexGrow?: number,
   flexShrink?: number,
+  flexBasis?: number | string,
   justifySelf?: 'auto' | 'normal' | 'start' | 'end' | 'flex-start' | 'flex-end' | 'self-start' | 'self-end' | 'center' | 'left' | 'right' | 'stretch', // ...
   alignSelf?: 'auto' | 'normal' | 'start' | 'end' | 'flex-start' | 'flex-end' | 'self-start' | 'self-end' | 'center' | 'stretch', // ...
   flexOrder?: number,


### PR DESCRIPTION
Make all the dialog things look pretty
Add flexBasis/Grow/Shrink to styles
Add a clear slots component. All it does it clear the context object so that nothing below it is influenced by the slots above

More info on ClearSlots:
Was thinking, slots is a bit pervasive, in a dialog, it applies specific styles to the Divider. If someone wanted to make a two column layout in their content and use a Divider, they'd need to do some work to get rid of the class name the dialog applies.
My thought was to start by just having the semantic element always clear the slots context because I don't think we typically want to reach into that region of anything with our styles.
This is also a convenience component to stop slots context propagation
Example added in stories


Closes https://jira.corp.adobe.com/browse/RSP-1529, https://jira.corp.adobe.com/browse/RSP-1531, https://jira.corp.adobe.com/browse/RSP-1532

Don't follow `all (except shouldFlip and containerPadding) - vertically center trigger button` looks like it's already doing this?

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
