### PR TITLE
Fix dialog divider margin

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -104,7 +104,7 @@ governing permissions and limitations under the License.
   outline: none; /* Hide focus outline around header */
 }
 
-.spectrum-Dialog-divider {
+.spectrum-Dialog .spectrum-Dialog-divider {
   grid-area: divider;
   width: 100%;
   margin-top: var(--spectrum-dialog-rule-margin-top);


### PR DESCRIPTION
Grid based classes should probably all be selectors of
`.container-grid .element`
so that they have a higher default specificity, we can discuss with css


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
