### PR TITLE
Well documentation

### DIFF
--- a/packages/@react-spectrum/well/docs/Well.mdx
+++ b/packages/@react-spectrum/well/docs/Well.mdx
@@ -15,6 +15,7 @@ import {HeaderInfo, PropTable} from '@react-spectrum/docs';
 import packageData from '../package.json';
 
 ```jsx import
+import {Heading} from '@react-spectrum/typography';
 import {Well} from '@react-spectrum/well';
 ```
 
@@ -46,6 +47,19 @@ Wells can have children. They can be nested.
 ### Internationalization
 
 In order to internationalize a well, a localized string should be passed to the `children` prop.
+
+### Accessibility
+
+By default, the visual separation of a Well is not conveyed to assistive technologies. As such it should be used where this separation makes no difference in understanding the content.
+
+However, if the Well does convey semantic meaning then a role must be specified and, if appropriate, labeled using either aria-label or aria-labelledby.
+
+```tsx example
+<Well role="region" aria-labelledby="wellLabel">
+    <Heading id="wellLabel" variant="subtitle1">Shipping Address</Heading>
+    <p>601 Townsend Street<br /> San Francisco, CA 94103</p>
+</Well>
+```
 
 ## Props
 

--- a/packages/@react-spectrum/well/docs/Well.mdx
+++ b/packages/@react-spectrum/well/docs/Well.mdx
@@ -25,8 +25,7 @@ import {Well} from '@react-spectrum/well';
 
 <HeaderInfo
   packageData={packageData}
-  componentNames={['Well']}
-  sourceData={[]} />
+  componentNames={['Well']} />
 
 ## Example
 

--- a/packages/@react-spectrum/well/docs/Well.mdx
+++ b/packages/@react-spectrum/well/docs/Well.mdx
@@ -1,0 +1,52 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-spectrum/well';
+import {HeaderInfo, PropTable} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+```jsx import
+import {Well} from '@react-spectrum/well';
+```
+
+# Well
+
+<p>{docs.exports.Well.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['Well']}
+  sourceData={[]} />
+
+## Example
+
+```tsx example
+<Well>Better a little which is well done, than a great deal imperfectly.</Well>
+```
+
+## Content
+
+Wells can have children. They can be nested.
+
+```tsx example
+<Well>Well</Well>
+
+<Well>Well <Well>oh well.</Well></Well>
+```
+
+### Internationalization
+
+In order to internationalize a well, a localized string should be passed to the `children` prop.
+
+## Props
+
+<PropTable component={docs.exports.Well} links={docs.links} />

--- a/packages/@react-spectrum/well/src/Well.tsx
+++ b/packages/@react-spectrum/well/src/Well.tsx
@@ -39,5 +39,9 @@ function Well(props: SpectrumWellProps, ref: DOMRef<HTMLDivElement>) {
   );
 }
 
+/**
+ * A Well is a content container that displays non-editable content separate from other content on the screen.
+ * Often this is used to display preformatted text, such as code/markup examples on a documentation page.
+ */
 const _Well = forwardRef(Well);
 export {_Well as Well};

--- a/packages/dev/docs/src/HeaderInfo.js
+++ b/packages/dev/docs/src/HeaderInfo.js
@@ -23,7 +23,7 @@ export function HeaderInfo(props) {
   let {
     packageData,
     componentNames,
-    sourceData
+    sourceData = []
   } = props;
 
   return (


### PR DESCRIPTION
Closes RSP-1262

Note: i've also made `sourceData` default to an empty `[]` so that if we dont have it, we dont have to add the extra prop.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

`Well` docs should appear on the website.

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
