### PR TITLE
fix RSP-1412 DatePicker should not have combobox on grouping

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/calendar/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/calendar/index.css
@@ -151,6 +151,10 @@ governing permissions and limitations under the License.
   transition: background var(--spectrum-global-animation-duration-100) ease-in-out,
       color var(--spectrum-global-animation-duration-100) ease-in-out,
       border-color var(--spectrum-global-animation-duration-100) ease-in-out;
+  
+  &:focus {
+    outline: 0;
+  }
 
   &:lang(ja), &:lang(zh), &:lang(ko) {
     font-size: var(--spectrum-calendar-day-text-size-han);

--- a/packages/@adobe/spectrum-css-temp/components/calendar/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/calendar/skin.css
@@ -94,6 +94,10 @@ governing permissions and limitations under the License.
 
     &.is-today {
       border-color: var(--spectrum-calendar-day-border-color-key-focus);
+
+      &:before {
+        border-color: var(--spectrum-calendar-day-border-color-key-focus);
+      }
     }
 
     &:active,
@@ -113,6 +117,7 @@ governing permissions and limitations under the License.
 
     &.is-range-selection {
       &:before {
+        border-color: var(--spectrum-calendar-day-border-color-key-focus);
         background: var(--spectrum-calendar-day-background-color-selected-hover);
       }
     }

--- a/packages/@react-aria/calendar/intl/fr-FR.json
+++ b/packages/@react-aria/calendar/intl/fr-FR.json
@@ -2,7 +2,7 @@
   "previous": "Précédent",
   "next": "Suivant",
   "selectedDateDescription": "Date sélectionnée: {date, date, full}",
-  "selectedRangeDescription": "Plage de dates sélectionnée: {start, date, long} to {end, date, long}",
+  "selectedRangeDescription": "Plage de dates sélectionnée: {start, date, long} au {end, date, long}",
   "todayDate": "Aujourd’hui, {date, date, full}",
   "todayDateSelected": "Aujourd’hui, sélection de {date, date, full}",
   "dateSelected": "Sélection de {date, date, full}",

--- a/packages/@react-aria/calendar/intl/tr-TR.json
+++ b/packages/@react-aria/calendar/intl/tr-TR.json
@@ -2,7 +2,7 @@
   "previous": "Önceki",
   "next": "İleri",
   "selectedDateDescription": "Seçilen Tarih: {date, date, full}",
-  "selectedRangeDescription": "Seçilen Aralık: {start, date, long} to {end, date, long}",
+  "selectedRangeDescription": "Seçilen Aralık: {start, date, long} ila {end, date, long}",
   "todayDate": "Bugün, {date, date, full}",
   "todayDateSelected": "Bugün, {date, date, full} seçildi",
   "dateSelected": "{date, date, full} seçildi",

--- a/packages/@react-aria/calendar/src/index.ts
+++ b/packages/@react-aria/calendar/src/index.ts
@@ -13,4 +13,5 @@
 export * from './useCalendar';
 export * from './useRangeCalendar';
 export * from './useCalendarCell';
+export * from './useCalendarTableHeader';
 export * from './types';

--- a/packages/@react-aria/calendar/src/types.ts
+++ b/packages/@react-aria/calendar/src/types.ts
@@ -19,6 +19,6 @@ export interface CalendarAria {
   calendarTitleProps: DOMProps,
   nextButtonProps: DOMProps & PressProps,
   prevButtonProps: DOMProps & PressProps,
-  calendarBodyProps: DOMProps & {ref: RefObject<HTMLDivElement>},
+  calendarBodyProps: DOMProps & {ref: RefObject<HTMLTableElement>},
   captionProps: DOMProps & {children: string}
 }

--- a/packages/@react-aria/calendar/src/useCalendarBase.ts
+++ b/packages/@react-aria/calendar/src/useCalendarBase.ts
@@ -18,7 +18,7 @@ import {DOMProps} from '@react-types/shared';
 import {format} from 'date-fns';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {KeyboardEvent, useEffect, useRef} from 'react';
+import {KeyboardEvent, useCallback, useEffect, useRef} from 'react';
 import {useDateFormatter, useLocale, useMessageFormatter} from '@react-aria/i18n';
 import {useId, useLabels, useUpdateEffect} from '@react-aria/utils';
 
@@ -51,36 +51,48 @@ export function useCalendarBase(props: CalendarPropsBase & DOMProps, state: Cale
   // Kinda hacky, but it's the easiest way to get the id from the cell.
   calendarIds.set(state, calendarId);
 
+  let focusFocusedDateCell = useCallback(() => {
+    const focusedCell = calendarBody.current.querySelector(`#${getCellId(state.focusedDate, calendarId)}`);
+    if (focusedCell && focusedCell !== document.activeElement) {
+      focusedCell.focus();
+    }
+  }, [state.focusedDate, calendarId]);
+
   useEffect(() => {
     // focus the calendar body when mounting
     if (autoFocus) {
-      calendarBody.current.focus();
+      focusFocusedDateCell();
     }
+    // omitting focusFocusedDateCell method from dependencies
+    // so that autoFocus does not restore focus with a month change from Previous or Next button 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoFocus]);
 
   // Announce when the current month changes
   useUpdateEffect(() => {
-    announce(monthFormatter.format(state.currentMonth));
+    // announce the new month with a change from the Previous or Next button 
+    if (!state.isFocused) {
+      announce(monthFormatter.format(state.currentMonth));
+    }
+    // handle an update to the current month from the Previous or Next button
+    // rather than move focus, we announce the new month value
   }, [state.currentMonth]);
 
   // Announce when the selected value changes
   useUpdateEffect(() => {
     if (selectedDateDescription) {
-      announce(selectedDateDescription);
+      announce(selectedDateDescription, 'polite', 4000);
     }
+    // handle an update to the caption that describes the currently selected range, to announce the new value
   }, [selectedDateDescription]);
 
-  // Ensure that the focused date is announced when it changes.
-  // VoiceOver does not announce changes to aria-activedescendant or move the VoiceOver cursor,
-  // so we blur and re-focus the calendar body to force it to do so.
-  // This will cause the focused date, along with the selected date (part of the table caption)
-  // to be announced as you move around the calendar.
+  // Ensure that the focused date moves focus to the focused date cell within the calendar.
   useUpdateEffect(() => {
-    if (document.activeElement === calendarBody.current) {
-      calendarBody.current.blur();
-      calendarBody.current.focus();
+    if (state.isFocused) {
+      focusFocusedDateCell();
     }
-  }, [state.focusedDate]);
+    // handling focused date change initiated from within the calendar table
+  }, [state.focusedDate, state.isFocused, focusFocusedDateCell]);
 
   let onKeyDown = (e: KeyboardEvent) => {
     switch (e.key) {
@@ -167,12 +179,12 @@ export function useCalendarBase(props: CalendarPropsBase & DOMProps, state: Cale
     calendarBodyProps: {
       ref: calendarBody,
       role: 'grid',
-      tabIndex: isDisabled ? null : 0,
-      'aria-readonly': isReadOnly,
-      'aria-disabled': isDisabled,
-      'aria-activedescendant': getCellId(state.focusedDate, calendarId),
+      'aria-readonly': isReadOnly || null,
+      'aria-disabled': isDisabled || null,
       'aria-labelledby': labelProps['aria-labelledby'],
       'aria-describedby': selectedDateDescription ? captionId : null,
+      'aria-colcount': 7,
+      'aria-rowcount': state.weeksInMonth + 1,
       onKeyDown,
       onFocus: () => state.setFocused(true),
       onBlur: () => state.setFocused(false)

--- a/packages/@react-aria/calendar/src/useCalendarCell.ts
+++ b/packages/@react-aria/calendar/src/useCalendarCell.ts
@@ -15,11 +15,12 @@ import {getCalendarId, getCellId} from './useCalendarBase';
 import {HTMLAttributes} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
-import {PressProps, usePress} from '@react-aria/interactions';
+import {PressProps, useFocus, usePress} from '@react-aria/interactions';
 import {useDateFormatter, useMessageFormatter} from '@react-aria/i18n';
 
 interface CalendarCellAria {
-  cellProps: PressProps & HTMLAttributes<HTMLElement>
+  cellProps: PressProps & HTMLAttributes<HTMLElement>,
+  cellDateProps: HTMLAttributes<HTMLElement>
 }
 
 export function useCalendarCell(props: CalendarCellOptions, state: CalendarState | RangeCalendarState): CalendarCellAria {
@@ -68,20 +69,43 @@ export function useCalendarCell(props: CalendarCellOptions, state: CalendarState
     }
   });
 
+  let {focusProps} = useFocus({
+    onFocus: (event) => {
+      if (!props.isDisabled) {
+        state.setFocusedDate(props.cellDate);
+        event.continuePropagation();
+      }
+    }
+  });
+
   let onMouseEnter = () => {
     if ('highlightDate' in state) {
       state.highlightDate(props.cellDate);
     }
   };
 
+  let tabIndex =  null;
+  if (!props.isDisabled) {
+    const focusedDate = state.focusedDate;
+    focusedDate.setHours(0, 0, 0, 0);
+    tabIndex = props.isFocused || props.cellDate.valueOf() === focusedDate.valueOf() ? 0 : -1;
+  }
+
   return {
     cellProps: {
-      ...pressProps,
       onMouseEnter: props.isDisabled ? null : onMouseEnter,
-      id: getCellId(props.cellDate, getCalendarId(state)),
       role: 'gridcell',
+      'aria-colindex': props.colIndex,
       'aria-disabled': props.isDisabled || null,
-      'aria-selected': props.isSelected || null,
+      'aria-selected': props.isSelected
+    },
+    cellDateProps: {
+      ...pressProps,
+      ...focusProps,
+      tabIndex,
+      id: getCellId(props.cellDate, getCalendarId(state)),
+      role: 'button',
+      'aria-disabled': props.isDisabled || null,
       'aria-label': label
     }
   };

--- a/packages/@react-aria/calendar/src/useCalendarTableHeader.ts
+++ b/packages/@react-aria/calendar/src/useCalendarTableHeader.ts
@@ -1,0 +1,11 @@
+interface CalendarTableHeaderAria {
+  columnHeaderProps: {scope?: 'col'}
+}
+
+export function useCalendarTableHeader(): CalendarTableHeaderAria {
+  return {
+    columnHeaderProps: {
+      scope: 'col'
+    }
+  };
+}

--- a/packages/@react-aria/datepicker/intl/ar-AE.json
+++ b/packages/@react-aria/datepicker/intl/ar-AE.json
@@ -1,5 +1,7 @@
 {
   "calendar": "التقويم",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} إلى {end, date, long}",
   "date": "التاريخ",
   "dateRange": "نطاق التاريخ",
   "day": "اليوم",

--- a/packages/@react-aria/datepicker/intl/bg-BG.json
+++ b/packages/@react-aria/datepicker/intl/bg-BG.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Календар",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} до {end, date, long}",
   "date": "Дата",
   "dateRange": "Времеви интервал",
   "day": "Ден",

--- a/packages/@react-aria/datepicker/intl/cs-CZ.json
+++ b/packages/@react-aria/datepicker/intl/cs-CZ.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalendář",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} až {end, date, long}",
   "date": "Datum",
   "dateRange": "Rozsah dat",
   "day": "Den",

--- a/packages/@react-aria/datepicker/intl/da-DK.json
+++ b/packages/@react-aria/datepicker/intl/da-DK.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalender",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} til {end, date, long}",
   "date": "Dato",
   "dateRange": "Datointerval",
   "day": "Dag",

--- a/packages/@react-aria/datepicker/intl/de-DE.json
+++ b/packages/@react-aria/datepicker/intl/de-DE.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalender",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} bis {end, date, long}",
   "date": "Datum",
   "dateRange": "Datumsbereich",
   "day": "Tag",

--- a/packages/@react-aria/datepicker/intl/el-GR.json
+++ b/packages/@react-aria/datepicker/intl/el-GR.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Ημερολόγιο",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} έως {end, date, long}",
   "date": "Ημερομηνία",
   "dateRange": "Εύρος ημερομηνιών",
   "day": "Ημέρα",

--- a/packages/@react-aria/datepicker/intl/en-US.json
+++ b/packages/@react-aria/datepicker/intl/en-US.json
@@ -10,5 +10,7 @@
   "date": "Date",
   "dateRange": "Date Range",
   "startDate": "Start Date",
-  "endDate": "End Date"
+  "endDate": "End Date",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} to {end, date, long}"
 }

--- a/packages/@react-aria/datepicker/intl/es-ES.json
+++ b/packages/@react-aria/datepicker/intl/es-ES.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Calendario",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} a {end, date, long}",
   "date": "Fecha",
   "dateRange": "Intervalo de fecha",
   "day": "Día",

--- a/packages/@react-aria/datepicker/intl/et-EE.json
+++ b/packages/@react-aria/datepicker/intl/et-EE.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalender",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} kuni {end, date, long}",
   "date": "Kuupäev",
   "dateRange": "Kuupäevavahemik",
   "day": "Päev",

--- a/packages/@react-aria/datepicker/intl/fi-FI.json
+++ b/packages/@react-aria/datepicker/intl/fi-FI.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalenteri",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long}-{end, date, long}",
   "date": "Päivämäärä",
   "dateRange": "Päivämääräalue",
   "day": "Päivä",

--- a/packages/@react-aria/datepicker/intl/fr-FR.json
+++ b/packages/@react-aria/datepicker/intl/fr-FR.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Calendrier",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} au {end, date, long}",
   "date": "Date",
   "dateRange": "Plage de dates",
   "day": "Jour",

--- a/packages/@react-aria/datepicker/intl/he-IL.json
+++ b/packages/@react-aria/datepicker/intl/he-IL.json
@@ -1,5 +1,7 @@
 {
   "calendar": "לוח שנה",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "מ-{start, date, long} ועד {end, date, long}",
   "date": "תאריך",
   "dateRange": "טווח תאריכים",
   "day": "יום",

--- a/packages/@react-aria/datepicker/intl/hr-HR.json
+++ b/packages/@react-aria/datepicker/intl/hr-HR.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalendar",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "od {start, date, long} do {end, date, long}",
   "date": "Datum",
   "dateRange": "Raspon datuma",
   "day": "Dan",

--- a/packages/@react-aria/datepicker/intl/hu-HU.json
+++ b/packages/@react-aria/datepicker/intl/hu-HU.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Naptár",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} – {end, date, long}",
   "date": "Dátum",
   "dateRange": "Dátumtartomány",
   "day": "Nap",

--- a/packages/@react-aria/datepicker/intl/it-IT.json
+++ b/packages/@react-aria/datepicker/intl/it-IT.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Calendario",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} a {end, date, long}",
   "date": "Data",
   "dateRange": "Intervallo date",
   "day": "Giorno",

--- a/packages/@react-aria/datepicker/intl/ja-JP.json
+++ b/packages/@react-aria/datepicker/intl/ja-JP.json
@@ -1,5 +1,7 @@
 {
   "calendar": "カレンダー",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} ~ {end, date, long}",
   "date": "日付",
   "dateRange": "日付範囲",
   "day": "日",

--- a/packages/@react-aria/datepicker/intl/ko-KR.json
+++ b/packages/@react-aria/datepicker/intl/ko-KR.json
@@ -1,5 +1,7 @@
 {
   "calendar": "달력",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} ~ {end, date, long}",
   "date": "날짜",
   "dateRange": "날짜 범위",
   "day": "요일",

--- a/packages/@react-aria/datepicker/intl/lt-LT.json
+++ b/packages/@react-aria/datepicker/intl/lt-LT.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalendorius",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "nuo {start, date, long} iki {end, date, long}",
   "date": "Data",
   "dateRange": "Datų intervalas",
   "day": "Diena",

--- a/packages/@react-aria/datepicker/intl/lv-LV.json
+++ b/packages/@react-aria/datepicker/intl/lv-LV.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalendārs",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} līdz {end, date, long}",
   "date": "Datums",
   "dateRange": "Datumu diapazons",
   "day": "Diena",

--- a/packages/@react-aria/datepicker/intl/nb-NO.json
+++ b/packages/@react-aria/datepicker/intl/nb-NO.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalender",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} til {end, date, long}",
   "date": "Dato",
   "dateRange": "Datoområde",
   "day": "Dag",

--- a/packages/@react-aria/datepicker/intl/nl-NL.json
+++ b/packages/@react-aria/datepicker/intl/nl-NL.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalender",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} tot {end, date, long}",
   "date": "Datum",
   "dateRange": "Datumbereik",
   "day": "Dag",

--- a/packages/@react-aria/datepicker/intl/pl-PL.json
+++ b/packages/@react-aria/datepicker/intl/pl-PL.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalendarz",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} do {end, date, long}",
   "date": "Data",
   "dateRange": "Zakres dat",
   "day": "Dzień",

--- a/packages/@react-aria/datepicker/intl/pt-BR.json
+++ b/packages/@react-aria/datepicker/intl/pt-BR.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Calendário",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} para {end, date, long}",
   "date": "Data",
   "dateRange": "Intervalo de datas",
   "day": "Dia",

--- a/packages/@react-aria/datepicker/intl/ro-RO.json
+++ b/packages/@react-aria/datepicker/intl/ro-RO.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Calendar",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} la {end, date, long}",
   "date": "Dată",
   "dateRange": "Raza datei",
   "day": "Zi",

--- a/packages/@react-aria/datepicker/intl/ru-RU.json
+++ b/packages/@react-aria/datepicker/intl/ru-RU.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Календарь",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} до {end, date, long}",
   "date": "Дата",
   "dateRange": "Диапазон дат",
   "day": "День",

--- a/packages/@react-aria/datepicker/intl/sk-SK.json
+++ b/packages/@react-aria/datepicker/intl/sk-SK.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalendár",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} do {end, date, long}",
   "date": "Dátum",
   "dateRange": "Rozsah dátumov",
   "day": "Deň",

--- a/packages/@react-aria/datepicker/intl/sl-SI.json
+++ b/packages/@react-aria/datepicker/intl/sl-SI.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Koledar",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} do {end, date, long}",
   "date": "Datum",
   "dateRange": "Datumski obseg",
   "day": "Dan",

--- a/packages/@react-aria/datepicker/intl/sr-SP.json
+++ b/packages/@react-aria/datepicker/intl/sr-SP.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalendar",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "od {start, date, long} do {end, date, long}",
   "date": "Datum",
   "dateRange": "Opseg datuma",
   "day": "Dan",

--- a/packages/@react-aria/datepicker/intl/sv-SE.json
+++ b/packages/@react-aria/datepicker/intl/sv-SE.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Kalender",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} till {end, date, long}",
   "date": "Datum",
   "dateRange": "Datumintervall",
   "day": "Dag",

--- a/packages/@react-aria/datepicker/intl/tr-TR.json
+++ b/packages/@react-aria/datepicker/intl/tr-TR.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Takvim",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long} ila {end, date, long}",
   "date": "Tarih",
   "dateRange": "Tarih Aralığı",
   "day": "Gün",

--- a/packages/@react-aria/datepicker/intl/uk-UA.json
+++ b/packages/@react-aria/datepicker/intl/uk-UA.json
@@ -1,5 +1,7 @@
 {
   "calendar": "Календар",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "від {start, date, long} до {end, date, long}",
   "date": "Дата",
   "dateRange": "Діапазон дат",
   "day": "День",

--- a/packages/@react-aria/datepicker/intl/zh-CN.json
+++ b/packages/@react-aria/datepicker/intl/zh-CN.json
@@ -1,5 +1,7 @@
 {
   "calendar": "日历",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long}至{end, date, long}",
   "date": "日期",
   "dateRange": "日期范围",
   "day": "日",

--- a/packages/@react-aria/datepicker/intl/zh-TW.json
+++ b/packages/@react-aria/datepicker/intl/zh-TW.json
@@ -1,5 +1,7 @@
 {
   "calendar": "日曆",
+  "currentDate": "{date, date, full}",
+  "currentDateRange": "{start, date, long}至{end, date, long}",
   "date": "日期",
   "dateRange": "日期範圍",
   "day": "日",

--- a/packages/@react-aria/datepicker/package.json
+++ b/packages/@react-aria/datepicker/package.json
@@ -22,6 +22,7 @@
     "@react-aria/interactions": "^3.0.0-alpha.2",
     "@react-aria/spinbutton": "^3.0.0-alpha.2",
     "@react-aria/utils": "^3.0.0-alpha.2",
+    "@react-spectrum/utils": "^3.0.0-alpha.2",
     "@react-stately/datepicker": "^3.0.0-alpha.2",
     "@react-types/datepicker": "^3.0.0-alpha.2",
     "@react-types/shared": "^3.0.0-alpha.2",

--- a/packages/@react-aria/datepicker/src/useDateField.ts
+++ b/packages/@react-aria/datepicker/src/useDateField.ts
@@ -21,7 +21,10 @@ import {useMessageFormatter} from '@react-aria/i18n';
 
 interface DateFieldAria {
   fieldProps: HTMLAttributes<HTMLElement>,
-  segmentProps: DOMProps
+  segmentProps: DOMProps & {
+    'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog',
+    'aria-invalid'?: string
+  }
 }
 
 export function useDateField(props: DatePickerProps & DOMProps): DateFieldAria {
@@ -43,6 +46,9 @@ export function useDateField(props: DatePickerProps & DOMProps): DateFieldAria {
       onMouseDown
     },
     segmentProps: {
+      'aria-controls': props['aria-controls'],
+      'aria-haspopup': props['aria-haspopup'],
+      'aria-invalid': props['aria-invalid'],
       // Segments should be labeled by the input id if provided, otherwise the field itself
       'aria-labelledby': fieldProps['aria-labelledby'] || fieldProps.id
     }

--- a/packages/@react-aria/datepicker/src/useDatePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDatePicker.ts
@@ -18,14 +18,24 @@ import {HTMLAttributes, KeyboardEvent} from 'react';
 import intlMessages from '../intl/*.json';
 import {mergeProps, useId, useLabels} from '@react-aria/utils';
 import {SpectrumBaseDialogProps} from '@react-types/dialog';
+import {useMemo} from 'react';
 import {useMessageFormatter} from '@react-aria/i18n';
 import {usePress} from '@react-aria/interactions';
 
+interface DateFieldDescProps extends DOMProps {
+  children?: string,
+  hidden?: boolean
+}
+
 interface DatePickerAria {
-  comboboxProps: HTMLAttributes<HTMLElement>,
-  fieldProps: DOMProps,
+  groupProps: HTMLAttributes<HTMLElement>,
+  fieldProps: DOMProps & {
+    'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog',
+    'aria-invalid'?: boolean | 'false' | 'true'
+  },
   buttonProps: HTMLAttributes<HTMLElement>,
-  dialogProps: SpectrumBaseDialogProps
+  dialogProps: SpectrumBaseDialogProps,
+  descProps: DateFieldDescProps
 }
 
 type DatePickerAriaProps = (DatePickerProps | DateRangePickerProps) & DOMProps;
@@ -33,17 +43,30 @@ type DatePickerAriaProps = (DatePickerProps | DateRangePickerProps) & DOMProps;
 export function useDatePicker(props: DatePickerAriaProps, state: DatePickerState | DateRangePickerState): DatePickerAria {
   let buttonId = useId();
   let dialogId = useId();
+  let descId = useId();
   let formatMessage = useMessageFormatter(intlMessages);
   let labels = useLabels(props, formatMessage('date'));
   let labelledBy = labels['aria-labelledby'] || labels.id;
+  let dateValueDescription = useMemo(
+    () => {
+      if (state.value) {
+        if (state.value instanceof Date) {
+          return formatMessage('currentDate', {date: state.value});
+        } else if (state.value.start && state.value.start instanceof Date && state.value.end && state.value.end instanceof Date) {
+          return formatMessage('currentDateRange', {start: state.value.start, end: state.value.end});
+        }
+      }
+      return null;
+    },
+    [formatMessage, state.value]
+  );
 
   // When a touch event occurs on the date field, open the calendar instead.
   // The date segments are too small to interact with on a touch device.
   // TODO: time picker in popover??
   let {pressProps} = usePress({
     onPress: (e) => {
-      // really should detect if there is a keyboard attached too, but not sure how to do that.
-      if (e.pointerType === 'touch' || e.pointerType === 'pen') {
+      if (e.pointerType === 'touch' || e.pointerType === 'pen' || e.pointerType === 'keyboard') {
         state.setOpen(true);
       }
     }
@@ -59,24 +82,28 @@ export function useDatePicker(props: DatePickerAriaProps, state: DatePickerState
   };
 
   return {
-    comboboxProps: {
-      role: 'combobox',
-      'aria-haspopup': 'dialog',
-      'aria-expanded': state.isOpen,
-      'aria-owns': state.isOpen ? dialogId : null,
-      'aria-invalid': state.validationState === 'invalid' || null,
+    groupProps: {
+      role: 'group',
+      'aria-describedby': dateValueDescription ? descId : null,
       'aria-disabled': props.isDisabled || null,
-      'aria-readonly': props.isReadOnly || null,
-      'aria-required': props.isRequired || null,
       ...mergeProps(pressProps, {onKeyDown}),
       ...labels
     },
+    descProps: {
+      children: dateValueDescription,
+      hidden: true,
+      id: descId
+    },
     fieldProps: {
+      role: 'presentation',
+      'aria-controls': state.isOpen ? dialogId : null,
+      'aria-haspopup': 'dialog',
+      'aria-invalid': state.validationState === 'invalid' || null,
       'aria-labelledby': labelledBy
     },
     buttonProps: {
-      tabIndex: -1,
       id: buttonId,
+      'aria-describedby': dateValueDescription ? descId : null,
       'aria-haspopup': 'dialog',
       'aria-label': formatMessage('calendar'),
       'aria-labelledby': `${labelledBy} ${buttonId}`

--- a/packages/@react-aria/datepicker/src/useDateRangePicker.ts
+++ b/packages/@react-aria/datepicker/src/useDateRangePicker.ts
@@ -13,44 +13,91 @@
 import {DateRangePickerProps} from '@react-types/datepicker';
 import {DateRangePickerState} from '@react-stately/datepicker';
 import {DOMProps} from '@react-types/shared';
-import {HTMLAttributes} from 'react';
+import {HTMLAttributes, useMemo} from 'react';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
+import {mergeProps, useId, useLabels} from '@react-aria/utils';
 import {SpectrumBaseDialogProps} from '@react-types/dialog';
 import {useDatePicker} from './useDatePicker';
-import {useLabels} from '@react-aria/utils';
 import {useMessageFormatter} from '@react-aria/i18n';
 
+interface DateFieldDescProps extends DOMProps {
+  children?: string,
+  hidden?: boolean
+}
+
 interface DateRangePickerAria {
-  comboboxProps: HTMLAttributes<HTMLElement>,
-  startFieldProps: DOMProps,
-  endFieldProps: DOMProps,
+  groupProps: HTMLAttributes<HTMLElement>,
+  startFieldProps: HTMLAttributes<HTMLElement> & {
+    descProps?: DateFieldDescProps
+  },
+  endFieldProps: HTMLAttributes<HTMLElement> & {
+    descProps?: DateFieldDescProps
+  },
   buttonProps: HTMLAttributes<HTMLElement>,
-  dialogProps: SpectrumBaseDialogProps
+  dialogProps: SpectrumBaseDialogProps,
+  descProps: DateFieldDescProps
 }
 
 export function useDateRangePicker(props: DateRangePickerProps & DOMProps, state: DateRangePickerState): DateRangePickerAria {
   let formatMessage = useMessageFormatter(intlMessages);
-  let {comboboxProps, buttonProps, fieldProps, dialogProps} = useDatePicker({
+  let {groupProps, buttonProps, fieldProps, dialogProps, descProps} = useDatePicker({
     ...props,
     ...useLabels(props, formatMessage('dateRange'))
   }, state);
 
-  let startFieldProps = useLabels({
-    'aria-label': formatMessage('startDate'),
-    'aria-labelledby': fieldProps['aria-labelledby']
-  });
+  let startFieldDescId = useId();
+  let startFieldValue:string = useMemo(
+    () => state.value.start && state.value.start instanceof Date ? formatMessage('currentDate', {date: state.value.start}) : null,
+    [formatMessage, state.value.start]
+  );
 
-  let endFieldProps = useLabels({
-    'aria-label': formatMessage('endDate'),
-    'aria-labelledby': fieldProps['aria-labelledby']
-  });
+  let startFieldProps = mergeProps(
+    fieldProps,
+    {
+      role: 'group',
+      'aria-describedby': startFieldValue ? startFieldDescId : null,
+      ...useLabels({
+        'aria-label': formatMessage('startDate'),
+        'aria-labelledby': fieldProps['aria-labelledby']
+      }),
+      descProps: {
+        children: startFieldValue,
+        hidden: true,
+        id: startFieldDescId
+      }
+    }
+  );
+
+  let endFieldDescId = useId();
+  let endFieldValue:string = useMemo(
+    () => state.value.end && state.value.end instanceof Date ? formatMessage('currentDate', {date: state.value.end}) : null,
+    [formatMessage, state.value.end]
+  );
+
+  let endFieldProps = mergeProps(
+    fieldProps,
+    {
+      role: 'group',
+      'aria-describedby': endFieldValue ? endFieldDescId : null,
+      ...useLabels({
+        'aria-label': formatMessage('endDate'),
+        'aria-labelledby': fieldProps['aria-labelledby']
+      }),
+      descProps: {
+        children: endFieldValue,
+        hidden: true,
+        id: endFieldDescId
+      }
+    }
+  );
 
   return {
-    comboboxProps,
+    groupProps,
     buttonProps,
     dialogProps,
     startFieldProps,
-    endFieldProps
+    endFieldProps,
+    descProps
   };
 }

--- a/packages/@react-aria/datepicker/src/useDateSegment.ts
+++ b/packages/@react-aria/datepicker/src/useDateSegment.ts
@@ -19,6 +19,7 @@ import intlMessages from '../intl/*.json';
 import {mergeProps, useId} from '@react-aria/utils';
 import {useDateFormatter, useLocale, useMessageFormatter} from '@react-aria/i18n';
 import {useFocusManager} from '@react-aria/focus';
+import {useMediaQuery} from '@react-spectrum/utils';
 import {useSpinButton} from '@react-aria/spinbutton';
 
 interface DateSegmentAria {
@@ -39,7 +40,8 @@ export function useDateSegment(props: DatePickerProps & DOMProps, segment: DateS
   });
 
   if (segment.type === 'month') {
-    textValue = monthDateFormatter.format(state.value);
+    let monthTextValue = monthDateFormatter.format(state.value);
+    textValue = monthTextValue !== textValue ? `${textValue} - ${monthTextValue}` : monthTextValue;
   } else if (segment.type === 'hour' || segment.type === 'dayPeriod') {
     textValue = hourDateFormatter.format(state.value);
   }
@@ -157,10 +159,22 @@ export function useDateSegment(props: DatePickerProps & DOMProps, segment: DateS
     setEnteredKeys('');
   };
 
+  let touchPropOverrides = useMediaQuery('(hover: none) and (pointer: coarse)') ? {
+    role: 'textbox',
+    'aria-valuemax': null,
+    'aria-valuemin': null,
+    'aria-valuetext': null,
+    'aria-valuenow': null
+  } : {};
+
   let id = useId(props.id);
   return {
     segmentProps: mergeProps(spinButtonProps, {
       id,
+      ...touchPropOverrides,
+      'aria-controls': props['aria-controls'],
+      'aria-haspopup': props['aria-haspopup'],
+      'aria-invalid': props['aria-invalid'],
       'aria-label': messageFormatter(segment.type),
       'aria-labelledby': `${props['aria-labelledby']} ${id}`,
       tabIndex: props.isDisabled ? undefined : 0,

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -80,16 +80,13 @@ export function CalendarBase(props: CalendarBaseProps) {
           isDisabled={props.isDisabled}
           icon={direction === 'rtl' ? <ChevronLeft /> : <ChevronRight />} />
       </div>
-      <div
+      <table
         {...calendarBodyProps}
-        className={classNames(styles, 'spectrum-Calendar-body')}>
-        <table
-          className={classNames(styles, 'spectrum-Calendar-table')}>
-          <VisuallyHidden elementType="caption" {...captionProps} />
-          <CalendarTableHeader weekStart={state.weekStart} />
-          <CalendarTableBody state={state} />
-        </table>
-      </div>
+        className={classNames(styles, 'spectrum-Calendar-body', 'spectrum-Calendar-table')}>
+        <VisuallyHidden elementType="caption" {...captionProps} />
+        <CalendarTableHeader weekStart={state.weekStart} />
+        <CalendarTableBody state={state} />
+      </table>
     </div>
   );
 }

--- a/packages/@react-spectrum/calendar/src/CalendarCell.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarCell.tsx
@@ -22,7 +22,7 @@ interface CalendarCellProps extends CalendarCellOptions {
 }
 
 export function CalendarCell({state, ...props}: CalendarCellProps) {
-  let {cellProps} = useCalendarCell(props, state);
+  let {cellProps, cellDateProps} = useCalendarCell(props, state);
   let dateFormatter = useDateFormatter({day: 'numeric'});
 
   return (
@@ -30,7 +30,7 @@ export function CalendarCell({state, ...props}: CalendarCellProps) {
       {...cellProps}
       className={classNames(styles, 'spectrum-Calendar-tableCell')}>
       <span
-        role="presentation"
+        {...cellDateProps}
         className={classNames(styles, 'spectrum-Calendar-date', {
           'is-today': props.isToday,
           'is-selected': props.isSelected,

--- a/packages/@react-spectrum/calendar/src/CalendarTableBody.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarTableBody.tsx
@@ -23,7 +23,7 @@ export function CalendarTableBody({state}: CalendarTableBodyProps) {
     <tbody>
       {
         [...new Array(state.weeksInMonth).keys()].map(weekIndex => (
-          <tr key={weekIndex}>
+          <tr key={weekIndex} aria-rowindex={weekIndex + 2}>
             {
               [...new Array(7).keys()].map(dayIndex => (
                 <CalendarCell

--- a/packages/@react-spectrum/calendar/src/CalendarTableHeader.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarTableHeader.tsx
@@ -14,6 +14,7 @@ import {classNames} from '@react-spectrum/utils';
 import React from 'react';
 import {setDay} from 'date-fns'; // pull these out individually
 import styles from '@adobe/spectrum-css-temp/components/calendar/vars.css';
+import {useCalendarTableHeader} from '@react-aria/calendar';
 import {useDateFormatter} from '@react-aria/i18n';
 
 interface CalendarTableHeaderProps {
@@ -21,19 +22,26 @@ interface CalendarTableHeaderProps {
 }
 
 export function CalendarTableHeader({weekStart}: CalendarTableHeaderProps) {
+  const {
+    columnHeaderProps
+  } = useCalendarTableHeader();
   let dayFormatter = useDateFormatter({weekday: 'short'});
-
+  let dayFormatterLong = useDateFormatter({weekday: 'long'});
   return (
     <thead>
-      <tr>
+      <tr aria-rowindex={1}>
         {
           [...new Array(7).keys()].map(index => {
-            let day = dayFormatter.format(setDay(Date.now(), (index + weekStart) % 7));
+            let dateDay = setDay(Date.now(), (index + weekStart) % 7);
+            let day = dayFormatter.format(dateDay);
+            let dayLong = dayFormatterLong.format(dateDay);
             return (
               <th
                 key={index}
+                aria-colindex={index + 1}
+                {...columnHeaderProps}
                 className={classNames(styles, 'spectrum-Calendar-tableCell')}>
-                <abbr className={classNames(styles, 'spectrum-Calendar-dayOfWeek')}>
+                <abbr className={classNames(styles, 'spectrum-Calendar-dayOfWeek')} title={dayLong}>
                   {day}
                 </abbr>
               </th>

--- a/packages/@react-spectrum/calendar/test/Calendar.test.js
+++ b/packages/@react-spectrum/calendar/test/Calendar.test.js
@@ -37,6 +37,7 @@ describe('Calendar', () => {
       ${'v3'}   | ${Calendar}
       ${'v2'}   | ${V2Calendar}
     `('$Name should render a calendar with a defaultValue', ({Calendar}) => {
+      let isV2 = Calendar === V2Calendar;
       let {getByLabelText, getByRole, getAllByRole} = render(<Calendar defaultValue={new Date(2019, 5, 5)} />);
 
       let heading = getByRole('heading');
@@ -46,8 +47,8 @@ describe('Calendar', () => {
       expect(gridCells.length).toBe(30);
 
       let selectedDate = getByLabelText('Selected', {exact: false});
-      expect(selectedDate).toHaveAttribute('role', 'gridcell');
-      expect(selectedDate).toHaveAttribute('aria-selected', 'true');
+      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('role', 'gridcell');
+      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('aria-selected', 'true');
       expect(selectedDate).toHaveAttribute('aria-label', 'Wednesday, June 5, 2019 selected');
     });
 
@@ -56,6 +57,7 @@ describe('Calendar', () => {
       ${'v3'}   | ${Calendar}
       ${'v2'}   | ${V2Calendar}
     `('$Name should render a calendar with a value', ({Calendar}) => {
+      let isV2 = Calendar === V2Calendar;
       let {getByLabelText, getByRole, getAllByRole} = render(<Calendar value={new Date(2019, 5, 5)} />);
 
       let heading = getByRole('heading');
@@ -65,8 +67,8 @@ describe('Calendar', () => {
       expect(gridCells.length).toBe(30);
 
       let selectedDate = getByLabelText('Selected', {exact: false});
-      expect(selectedDate).toHaveAttribute('role', 'gridcell');
-      expect(selectedDate).toHaveAttribute('aria-selected', 'true');
+      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('role', 'gridcell');
+      expect(isV2 ? selectedDate : selectedDate.parentElement).toHaveAttribute('aria-selected', 'true');
       expect(selectedDate).toHaveAttribute('aria-label', 'Wednesday, June 5, 2019 selected');
     });
 
@@ -78,12 +80,19 @@ describe('Calendar', () => {
       let {getByRole, getByLabelText} = render(<Calendar value={new Date(2019, 1, 3)} autoFocus />);
 
       let cell = getByLabelText('selected', {exact: false});
-      expect(cell).toHaveAttribute('role', 'gridcell');
-      expect(cell).toHaveAttribute('aria-selected', 'true');
 
       let grid = getByRole('grid');
-      expect(grid).toHaveFocus();
-      expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
+      if (Calendar === V2Calendar) {
+        expect(cell).toHaveAttribute('role', 'gridcell');
+        expect(cell).toHaveAttribute('aria-selected', 'true');
+        expect(grid).toHaveFocus();
+        expect(grid).toHaveAttribute('aria-activedescendant', cell.id);
+      } else {
+        expect(cell.parentElement).toHaveAttribute('role', 'gridcell');
+        expect(cell.parentElement).toHaveAttribute('aria-selected', 'true');
+        expect(cell).toHaveFocus();
+        expect(grid).not.toHaveAttribute('aria-activedescendant');
+      }
     });
   });
 
@@ -94,26 +103,27 @@ describe('Calendar', () => {
       ${'v2'}   | ${V2Calendar}
     `('$Name selects a date on keyDown Enter/Space (uncontrolled)', ({Calendar}) => {
       let onChange = jest.fn();
-      let {getByLabelText} = render(
+      let {getByLabelText, getByRole} = render(
         <Calendar
           defaultValue={new Date(2019, 5, 5)}
           autoFocus
           onChange={onChange} />
       );
 
+      let grid = getByRole('grid');
       let selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('5');
 
       // Select a new date
-      fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
-      fireEvent.keyDown(document.activeElement, {key: 'Enter', keyCode: keyCodes.Enter});
+      fireEvent.keyDown(grid, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
+      fireEvent.keyDown(grid, {key: 'Enter', keyCode: keyCodes.Enter});
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('4');
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls[0][0].valueOf()).toBe(new Date(2019, 5, 4).valueOf()); // v2 returns a moment object
 
-      fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
-      fireEvent.keyDown(document.activeElement, {key: ' ', keyCode: keyCodes[' ']});
+      fireEvent.keyDown(grid, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
+      fireEvent.keyDown(grid, {key: ' ', keyCode: keyCodes[' ']});
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('3');
       expect(onChange).toHaveBeenCalledTimes(2);
@@ -126,26 +136,27 @@ describe('Calendar', () => {
       ${'v2'}   | ${V2Calendar}
     `('$Name selects a date on keyDown Enter/Space (controlled)', ({Calendar}) => {
       let onChange = jest.fn();
-      let {getByLabelText} = render(
+      let {getByLabelText, getByRole} = render(
         <Calendar
           value={new Date(2019, 5, 5)}
           autoFocus
           onChange={onChange} />
       );
 
+      let grid = getByRole('grid');
       let selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('5');
 
       // Select a new date
-      fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
-      fireEvent.keyDown(document.activeElement, {key: 'Enter', keyCode: keyCodes.Enter});
+      fireEvent.keyDown(grid, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
+      fireEvent.keyDown(grid, {key: 'Enter', keyCode: keyCodes.Enter});
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('5'); // controlled
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls[0][0].valueOf()).toBe(new Date(2019, 5, 4).valueOf()); // v2 returns a moment object
 
-      fireEvent.keyDown(document.activeElement, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
-      fireEvent.keyDown(document.activeElement, {key: ' ', keyCode: keyCodes[' ']});
+      fireEvent.keyDown(grid, {key: 'ArrowLeft', keyCode: keyCodes.ArrowLeft});
+      fireEvent.keyDown(grid, {key: ' ', keyCode: keyCodes[' ']});
       selectedDate = getByLabelText('selected', {exact: false});
       expect(selectedDate.textContent).toBe('5'); // controlled
       expect(onChange).toHaveBeenCalledTimes(2);
@@ -335,25 +346,18 @@ describe('Calendar', () => {
       triggerPress(newDate);
 
       expect(announce).toHaveBeenCalledTimes(1);
-      expect(announce).toHaveBeenCalledWith('Selected Date: Monday, June 17, 2019');
+      expect(announce).toHaveBeenCalledWith('Selected Date: Monday, June 17, 2019', 'polite', 4000);
     });
 
     it('ensures that the active descendant is announced when the focused date changes', () => {
-      let {getByRole} = render(<Calendar defaultValue={new Date(2019, 5, 5)} autoFocus />);
+      let {getByRole, getByLabelText} = render(<Calendar defaultValue={new Date(2019, 5, 5)} autoFocus />);
 
       let grid = getByRole('grid');
-      let onBlur = jest.fn();
-      let onFocus = jest.fn();
+      let selectedDate = getByLabelText('selected', {exact: false});
+      expect(selectedDate).toHaveFocus();
 
-      grid.addEventListener('blur', onBlur);
-      grid.addEventListener('focus', onFocus);
-
-      expect(grid).toHaveFocus();
       fireEvent.keyDown(grid, {key: 'ArrowRight'});
-
-      expect(onBlur).toHaveBeenCalledTimes(1);
-      expect(onFocus).toHaveBeenCalledTimes(1);
-      expect(grid).toHaveFocus();
+      expect(getByLabelText('Thursday, June 6, 2019', {exact: false})).toHaveFocus();
     });
 
     it('renders a caption with the selected date', () => {

--- a/packages/@react-spectrum/datepicker/package.json
+++ b/packages/@react-spectrum/datepicker/package.json
@@ -37,6 +37,7 @@
     "@react-spectrum/calendar": "^3.0.0-alpha.2",
     "@react-spectrum/dialog": "^3.0.0-alpha.2",
     "@react-spectrum/utils": "^3.0.0-alpha.2",
+    "@react-spectrum/view": "^3.0.0-alpha.2",
     "@react-stately/datepicker": "^3.0.0-alpha.2",
     "@react-types/datepicker": "^3.0.0-alpha.2",
     "@spectrum-icons/ui": "^3.0.0-alpha.2",

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -13,6 +13,7 @@
 import {Calendar} from '@react-spectrum/calendar';
 import CalendarIcon from '@spectrum-icons/workflow/Calendar';
 import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
+import {Content} from '@react-spectrum/view';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
@@ -41,7 +42,7 @@ export function DatePicker(props: SpectrumDatePickerProps) {
   } = props;
   let {styleProps} = useStyleProps(otherProps);
   let state = useDatePickerState(props);
-  let {comboboxProps, fieldProps, buttonProps, dialogProps} = useDatePicker(props, state);
+  let {groupProps, fieldProps, buttonProps, dialogProps, descProps} = useDatePicker(props, state);
   let {value, setValue, selectDate, isOpen, setOpen} = state;
   let targetRef = useRef<HTMLDivElement>();
   let {direction} = useLocale();
@@ -66,9 +67,10 @@ export function DatePicker(props: SpectrumDatePickerProps) {
       <div
         {...filterDOMProps(otherProps)}
         {...styleProps}
-        {...comboboxProps}
+        {...groupProps}
         className={className}
         ref={targetRef}>
+        {descProps && descProps.children && <span {...descProps} />}
         <FocusScope autoFocus={autoFocus}>
           <DatePickerField
             {...fieldProps}
@@ -100,10 +102,12 @@ export function DatePicker(props: SpectrumDatePickerProps) {
             icon={<CalendarIcon />}
             isDisabled={isDisabled || isReadOnly} />
           <Dialog UNSAFE_className={classNames(datepickerStyles, 'react-spectrum-Datepicker-dialog')} {...dialogProps}>
-            <Calendar
-              autoFocus
-              value={value}
-              onChange={selectDate} />
+            <Content>
+              <Calendar
+                autoFocus
+                value={value}
+                onChange={selectDate} />
+            </Content>
           </Dialog>
         </DialogTrigger>
       </div>

--- a/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
@@ -15,6 +15,7 @@ import Checkmark from '@spectrum-icons/ui/CheckmarkMedium';
 import {classNames} from '@react-spectrum/utils';
 import {DatePickerSegment} from './DatePickerSegment';
 import datepickerStyles from './index.css';
+import {DOMProps} from '@react-types/shared';
 import {filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import inputgroupStyles from '@adobe/spectrum-css-temp/components/inputgroup/vars.css';
 import {mergeProps} from '@react-aria/utils';
@@ -24,7 +25,12 @@ import textfieldStyles from '@adobe/spectrum-css-temp/components/textfield/vars.
 import {useDateField} from '@react-aria/datepicker';
 import {useDatePickerFieldState} from '@react-stately/datepicker';
 
-export function DatePickerField(props: SpectrumDatePickerProps) {
+interface DateFieldDescProps extends DOMProps {
+  children?: string,
+  hidden?: boolean
+}
+
+export function DatePickerField(props: SpectrumDatePickerProps & {descProps?: DateFieldDescProps}) {
   let state = useDatePickerFieldState(props);
   let {
     isDisabled,
@@ -32,6 +38,7 @@ export function DatePickerField(props: SpectrumDatePickerProps) {
     isRequired,
     isQuiet,
     validationState,
+    descProps,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
@@ -90,7 +97,8 @@ export function DatePickerField(props: SpectrumDatePickerProps) {
 
   return (
     <div {...domProps} {...styleProps} className={textfieldClass}>
-      <div className={inputClass}>
+      {descProps && descProps.children && <span {...descProps} />}
+      <div role="presentation" className={inputClass}>
         {state.segments.map((segment, i) =>
           (<DatePickerSegment
             {...segmentProps}

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -12,6 +12,7 @@
 
 import CalendarIcon from '@spectrum-icons/workflow/Calendar';
 import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
+import {Content} from '@react-spectrum/view';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
@@ -40,7 +41,7 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
   } = props;
   let {styleProps} = useStyleProps(otherProps);
   let state = useDateRangePickerState(props);
-  let {comboboxProps, buttonProps, dialogProps, startFieldProps, endFieldProps} = useDateRangePicker(props, state);
+  let {groupProps, buttonProps, dialogProps, startFieldProps, endFieldProps, descProps} = useDateRangePicker(props, state);
   let {value, setDate, selectDateRange, isOpen, setOpen} = state;
   let targetRef = useRef<HTMLDivElement>();
   let {direction} = useLocale();
@@ -67,9 +68,10 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
       <div 
         {...filterDOMProps(otherProps)}
         {...styleProps}
-        {...comboboxProps}
+        {...groupProps}
         className={className}
         ref={targetRef}>
+        {descProps && descProps.children && <span {...descProps} />}
         <FocusScope autoFocus={autoFocus}>
           <DatePickerField
             {...startFieldProps}
@@ -80,6 +82,7 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
             formatOptions={formatOptions}
             placeholderDate={placeholderDate}
             value={value.start}
+            defaultValue={null}
             onChange={start => setDate('start', start)}
             UNSAFE_className={classNames(styles, 'spectrum-Datepicker-startField')} />
           <DateRangeDash />
@@ -93,6 +96,7 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
             formatOptions={formatOptions}
             placeholderDate={placeholderDate}
             value={value.end}
+            defaultValue={null}
             onChange={end => setDate('end', end)}
             UNSAFE_className={classNames(
               styles,
@@ -119,10 +123,12 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
             icon={<CalendarIcon />}
             isDisabled={isDisabled || isReadOnly} />
           <Dialog UNSAFE_className={classNames(datepickerStyles, 'react-spectrum-Datepicker-dialog')} {...dialogProps}>
-            <RangeCalendar
-              autoFocus
-              value={value}
-              onChange={selectDateRange} />
+            <Content>
+              <RangeCalendar
+                autoFocus
+                value={value || null}
+                onChange={selectDateRange} />
+            </Content>
           </Dialog>
         </DialogTrigger>
       </div>

--- a/packages/@react-spectrum/datepicker/src/index.css
+++ b/packages/@react-spectrum/datepicker/src/index.css
@@ -46,12 +46,24 @@
 }
 
 .react-spectrum-DatePicker-cell:focus {
-  background: rgba(38, 128, 235, 0.25);
+  background-color: var(--spectrum-alias-text-highlight-color);
   outline: none;
 }
 
 .react-spectrum-DatePicker-cell.is-placeholder {
   color: var(--spectrum-textfield-placeholder-text-color, var(--spectrum-global-color-gray-600));
+}
+
+.react-spectrum-DatePicker-cell.is-placeholder ~ .react-spectrum-Datepicker-literal {
+  color: var(--spectrum-textfield-placeholder-text-color, var(--spectrum-global-color-gray-600));
+}
+
+.react-spectrum-DatePicker-cell.is-placeholder:focus {
+  color: inherit;
+}
+
+.react-spectrum-Datepicker-dialog {
+  width: calc(var(--spectrum-dialog-padding) * 2 +(var(--spectrum-calendar-day-width, var(--spectrum-global-dimension-size-400)) + var(--spectrum-calendar-day-padding, 4px) * 2) * 7);
 }
 
 /* When displayed in a tray (aria-modal), center the dialog rather than using fixed padding. */

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -30,7 +30,7 @@ describe('DatePicker', function () {
     it('should render a datepicker with a specified date', function () {
       let {getByRole, getAllByRole} = render(<DatePicker value={new Date(2019, 1, 3)} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toBeVisible();
       expect(combobox).not.toHaveAttribute('aria-disabled');
       expect(combobox).not.toHaveAttribute('aria-invalid');
@@ -41,7 +41,7 @@ describe('DatePicker', function () {
       expect(segments[0].textContent).toBe('2');
       expect(segments[0].getAttribute('aria-label')).toBe('Month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
-      expect(segments[0].getAttribute('aria-valuetext')).toBe('February');
+      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 - February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
@@ -71,7 +71,7 @@ describe('DatePicker', function () {
       };
       let {getByRole, getAllByRole} = render(<DatePicker value={new Date(2019, 1, 3)} formatOptions={format} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toBeVisible();
       expect(combobox).not.toHaveAttribute('aria-disabled');
       expect(combobox).not.toHaveAttribute('aria-invalid');
@@ -136,7 +136,7 @@ describe('DatePicker', function () {
         </Provider>
       );
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent('2/3/2019');
 
       let button = getByRole('button');
@@ -165,7 +165,7 @@ describe('DatePicker', function () {
         </Provider>
       );
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent('2/3/2019');
 
       let button = getByRole('button');
@@ -191,7 +191,7 @@ describe('DatePicker', function () {
     it('should support labeling with a default label', function () {
       let {getByRole, getAllByRole} = render(<DatePicker />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveAttribute('aria-label', 'Date');
       expect(combobox).toHaveAttribute('id');
       let comboboxId = combobox.getAttribute('id');
@@ -213,7 +213,7 @@ describe('DatePicker', function () {
     it('should support labeling with aria-label', function () {
       let {getByRole, getAllByRole} = render(<DatePicker aria-label="Birth date" />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveAttribute('aria-label', 'Birth date');
       expect(combobox).toHaveAttribute('id');
       let comboboxId = combobox.getAttribute('id');
@@ -235,7 +235,7 @@ describe('DatePicker', function () {
     it('should support labeling with aria-labelledby', function () {
       let {getByRole, getAllByRole} = render(<DatePicker aria-labelledby="foo" />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).not.toHaveAttribute('aria-label');
       expect(combobox).toHaveAttribute('aria-labelledby', 'foo');
 
@@ -777,7 +777,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole} = render(<DatePicker onChange={onChange} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent(`1/1/${new Date().getFullYear()}`);
     });
 
@@ -785,7 +785,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole} = render(<DatePicker onChange={onChange} value={null} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent(`1/1/${new Date().getFullYear()}`);
     });
 
@@ -793,7 +793,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole} = render(<DatePicker onChange={onChange} placeholderDate={new Date(1980, 0, 1)} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent('1/1/1980');
     });
 
@@ -801,7 +801,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole, getAllByRole} = render(<DatePicker onChange={onChange} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent(`1/1/${new Date().getFullYear()}`);
 
       let segments = getAllByRole('spinbutton');
@@ -826,7 +826,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole, getAllByRole} = render(<DatePicker onChange={onChange} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent(`1/1/${new Date().getFullYear()}`);
 
       let segments = getAllByRole('spinbutton');
@@ -854,7 +854,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole, getAllByRole, rerender} = render(<DatePicker onChange={onChange} value={null} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent(`1/1/${new Date().getFullYear()}`);
 
       let segments = getAllByRole('spinbutton');
@@ -885,7 +885,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole, getAllByRole} = render(<DatePicker onChange={onChange} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent(`1/1/${new Date().getFullYear()}`);
 
       let segments = getAllByRole('spinbutton');
@@ -918,7 +918,7 @@ describe('DatePicker', function () {
       let onChange = jest.fn();
       let {getByRole, getAllByRole, rerender} = render(<DatePicker onChange={onChange} value={null} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getByRole('group');
       expect(combobox).toHaveTextContent(`1/1/${new Date().getFullYear()}`);
 
       let segments = getAllByRole('spinbutton');

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -147,9 +147,9 @@ describe('DatePicker', function () {
 
       let cells = getAllByRole('gridcell');
       let selected = cells.find(cell => cell.getAttribute('aria-selected') === 'true');
-      expect(selected).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
+      expect(selected.children[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
 
-      triggerPress(selected.nextSibling);
+      triggerPress(selected.nextSibling.children[0]);
 
       expect(dialog).not.toBeInTheDocument();
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -176,9 +176,9 @@ describe('DatePicker', function () {
 
       let cells = getAllByRole('gridcell');
       let selected = cells.find(cell => cell.getAttribute('aria-selected') === 'true');
-      expect(selected).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
+      expect(selected.children[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected');
 
-      triggerPress(selected.nextSibling);
+      triggerPress(selected.nextSibling.children[0]);
 
       expect(dialog).not.toBeInTheDocument();
       expect(onChange).toHaveBeenCalledTimes(1);

--- a/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
@@ -145,8 +145,8 @@ describe('DatePickerBase', function () {
       expect(button).toHaveAttribute('aria-expanded', 'true');
       expect(button).toHaveAttribute('aria-controls', dialogId);
 
-      // Focuses the calendar body
-      expect(document.activeElement).toHaveAttribute('role', 'grid');
+      // Focuses the calendar date
+      expect(document.activeElement.parentElement).toHaveAttribute('role', 'gridcell');
     });
 
     it.each`
@@ -181,8 +181,8 @@ describe('DatePickerBase', function () {
       expect(button).toHaveAttribute('aria-expanded', 'true');
       expect(button).toHaveAttribute('aria-controls', dialogId);
 
-      // Focuses the calendar body
-      expect(document.activeElement).toHaveAttribute('role', 'grid');
+      // Focuses the calendar date
+      expect(document.activeElement.parentElement).toHaveAttribute('role', 'gridcell');
     });
 
     it.each`
@@ -218,8 +218,8 @@ describe('DatePickerBase', function () {
       expect(button).toHaveAttribute('aria-expanded', 'true');
       expect(button).toHaveAttribute('aria-controls', dialogId);
 
-      // Focuses the calendar body
-      expect(document.activeElement).toHaveAttribute('role', 'grid');
+      // Focuses the calendar date
+      expect(document.activeElement.parentElement).toHaveAttribute('role', 'gridcell');
     });
   });
 

--- a/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
@@ -32,9 +32,9 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}        | ${3}
       ${'DateRangePicker'}   | ${DateRangePicker}   | ${6}
     `('$Name should render a default datepicker', ({Component, numSegments}) => {
-      let {getByRole, getAllByRole} = render(<Component />);
+      let {getAllByRole} = render(<Component />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getAllByRole('group')[0];
       expect(combobox).toBeVisible();
       expect(combobox).not.toHaveAttribute('aria-disabled');
       expect(combobox).not.toHaveAttribute('aria-invalid');
@@ -42,7 +42,7 @@ describe('DatePickerBase', function () {
       let segments = getAllByRole('spinbutton');
       expect(segments.length).toBe(numSegments);
 
-      let button = getByRole('button');
+      let button = getAllByRole('button')[0];
       expect(button).toBeVisible();
     });
 
@@ -51,9 +51,9 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}
       ${'DateRangePicker'}   | ${DateRangePicker}
     `('$Name should set aria-disabled when isDisabled', ({Component}) => {
-      let {getByRole, getAllByRole} = render(<Component isDisabled />);
+      let {getAllByRole} = render(<Component isDisabled />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getAllByRole('group')[0];
       expect(combobox).toHaveAttribute('aria-disabled', 'true');
 
       let segments = getAllByRole('spinbutton');
@@ -61,7 +61,7 @@ describe('DatePickerBase', function () {
         expect(segment).toHaveAttribute('aria-disabled', 'true');
       }
 
-      let button = getByRole('button');
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('disabled');
     });
 
@@ -70,17 +70,17 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}
       ${'DateRangePicker'}   | ${DateRangePicker}
     `('$Name should set aria-readonly when isReadOnly', ({Component}) => {
-      let {getByRole, getAllByRole} = render(<Component isReadOnly />);
+      let {getAllByRole} = render(<Component isReadOnly />);
 
-      let combobox = getByRole('combobox');
-      expect(combobox).toHaveAttribute('aria-readonly', 'true');
+      let combobox = getAllByRole('group')[0];
+      expect(combobox).not.toHaveAttribute('aria-readonly', 'true');
 
       let segments = getAllByRole('spinbutton');
       for (let segment of segments) {
         expect(segment).toHaveAttribute('aria-readonly', 'true');
       }
 
-      let button = getByRole('button');
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('disabled');
     });
 
@@ -89,10 +89,10 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}
       ${'DateRangePicker'}   | ${DateRangePicker}
     `('$Name should set aria-required when isRequired', ({Component}) => {
-      let {getByRole, getAllByRole} = render(<Component isRequired />);
+      let {getAllByRole} = render(<Component isRequired />);
 
-      let combobox = getByRole('combobox');
-      expect(combobox).toHaveAttribute('aria-required', 'true');
+      let combobox = getAllByRole('group')[0];
+      expect(combobox).not.toHaveAttribute('aria-required', 'true');
 
       let segments = getAllByRole('spinbutton');
       for (let segment of segments) {
@@ -105,10 +105,15 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}
       ${'DateRangePicker'}   | ${DateRangePicker}
     `('$Name should set aria-invalid when validationState="invalid"', ({Component}) => {
-      let {getByRole} = render(<Component validationState="invalid" />);
+      let {getAllByRole} = render(<Component validationState="invalid" />);
 
-      let combobox = getByRole('combobox');
-      expect(combobox).toHaveAttribute('aria-invalid', 'true');
+      let combobox = getAllByRole('group')[0];
+      expect(combobox).not.toHaveAttribute('aria-invalid', 'true');
+ 
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-invalid', 'true');
+      }
     });
   });
 
@@ -118,29 +123,38 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}
       ${'DateRangePicker'}   | ${DateRangePicker}
     `('$Name should open a calendar popover when clicking the button', ({Component}) => {
-      let {getByRole} = render(
+      let {getAllByRole} = render(
         <Provider theme={theme}>
           <Component />
         </Provider>
       );
 
-      let combobox = getByRole('combobox');
-      expect(combobox).toHaveAttribute('aria-haspopup', 'dialog');
+      let combobox = getAllByRole('group')[0];
+      expect(combobox).not.toHaveAttribute('aria-haspopup', 'dialog');
       expect(combobox).not.toHaveAttribute('aria-owns');
 
-      let button = getByRole('button');
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-haspopup', 'dialog');
+        expect(segment).not.toHaveAttribute('aria-expanded');
+        expect(segment).not.toHaveAttribute('aria-controls');
+      }
+
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+      expect(button).toHaveAttribute('aria-expanded', 'false');
       expect(button).not.toHaveAttribute('aria-controls');
 
       triggerPress(button);
 
-      let dialog = getByRole('dialog');
+      let dialog = getAllByRole('dialog')[0];
       expect(dialog).toBeVisible();
       expect(dialog).toHaveAttribute('id');
       let dialogId = dialog.getAttribute('id');
 
-      expect(combobox).toHaveAttribute('aria-expanded', 'true');
-      expect(combobox).toHaveAttribute('aria-owns', dialogId);
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-controls', dialogId);
+      }
 
       expect(button).toHaveAttribute('aria-expanded', 'true');
       expect(button).toHaveAttribute('aria-controls', dialogId);
@@ -154,29 +168,37 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}
       ${'DateRangePicker'}   | ${DateRangePicker}
     `('$Name should open a calendar popover pressing Alt + ArrowDown on the keyboard', ({Component}) => {
-      let {getByRole} = render(
+      let {getAllByRole} = render(
         <Provider theme={theme}>
           <Component />
         </Provider>
       );
 
-      let combobox = getByRole('combobox');
-      expect(combobox).toHaveAttribute('aria-haspopup', 'dialog');
+      let combobox = getAllByRole('group')[0];
+      expect(combobox).not.toHaveAttribute('aria-haspopup', 'dialog');
       expect(combobox).not.toHaveAttribute('aria-owns');
 
-      let button = getByRole('button');
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-haspopup', 'dialog');
+        expect(segment).not.toHaveAttribute('aria-expanded');
+        expect(segment).not.toHaveAttribute('aria-controls');
+      }
+
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-haspopup', 'dialog');
       expect(button).not.toHaveAttribute('aria-controls');
 
       fireEvent.keyDown(combobox, {key: 'ArrowDown', altKey: true});
 
-      let dialog = getByRole('dialog');
+      let dialog = getAllByRole('dialog')[0];
       expect(dialog).toBeVisible();
       expect(dialog).toHaveAttribute('id');
       let dialogId = dialog.getAttribute('id');
 
-      expect(combobox).toHaveAttribute('aria-expanded', 'true');
-      expect(combobox).toHaveAttribute('aria-owns', dialogId);
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-controls', dialogId);
+      }
 
       expect(button).toHaveAttribute('aria-expanded', 'true');
       expect(button).toHaveAttribute('aria-controls', dialogId);
@@ -190,30 +212,38 @@ describe('DatePickerBase', function () {
       ${'DatePicker'}        | ${DatePicker}
       ${'DateRangePicker'}   | ${DateRangePicker}
     `('$Name should open a calendar popover when tapping on the date field with a touch device', ({Component}) => {
-      let {getByRole} = render(
+      let {getAllByRole} = render(
         <Provider theme={theme}>
           <Component />
         </Provider>
       );
 
-      let combobox = getByRole('combobox');
-      expect(combobox).toHaveAttribute('aria-haspopup', 'dialog');
+      let combobox = getAllByRole('group')[0];
+      expect(combobox).not.toHaveAttribute('aria-haspopup', 'dialog');
       expect(combobox).not.toHaveAttribute('aria-owns');
 
-      let button = getByRole('button');
+      let segments = getAllByRole('spinbutton');
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-haspopup', 'dialog');
+        expect(segment).not.toHaveAttribute('aria-expanded');
+        expect(segment).not.toHaveAttribute('aria-controls');
+      }
+
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-haspopup', 'dialog');
       expect(button).not.toHaveAttribute('aria-controls');
 
       fireEvent.touchStart(combobox, {targetTouches: [{identifier: 1}]});
       fireEvent.touchEnd(combobox, {changedTouches: [{identifier: 1, clientX: 0, clientY: 0}]});
 
-      let dialog = getByRole('dialog');
+      let dialog = getAllByRole('dialog')[0];
       expect(dialog).toBeVisible();
       expect(dialog).toHaveAttribute('id');
       let dialogId = dialog.getAttribute('id');
 
-      expect(combobox).toHaveAttribute('aria-expanded', 'true');
-      expect(combobox).toHaveAttribute('aria-owns', dialogId);
+      for (let segment of segments) {
+        expect(segment).toHaveAttribute('aria-controls', dialogId);
+      }
 
       expect(button).toHaveAttribute('aria-expanded', 'true');
       expect(button).toHaveAttribute('aria-controls', dialogId);

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -216,7 +216,7 @@ describe('DateRangePicker', function () {
 
       let cells = getAllByRole('gridcell');
       let selected = cells.filter(cell => cell.getAttribute('aria-selected') === 'true');
-      expect(selected[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected (Click to start selecting date range)');
+      expect(selected[0].children[0]).toHaveAttribute('aria-label', 'Sunday, February 3, 2019 selected (Click to start selecting date range)');
 
       triggerPress(getByLabelText('Sunday, February 10, 2019 selected'));
       triggerPress(getByLabelText('Sunday, February 17, 2019'));

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -28,9 +28,9 @@ describe('DateRangePicker', function () {
 
   describe('basics', function () {
     it('should render a DateRangePicker with a specified date range', function () {
-      let {getByRole, getAllByRole} = render(<DateRangePicker value={{start: new Date(2019, 1, 3), end: new Date(2019, 4, 6)}} />);
+      let {getAllByRole} = render(<DateRangePicker value={{start: new Date(2019, 1, 3), end: new Date(2019, 4, 6)}} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getAllByRole('group')[0];
       expect(combobox).toBeVisible();
       expect(combobox).not.toHaveAttribute('aria-disabled');
       expect(combobox).not.toHaveAttribute('aria-invalid');
@@ -41,7 +41,7 @@ describe('DateRangePicker', function () {
       expect(segments[0].textContent).toBe('2');
       expect(segments[0].getAttribute('aria-label')).toBe('Month');
       expect(segments[0].getAttribute('aria-valuenow')).toBe('2');
-      expect(segments[0].getAttribute('aria-valuetext')).toBe('February');
+      expect(segments[0].getAttribute('aria-valuetext')).toBe('2 - February');
       expect(segments[0].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[0].getAttribute('aria-valuemax')).toBe('12');
 
@@ -62,7 +62,7 @@ describe('DateRangePicker', function () {
       expect(segments[3].textContent).toBe('5');
       expect(segments[3].getAttribute('aria-label')).toBe('Month');
       expect(segments[3].getAttribute('aria-valuenow')).toBe('5');
-      expect(segments[3].getAttribute('aria-valuetext')).toBe('May');
+      expect(segments[3].getAttribute('aria-valuetext')).toBe('5 - May');
       expect(segments[3].getAttribute('aria-valuemin')).toBe('1');
       expect(segments[3].getAttribute('aria-valuemax')).toBe('12');
 
@@ -90,9 +90,9 @@ describe('DateRangePicker', function () {
         minute: 'numeric',
         second: 'numeric'
       };
-      let {getByRole, getAllByRole} = render(<DateRangePicker value={{start: new Date(2019, 1, 3), end: new Date(2019, 4, 6)}} formatOptions={format} />);
+      let {getAllByRole} = render(<DateRangePicker value={{start: new Date(2019, 1, 3), end: new Date(2019, 4, 6)}} formatOptions={format} />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getAllByRole('group')[0];
       expect(combobox).toBeVisible();
       expect(combobox).not.toHaveAttribute('aria-disabled');
       expect(combobox).not.toHaveAttribute('aria-invalid');
@@ -231,9 +231,9 @@ describe('DateRangePicker', function () {
 
   describe('labeling', function () {
     it('should support labeling with a default label', function () {
-      let {getByRole, getByLabelText} = render(<DateRangePicker />);
+      let {getAllByRole, getByLabelText} = render(<DateRangePicker />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getAllByRole('group')[0];
       expect(combobox).toHaveAttribute('aria-label', 'Date Range');
       expect(combobox).toHaveAttribute('id');
 
@@ -243,7 +243,7 @@ describe('DateRangePicker', function () {
       let endDate = getByLabelText('End Date');
       expect(endDate).toHaveAttribute('aria-labelledby', `${combobox.id} ${endDate.id}`);
 
-      let button = getByRole('button');
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-label', 'Calendar');
       expect(button).toHaveAttribute('id');
       expect(button).toHaveAttribute('aria-labelledby', `${combobox.id} ${button.id}`);
@@ -262,9 +262,9 @@ describe('DateRangePicker', function () {
     });
 
     it('should support labeling with aria-label', function () {
-      let {getByRole, getByLabelText} = render(<DateRangePicker aria-label="Birth date" />);
+      let {getAllByRole, getByLabelText} = render(<DateRangePicker aria-label="Birth date" />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getAllByRole('group')[0];
       expect(combobox).toHaveAttribute('aria-label', 'Birth date');
       expect(combobox).toHaveAttribute('id');
 
@@ -274,7 +274,7 @@ describe('DateRangePicker', function () {
       let endDate = getByLabelText('End Date');
       expect(endDate).toHaveAttribute('aria-labelledby', `${combobox.id} ${endDate.id}`);
 
-      let button = getByRole('button');
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-label', 'Calendar');
       expect(button).toHaveAttribute('id');
       expect(button).toHaveAttribute('aria-labelledby', `${combobox.id} ${button.id}`);
@@ -293,9 +293,9 @@ describe('DateRangePicker', function () {
     });
 
     it('should support labeling with aria-labelledby', function () {
-      let {getByRole, getByLabelText} = render(<DateRangePicker aria-labelledby="foo" />);
+      let {getAllByRole, getByLabelText} = render(<DateRangePicker aria-labelledby="foo" />);
 
-      let combobox = getByRole('combobox');
+      let combobox = getAllByRole('group')[0];
       expect(combobox).not.toHaveAttribute('aria-label');
       expect(combobox).toHaveAttribute('aria-labelledby', 'foo');
 
@@ -305,7 +305,7 @@ describe('DateRangePicker', function () {
       let endDate = getByLabelText('End Date');
       expect(endDate).toHaveAttribute('aria-labelledby', `foo ${endDate.id}`);
 
-      let button = getByRole('button');
+      let button = getAllByRole('button')[0];
       expect(button).toHaveAttribute('aria-label', 'Calendar');
       expect(button).toHaveAttribute('id');
       expect(button).toHaveAttribute('aria-labelledby', `foo ${button.id}`);

--- a/packages/@react-stately/calendar/src/types.ts
+++ b/packages/@react-stately/calendar/src/types.ts
@@ -62,5 +62,6 @@ export interface CalendarCellOptions {
   isRangeStart?: boolean,
   isRangeEnd?: boolean,
   isSelectionStart?: boolean,
-  isSelectionEnd?: boolean
+  isSelectionEnd?: boolean,
+  colIndex?: number
 }

--- a/packages/@react-stately/calendar/src/useCalendarState.ts
+++ b/packages/@react-stately/calendar/src/useCalendarState.ts
@@ -45,6 +45,8 @@ export function useCalendarState(props: CalendarProps): CalendarState {
 
     if (!isSameMonth(date, currentMonth)) {
       setCurrentMonth(startOfMonth(date));
+      setFocusedDate(date);
+      return;
     }
 
     setFocusedDate(date);
@@ -115,7 +117,8 @@ export function useCalendarState(props: CalendarProps): CalendarState {
         isDisabled: props.isDisabled || !isCurrentMonth || isInvalid(cellDate, minDate, maxDate),
         isSelected: isSameDay(cellDate, value),
         isFocused: isFocused && focusedDate && isSameDay(cellDate, focusedDate),
-        isReadOnly: props.isReadOnly
+        isReadOnly: props.isReadOnly,
+        colIndex: dayIndex + 1
       };
     }
   };

--- a/packages/@react-types/calendar/src/index.d.ts
+++ b/packages/@react-types/calendar/src/index.d.ts
@@ -21,8 +21,9 @@ export interface CalendarPropsBase {
   autoFocus?: boolean
 }
 
+export type DateRange = RangeValue<DateValue>;
 export interface CalendarProps extends CalendarPropsBase, ValueBase<DateValue> {}
-export interface RangeCalendarProps extends CalendarPropsBase, ValueBase<RangeValue<DateValue>> {}
+export interface RangeCalendarProps extends CalendarPropsBase, ValueBase<DateRange> {}
 
 export interface SpectrumCalendarProps extends CalendarProps, DOMProps, StyleProps {}
 export interface SpectrumRangeCalendarProps extends RangeCalendarProps, DOMProps, StyleProps {}


### PR DESCRIPTION
Closes [RSP-1412](https://jira.corp.adobe.com/browse/RSP-1412)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [RSP-1412](https://jira.corp.adobe.com/browse/RSP-1412)).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- Updated documentation (if it already exist for this component).
- [x] Looked at the [Accessibility Standard](https://wiki.corp.adobe.com/display/Accessibility/Adobe+Accessibility+Standard) and/or talked to [@mijordan](https://git.corp.adobe.com/mijordan) about Accessibility for this feature.

## 📝 Test Instructions:

1. With date segments, the DatePicker and DateRangePicker should use role="group" instead of role="combobox". 
2. The spinbutton role is problematic with screen readers on touch devices. So `role="textbox"` is used when `useMediaQuery('(hover: none) and (pointer: coarse)')`. Calendar Popover will now open when a segment is double tapped with VoiceOver running. 

Test all DatePicker and DateRangePicker examples with a variety of browser/screen reader combinations.

## 🧢 Your Team:

Accessibility
