### PR TITLE
Add support for DOM heirarchy in CollectionView

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -45,6 +45,7 @@ governing permissions and limitations under the License.
   list-style-type: none;
 
   overflow: auto;
+  user-select: none;
 
   width: 200px;
   max-height: inherit; /* inherit from parent popover */

--- a/packages/@react-aria/collections/src/CollectionItem.tsx
+++ b/packages/@react-aria/collections/src/CollectionItem.tsx
@@ -1,0 +1,43 @@
+import {LayoutInfo} from '@react-stately/collections';
+import React, {CSSProperties, useRef} from 'react';
+import {ReusableView} from '@react-stately/collections';
+import {useCollectionItem} from './useCollectionItem';
+
+interface CollectionItemProps<T extends object, V> {
+  reusableView: ReusableView<T, V>,
+  parent?: ReusableView<T, V>
+}
+
+export function CollectionItem<T extends object, V>(props: CollectionItemProps<T, V>) {
+  let {reusableView, parent} = props;
+  let ref = useRef();
+  useCollectionItem({
+    reusableView,
+    ref
+  });
+
+  return (
+    <div role="presentation" ref={ref} style={layoutInfoToStyle(reusableView.layoutInfo, parent && parent.layoutInfo)}>
+      {reusableView.rendered}
+    </div>
+  );
+}
+
+export function layoutInfoToStyle(layoutInfo: LayoutInfo, parent?: LayoutInfo | null): CSSProperties {
+  return {
+    position: 'absolute',
+    overflow: 'hidden',
+    top: layoutInfo.rect.y - (parent ? parent.rect.y : 0),
+    left: layoutInfo.rect.x - (parent ? parent.rect.x : 0),
+    transition: 'all',
+    WebkitTransition: 'all',
+    WebkitTransitionDuration: 'inherit',
+    transitionDuration: 'inherit',
+    width: layoutInfo.rect.width + 'px',
+    height: layoutInfo.rect.height + 'px',
+    opacity: layoutInfo.opacity,
+    zIndex: layoutInfo.zIndex,
+    transform: layoutInfo.transform,
+    contain: 'size layout style paint'
+  };
+}

--- a/packages/@react-aria/collections/src/ScrollView.tsx
+++ b/packages/@react-aria/collections/src/ScrollView.tsx
@@ -136,7 +136,7 @@ function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
 
   return (
     <div {...otherProps} style={{position: 'relative', overflow: 'auto'}} ref={ref} onScroll={onScroll}>
-      <div style={{width: contentSize.width, height: contentSize.height, pointerEvents: isScrolling ? 'none' : 'auto', ...innerStyle}}>
+      <div role="presentation" style={{width: contentSize.width, height: contentSize.height, pointerEvents: isScrolling ? 'none' : 'auto', ...innerStyle}}>
         {children}
       </div>
     </div>

--- a/packages/@react-aria/collections/src/index.ts
+++ b/packages/@react-aria/collections/src/index.ts
@@ -12,3 +12,4 @@
 
 export * from './CollectionView';
 export * from './useCollectionItem';
+export * from './CollectionItem';

--- a/packages/@react-aria/collections/src/useCollectionItem.ts
+++ b/packages/@react-aria/collections/src/useCollectionItem.ts
@@ -10,17 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import {CollectionManager, LayoutInfo, Size} from '@react-stately/collections';
 import {RefObject, useCallback, useLayoutEffect} from 'react';
+import {ReusableView} from '@react-stately/collections';
+import {Size} from '@react-stately/collections';
 
 interface CollectionItemOptions<T extends object, V, W> {
-  layoutInfo: LayoutInfo,
-  collectionManager: CollectionManager<T, V, W>,
+  reusableView: ReusableView<T, V>,
   ref: RefObject<HTMLElement>
 }
 
 export function useCollectionItem<T extends object, V, W>(options: CollectionItemOptions<T, V, W>) {
-  let {layoutInfo, collectionManager, ref} = options;
+  let {reusableView: {layoutInfo, collectionManager}, ref} = options;
 
   let updateSize = useCallback(() => {
     let size = getSize(ref.current);
@@ -37,15 +37,5 @@ export function useCollectionItem<T extends object, V, W>(options: CollectionIte
 }
 
 function getSize(node: HTMLElement) {
-  // Get bounding rect of all children
-  let top = Infinity, left = Infinity, bottom = 0, right = 0;
-  for (let child of Array.from(node.childNodes)) {
-    let rect = (child as HTMLElement).getBoundingClientRect();
-    top = Math.min(top, rect.top);
-    left = Math.min(left, rect.left);
-    bottom = Math.max(bottom, rect.bottom);
-    right = Math.max(right, rect.right);
-  }
-
-  return new Size(right - left, bottom - top);
+  return new Size(node.scrollWidth, node.scrollHeight);
 }

--- a/packages/@react-aria/listbox/src/useListBoxSection.ts
+++ b/packages/@react-aria/listbox/src/useListBoxSection.ts
@@ -14,7 +14,6 @@ import {HTMLAttributes} from 'react';
 import {useId} from '@react-aria/utils';
 
 interface ListBoxSectionAria {
-  itemProps: HTMLAttributes<HTMLElement>,
   headingProps: HTMLAttributes<HTMLElement>,
   groupProps: HTMLAttributes<HTMLElement>
 }
@@ -23,9 +22,6 @@ export function useListBoxSection(): ListBoxSectionAria {
   let headingId = useId();
 
   return {
-    itemProps: {
-      role: 'presentation'
-    },
     headingProps: {
       // Techincally, listbox cannot contain headings according to ARIA.
       // We hide the heading from assistive technology, and only use it

--- a/packages/@react-spectrum/listbox/src/ListBox.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBox.tsx
@@ -41,6 +41,8 @@ export function ListBox<T>(props: SpectrumMenuProps<T>) {
   let {listBoxProps} = useListBox({...completeProps, keyboardDelegate: layout, isVirtualized: true}, state);
   let {styleProps} = useStyleProps(completeProps);
 
+  // This overrides collection view's renderWrapper to support heirarchy of items in sections.
+  // The header is extracted from the children so it can receive ARIA labeling properties.
   type View = ReusableView<Node<T>, unknown>;
   let renderWrapper = (parent: View, reusableView: View, children: View[], renderChildren: (views: View[]) => ReactElement[]) => {
     if (reusableView.viewType === 'section') {

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -40,7 +40,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
     key
   } = item;
 
-  let ref = useRef<HTMLLIElement>();
+  let ref = useRef<HTMLDivElement>();
   let {optionProps} = useOption(
     {
       isSelected,
@@ -54,7 +54,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
 
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
-      <li
+      <div
         {...optionProps}
         ref={ref}
         className={classNames(
@@ -94,7 +94,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
               } />
           }
         </Grid>  
-      </li>
+      </div>
     </FocusRing>
   );
 }

--- a/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxSection.tsx
@@ -11,39 +11,49 @@
  */
 
 import {classNames} from '@react-spectrum/utils';
+import {layoutInfoToStyle, useCollectionItem} from '@react-aria/collections';
 import {ListState} from '@react-stately/list';
 import {Node} from '@react-stately/collections';
-import React, {Fragment, ReactNode} from 'react';
+import React, {Fragment, ReactNode, useRef} from 'react';
+import {ReusableView} from '@react-stately/collections';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
 import {useListBoxSection} from '@react-aria/listbox';
 import {useSeparator} from '@react-aria/separator';
 
 interface ListBoxSectionProps<T> {
-  item: Node<T>,
+  reusableView: ReusableView<Node<T>, unknown>,
+  header: ReusableView<Node<T>, unknown>,
   state: ListState<T>,
   children?: ReactNode
 }
 
 export function ListBoxSection<T>(props: ListBoxSectionProps<T>) {
-  let {item, state, children} = props;
-  let {itemProps, headingProps, groupProps} = useListBoxSection();
+  let {state, children, reusableView, header} = props;
+  let item = reusableView.content;
+  let {headingProps, groupProps} = useListBoxSection();
   let {separatorProps} = useSeparator({
     elementType: 'li'
   });
 
+  let headerRef = useRef();
+  useCollectionItem({
+    reusableView: header,
+    ref: headerRef
+  });
+
   return (
     <Fragment>
-      {item.key !== state.collection.getFirstKey() &&
-        <li
-          {...separatorProps}
-          className={classNames(
-            styles,
-            'spectrum-Menu-divider'
-          )} />
-      }
-      <li {...itemProps}>
+      <div role="presentation" ref={headerRef} style={layoutInfoToStyle(header.layoutInfo)}>
+        {item.key !== state.collection.getFirstKey() &&
+          <div
+            {...separatorProps}
+            className={classNames(
+              styles,
+              'spectrum-Menu-divider'
+            )} />
+        }
         {item.rendered &&
-          <span
+          <div
             {...headingProps}
             className={
               classNames(
@@ -52,19 +62,20 @@ export function ListBoxSection<T>(props: ListBoxSectionProps<T>) {
               )
             }>
             {item.rendered}
-          </span>
+          </div>
         }
-        <ul
-          {...groupProps}
-          className={
-            classNames(
-              styles, 
-              'spectrum-Menu'
-            )
-          }>
-          {children}
-        </ul>
-      </li>
+      </div>
+      <div
+        {...groupProps}
+        style={layoutInfoToStyle(reusableView.layoutInfo)}
+        className={
+          classNames(
+            styles, 
+            'spectrum-Menu'
+          )
+        }>
+        {children}
+      </div>
     </Fragment>
   );
 }

--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -16,15 +16,15 @@ import AlignLeft from '@spectrum-icons/workflow/AlignLeft';
 import AlignRight from '@spectrum-icons/workflow/AlignRight';
 import Blower from '@spectrum-icons/workflow/Blower';
 import Book from '@spectrum-icons/workflow/Book';
-import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
 import {Item, ListBox, Section} from '../';
-import {Keyboard, Text} from '@react-spectrum/typography';
+import {Label} from '@react-spectrum/label';
 import Paste from '@spectrum-icons/workflow/Paste';
 import {Popover} from '@react-spectrum/overlays';
-import React from 'react';
+import React, {Fragment} from 'react';
 import {storiesOf} from '@storybook/react';
+import {Text} from '@react-spectrum/typography';
 
 let iconMap = {
   AlignCenter,
@@ -39,18 +39,14 @@ let iconMap = {
 
 let hardModeProgrammatic = [
   {name: 'Section 1', children: [
-    {name: 'Copy', icon: 'Copy', shortcut: '⌘C'},
-    {name: 'Cut', icon: 'Cut', shortcut: '⌘X'},
-    {name: 'Paste', icon: 'Paste', shortcut: '⌘V'}
+    {name: 'Copy', icon: 'Copy'},
+    {name: 'Cut', icon: 'Cut'},
+    {name: 'Paste', icon: 'Paste'}
   ]},
   {name: 'Section 2', children: [
-    {name: 'Puppy', icon: 'AlignLeft', shortcut: '⌘P'},
-    {name: 'Doggo', icon: 'AlignCenter', shortcut: '⌘D'},
-    {name: 'Floof', icon: 'AlignRight', shortcut: '⌘F'},
-    {name: 'hasChildren', children: [
-      {name: 'Thailand', icon: 'Blower', shortcut: '⌘T'},
-      {name: 'Germany', icon: 'Book', shortcut: '⌘G'}
-    ]}
+    {name: 'Puppy', icon: 'AlignLeft'},
+    {name: 'Doggo', icon: 'AlignCenter'},
+    {name: 'Floof', icon: 'AlignRight'}
   ]}
 ];
 
@@ -75,18 +71,32 @@ let withSection = [
   {name: 'People', children: [
     {name: 'Danni'},
     {name: 'Devon'},
-    {name: 'Ross', children: [
-      {name: 'Tests'}
-    ]}
+    {name: 'Ross'}
   ]}
 ];
 
+let lotsOfSections: any[] = [];
+for (let i = 0; i < 50; i++) {
+  let children = [];
+  for (let j = 0; j < 50; j++) {
+    children.push({name: `Section ${i}, Item ${j}`});
+  }
+  
+  lotsOfSections.push({name: 'Section ' + i, children});
+}
+
 storiesOf('ListBox', module)
+  .addDecorator(story => (
+    <Fragment>
+      <Label id="label">Choose an item</Label>
+      {story()}
+    </Fragment>
+  ))
   .add(
     'Default ListBox',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} items={flatOptions} itemKey="name">
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={flatOptions} itemKey="name">
           {item => <Item>{item.name}</Item>}
         </ListBox>
       </Popover>
@@ -95,11 +105,25 @@ storiesOf('ListBox', module)
   .add(
     'ListBox w/ sections',
     () => (
-      <Popover isOpen hideArrow>
-        <ListBox items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+      <Popover isOpen hideArrow style={{maxHeight: 300}}>
+        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
+            </Section>
+          )}
+        </ListBox>
+      </Popover>
+    )
+  )
+  .add(
+    'ListBox w/ many sections',
+    () => (
+      <Popover isOpen hideArrow style={{maxHeight: 300}}>
+        <ListBox aria-labelledby="label" items={lotsOfSections} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+          {item => (
+            <Section items={item.children} title={item.name}>
+              {(item: any) => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -110,7 +134,7 @@ storiesOf('ListBox', module)
     'Static',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
           <Item>One</Item>
           <Item>Two</Item>
           <Item>Three</Item>
@@ -122,7 +146,7 @@ storiesOf('ListBox', module)
     'Static with sections',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
           <Section title="Section 1">
             <Item>One</Item>
             <Item>Two</Item>
@@ -141,10 +165,10 @@ storiesOf('ListBox', module)
     'with default selected options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -155,7 +179,7 @@ storiesOf('ListBox', module)
     'static with default selected options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -189,10 +213,10 @@ storiesOf('ListBox', module)
     'with selected options (controlled)',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -203,7 +227,7 @@ storiesOf('ListBox', module)
     'static with selected options (controlled)',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -237,10 +261,10 @@ storiesOf('ListBox', module)
     'with disabled options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -251,7 +275,7 @@ storiesOf('ListBox', module)
     'static with disabled options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} disabledKeys={['3', '5']}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} disabledKeys={['3', '5']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -285,10 +309,10 @@ storiesOf('ListBox', module)
     'Multiple selection',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
+        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -299,7 +323,7 @@ storiesOf('ListBox', module)
     'Multiple selection, static',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['2', '5']} disabledKeys={['1', '3']}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['2', '5']} disabledKeys={['1', '3']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -330,10 +354,10 @@ storiesOf('ListBox', module)
     'No selection allowed',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="none">
+        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="none">
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -344,7 +368,7 @@ storiesOf('ListBox', module)
     'No selection allowed, static',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')} selectionMode="none">
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectionMode="none">
           <Section title="Section 1">
             <Item>One</Item>
             <Item>Two</Item>
@@ -363,10 +387,10 @@ storiesOf('ListBox', module)
     'ListBox with autoFocus=true',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus>
+        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -377,10 +401,10 @@ storiesOf('ListBox', module)
     'ListBox with autoFocus=true and focusStrategy="last"',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus focusStrategy="last">
+        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus focusStrategy="last">
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -391,10 +415,10 @@ storiesOf('ListBox', module)
     'ListBox with keyboard selection wrapping',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} wrapAround>
+        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} wrapAround>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </ListBox>
@@ -405,22 +429,19 @@ storiesOf('ListBox', module)
     'with semantic elements (static)',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox onSelectionChange={action('onSelectionChange')}>
+        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
           <Section title="Section 1">
             <Item>
               <Copy size="S" />
               <Text>Copy</Text>
-              <Keyboard>⌘C</Keyboard>
             </Item>
             <Item>
               <Cut size="S" />
               <Text>Cut</Text>
-              <Keyboard>⌘X</Keyboard>
             </Item>
             <Item>
               <Paste size="S" />
               <Text>Paste</Text>
-              <Keyboard>⌘V</Keyboard>
             </Item>
           </Section>
           <Section title="Section 2">
@@ -432,8 +453,6 @@ storiesOf('ListBox', module)
             <Item>
               <AlignCenter size="S" />
               <Text>Doggo with really really really long long long text</Text>
-              <Text slot="end">Value</Text>
-              <ChevronRightMedium slot="keyboard" />
             </Item>
             <Item>
               <AlignRight size="S" />
@@ -451,7 +470,7 @@ storiesOf('ListBox', module)
     'with semantic elements (generative)',
     () => (
       <Popover isOpen hideArrow> 
-        <ListBox items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
+        <ListBox aria-labelledby="label"items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
           {item => (
             <Section items={item.children} title={item.name}>
               {item => customOption(item)}
@@ -465,10 +484,9 @@ storiesOf('ListBox', module)
 let customOption = (item) => {
   let Icon = iconMap[item.icon];
   return (
-    <Item childItems={item.children}>
+    <Item>
       {item.icon && <Icon size="S" />}
       <Text>{item.name}</Text>
-      {item.shortcut && <Keyboard>{item.shortcut}</Keyboard>}
     </Item>
   );	
 };

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -111,8 +111,9 @@ describe('ListBox', function () {
     expect(item3).toBeTruthy();
   });
 
-  it('allows user to change menu item focus via up/down arrow keys', function () {
+  it('allows user to change menu item focus via up/down arrow keys', async function () {
     let tree = renderComponent({autoFocus: true});
+    await waitForDomChange();
     let listbox = tree.getByRole('listbox');
     let options = within(listbox).getAllByRole('option');
     let selectedItem = options[0];
@@ -124,8 +125,9 @@ describe('ListBox', function () {
     expect(document.activeElement).toBe(selectedItem);
   });
 
-  it('wraps focus from first to last/last to first item if up/down arrow is pressed if wrapAround is true', function () {
+  it('wraps focus from first to last/last to first item if up/down arrow is pressed if wrapAround is true', async function () {
     let tree = renderComponent({autoFocus: true, wrapAround: true});
+    await waitForDomChange();
     let listbox = tree.getByRole('listbox');
     let options = within(listbox).getAllByRole('option');
     let firstItem = options[0];
@@ -138,9 +140,10 @@ describe('ListBox', function () {
   });
   
   describe('supports single selection', function () {
-    it('supports defaultSelectedKeys (uncontrolled)', function () {
+    it('supports defaultSelectedKeys (uncontrolled)', async function () {
       // Check that correct menu item is selected by default
       let tree = renderComponent({onSelectionChange, defaultSelectedKeys: ['Blah'], autoFocus: true});
+      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
       let selectedItem = options[3];
@@ -169,9 +172,10 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bleh')).toBeTruthy();
     });
 
-    it('supports selectedKeys (controlled)', function () {
+    it('supports selectedKeys (controlled)', async function () {
       // Check that correct menu item is selected by default
       let tree = renderComponent({onSelectionChange, selectedKeys: ['Blah'], autoFocus: true});
+      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
       let selectedItem = options[3];
@@ -243,8 +247,9 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bleh')).toBeTruthy();
     });
     
-    it('supports disabled items', function () {
+    it('supports disabled items', async function () {
       let tree = renderComponent({onSelectionChange, disabledKeys: ['Baz'], autoFocus: true});
+      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
     

--- a/packages/@react-spectrum/sidenav/package.json
+++ b/packages/@react-spectrum/sidenav/package.json
@@ -27,6 +27,7 @@
     "@react-aria/collections": "^3.0.0-alpha.1",
     "@react-aria/focus": "^3.0.0-alpha.1",
     "@react-aria/interactions": "^3.0.0-alpha.1",
+    "@react-aria/listbox": "^3.0.0-alpha.1",
     "@react-aria/sidenav": "^3.0.0-alpha.1",
     "@react-aria/selection": "^3.0.0-alpha.1",
     "@react-aria/utils": "^3.0.0-alpha.1",

--- a/packages/@react-spectrum/sidenav/src/SideNav.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNav.tsx
@@ -12,106 +12,67 @@
 
 import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {CollectionBase, Expandable, SingleSelectionBase, StyleProps} from '@react-types/shared';
-import {CollectionView} from '@react-aria/collections';
-import {FocusRing} from '@react-aria/focus';
+import {CollectionItem, CollectionView} from '@react-aria/collections';
 import {ListLayout, Node} from '@react-stately/collections';
-import React, {AllHTMLAttributes, useMemo, useRef} from 'react';
+import React, {ReactElement, useMemo} from 'react';
+import {ReusableView} from '@react-stately/collections';
+import {SideNavItem} from './SideNavItem';
+import {SideNavSection} from './SideNavSection';
 import styles from '@adobe/spectrum-css-temp/components/sidenav/vars.css';
-import {TreeState, useTreeState} from '@react-stately/tree';
-import {useSideNav, useSideNavItem} from '@react-aria/sidenav';
+import {useSideNav} from '@react-aria/sidenav';
+import {useTreeState} from '@react-stately/tree';
 
 export interface SideNavProps<T> extends CollectionBase<T>, SingleSelectionBase, Expandable, StyleProps {}
 
 export function SideNav<T>(props: SideNavProps<T>) {
   let state = useTreeState({...props, selectionMode: 'single'});
-
   let layout = useMemo(() => new ListLayout({rowHeight: 40}), []);
-
   let {navProps, listProps} = useSideNav(props, state, layout);
-
   let {styleProps} = useStyleProps(props);
+
+  type View = ReusableView<Node<T>, unknown>;
+  let renderWrapper = (parent: View, reusableView: View, children: View[], renderChildren: (views: View[]) => ReactElement[]) => {
+    if (reusableView.viewType === 'section') {
+      return (
+        <SideNavSection
+          key={reusableView.key}
+          reusableView={reusableView}
+          header={children.find(c => c.viewType === 'header')}>
+          {renderChildren(children.filter(c => c.viewType === 'item'))}
+        </SideNavSection>
+      );
+    }
+
+    return (
+      <CollectionItem 
+        key={reusableView.key}
+        reusableView={reusableView}
+        parent={parent} />
+    );
+  };
 
   return (
     <nav
       {...filterDOMProps(props)}
       {...navProps}
-      {...styleProps} >
+      {...styleProps}>
       <CollectionView
         {...listProps}
         focusedKey={state.selectionManager.focusedKey}
         className={classNames(styles, 'spectrum-SideNav')}
         layout={layout}
-        collection={state.collection}>
+        collection={state.collection}
+        renderWrapper={renderWrapper}>
         {(type, item) => {
-          if (type === 'section') {
+          if (type === 'item') {
             return (
-              <SideNavHeading
+              <SideNavItem
+                state={state}
                 item={item} />
             );
           }
-
-          return (
-            <SideNavItem
-              state={state}
-              item={item} />
-          );
         }}
       </CollectionView>
     </nav>
-  );
-}
-
-interface SideNavItemProps<T> extends AllHTMLAttributes<HTMLElement>{
-  item: Node<T>,
-  state: TreeState<T>
-}
-
-function SideNavItem<T>(props: SideNavItemProps<T>) {
-  let ref = useRef<HTMLAnchorElement>();
-  let {
-    isSelected,
-    isDisabled,
-    rendered
-  } = props.item;
-
-  let className = classNames(
-    styles,
-    'spectrum-SideNav-item',
-    {
-      'is-selected': isSelected,
-      'is-disabled': isDisabled
-    }
-  );
-
-  let {listItemProps, listItemLinkProps} = useSideNavItem(props, props.state, ref);
-
-  return (
-    <div
-      {...listItemProps}
-      className={className} >
-      <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
-        <a
-          {...listItemLinkProps}
-          ref={ref}
-          className={classNames(styles, 'spectrum-SideNav-itemLink')} >
-          {rendered}
-        </a>
-      </FocusRing>
-    </div>
-  );
-}
-
-interface SideNavHeadingProps<T> extends AllHTMLAttributes<HTMLElement> {
-  item: Node<T>
-}
-
-function SideNavHeading<T>({item, ...otherProps}: SideNavHeadingProps<T>) {
-
-  return (
-    <h2
-      {...otherProps}
-      className={classNames(styles, 'spectrum-SideNav-heading')} >
-      {item.rendered}
-    </h2>
   );
 }

--- a/packages/@react-spectrum/sidenav/src/SideNav.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNav.tsx
@@ -30,6 +30,8 @@ export function SideNav<T>(props: SideNavProps<T>) {
   let {navProps, listProps} = useSideNav(props, state, layout);
   let {styleProps} = useStyleProps(props);
 
+  // This overrides collection view's renderWrapper to support heirarchy of items in sections.
+  // The header is extracted from the children so it can receive ARIA labeling properties.
   type View = ReusableView<Node<T>, unknown>;
   let renderWrapper = (parent: View, reusableView: View, children: View[], renderChildren: (views: View[]) => ReactElement[]) => {
     if (reusableView.viewType === 'section') {

--- a/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNavItem.tsx
@@ -1,0 +1,47 @@
+import {classNames} from '@react-spectrum/utils';
+import {FocusRing} from '@react-aria/focus';
+import {Node} from '@react-stately/collections';
+import React, {useRef} from 'react';
+import styles from '@adobe/spectrum-css-temp/components/sidenav/vars.css';
+import {TreeState} from '@react-stately/tree';
+import {useSideNavItem} from '@react-aria/sidenav';
+
+interface SideNavItemProps<T> {
+  item: Node<T>,
+  state: TreeState<T>
+}
+
+export function SideNavItem<T>(props: SideNavItemProps<T>) {
+  let ref = useRef<HTMLAnchorElement>();
+  let {
+    isSelected,
+    isDisabled,
+    rendered
+  } = props.item;
+
+  let className = classNames(
+    styles,
+    'spectrum-SideNav-item',
+    {
+      'is-selected': isSelected,
+      'is-disabled': isDisabled
+    }
+  );
+
+  let {listItemProps, listItemLinkProps} = useSideNavItem(props, props.state, ref);
+
+  return (
+    <div
+      {...listItemProps}
+      className={className} >
+      <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
+        <a
+          {...listItemLinkProps}
+          ref={ref}
+          className={classNames(styles, 'spectrum-SideNav-itemLink')} >
+          {rendered}
+        </a>
+      </FocusRing>
+    </div>
+  );
+}

--- a/packages/@react-spectrum/sidenav/src/SideNavSection.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNavSection.tsx
@@ -1,0 +1,49 @@
+import {classNames} from '@react-spectrum/utils';
+import {layoutInfoToStyle, useCollectionItem} from '@react-aria/collections';
+import {Node} from '@react-stately/collections';
+import React, {Fragment, ReactNode, useRef} from 'react';
+import {ReusableView} from '@react-stately/collections';
+import styles from '@adobe/spectrum-css-temp/components/sidenav/vars.css';
+import {useListBoxSection} from '@react-aria/listbox';
+
+interface SideNavSectionProps<T> {
+  reusableView: ReusableView<Node<T>, unknown>,
+  header: ReusableView<Node<T>, unknown>,
+  children?: ReactNode
+}
+
+export function SideNavSection<T>(props: SideNavSectionProps<T>) {
+  let {children, reusableView, header} = props;
+  let item = reusableView.content;
+  let {headingProps, groupProps} = useListBoxSection();
+
+  let headerRef = useRef();
+  useCollectionItem({
+    reusableView: header,
+    ref: headerRef
+  });
+
+  return (
+    <Fragment>
+      <div role="presentation" ref={headerRef} style={layoutInfoToStyle(header.layoutInfo)}>
+        {item.rendered &&
+          <div
+            {...headingProps}
+            className={
+              classNames(
+                styles,
+                'spectrum-SideNav-heading'
+              )
+            }>
+            {item.rendered}
+          </div>
+        }
+      </div>
+      <div
+        {...groupProps}
+        style={layoutInfoToStyle(reusableView.layoutInfo)}>
+        {children}
+      </div>
+    </Fragment>
+  );
+}

--- a/packages/@react-stately/collections/src/LayoutInfo.ts
+++ b/packages/@react-stately/collections/src/LayoutInfo.ts
@@ -32,6 +32,11 @@ export class LayoutInfo {
   key: Key;
 
   /**
+   * The key for a parent layout info, if any.
+   */
+  parentKey: Key | null;
+
+  /**
    * The rectangle describing the size and position of this view.
    */
   rect: Rect;
@@ -65,6 +70,7 @@ export class LayoutInfo {
   constructor(type: string, key: Key, rect: Rect) {
     this.type = type;
     this.key = key;
+    this.parentKey = null;
     this.rect = rect;
     this.estimatedSize = false;
     this.opacity = 1;

--- a/packages/@react-stately/collections/src/ListLayout.ts
+++ b/packages/@react-stately/collections/src/ListLayout.ts
@@ -106,6 +106,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     let previousLayoutInfos = this.layoutInfos;
     this.layoutInfos = {};
 
+    // Build the layout recursively.
     let build = (nodes: Iterable<Node<T>>, y = 0): [number, LayoutNode[]] => {
       let startY = y;
       let layoutNodes: LayoutNode[] = [];

--- a/packages/@react-stately/collections/src/TreeCollection.ts
+++ b/packages/@react-stately/collections/src/TreeCollection.ts
@@ -22,18 +22,19 @@ export class TreeCollection<T> implements Collection<Node<T>> {
   constructor(nodes: Iterable<Node<T>>) {
     this.iterable = nodes;
 
-    let visit = (node: Node<T>) => {
+    let visit = (node: Node<T>, parentKey: Key) => {
+      node.parentKey = parentKey;
       this.keyMap.set(node.key, node);
 
       if (node.childNodes && (node.type === 'section' || node.isExpanded)) {
         for (let child of node.childNodes) {
-          visit(child);
+          visit(child, node.key);
         }
       }
     };
 
     for (let node of nodes) {
-      visit(node);
+      visit(node, null);
     }
 
     let last: Node<T>;
@@ -49,7 +50,7 @@ export class TreeCollection<T> implements Collection<Node<T>> {
       if (node.type === 'item') {
         node.index = index++;
       }
-      
+
       last = node;
     }
 

--- a/packages/@react-stately/collections/src/index.ts
+++ b/packages/@react-stately/collections/src/index.ts
@@ -21,6 +21,7 @@ export * from './Point';
 export * from './Rect';
 export * from './Size';
 export * from './ListLayout';
+export * from './ReusableView';
 
 export * from './useCollectionState';
 export * from './useAsyncList';

--- a/packages/@react-stately/collections/src/types.ts
+++ b/packages/@react-stately/collections/src/types.ts
@@ -32,6 +32,7 @@ export interface Node<T> extends ItemStates {
   childNodes: Iterable<Node<T>>,
   rendered: ReactNode,
   index?: number,
+  parentKey?: Key,
   prevKey?: Key,
   nextKey?: Key
 }
@@ -58,12 +59,17 @@ export interface InvalidationContext<T extends object, V> {
 }
 
 export interface CollectionManagerDelegate<T extends object, V, W> {
-  setVisibleViews(views: Set<W>): void,
+  setVisibleViews(views: W[]): void,
   setContentSize(size: Size): void,
   setVisibleRect(rect: Rect): void,
   getType?(content: T): string,
   renderView(type: string, content: T): V,
-  renderWrapper(reusableView: ReusableView<T, V>): W,
+  renderWrapper(
+    parent: ReusableView<T, V> | null,
+    reusableView: ReusableView<T, V>,
+    children: ReusableView<T, V>[],
+    renderChildren: (views: ReusableView<T, V>[]) => W[]
+  ): W,
   beginAnimations(): void,
   endAnimations(): void,
   getScrollAnchor?(rect: Rect): Key

--- a/packages/@react-stately/collections/src/useCollectionState.ts
+++ b/packages/@react-stately/collections/src/useCollectionState.ts
@@ -20,14 +20,19 @@ import {Size} from './Size';
 
 interface CollectionProps<T extends object, V, W> {
   renderView(type: string, content: T): V,
-  renderWrapper(reusableView: ReusableView<T, V>): W,
+  renderWrapper(
+    parent: ReusableView<T, V> | null,
+    reusableView: ReusableView<T, V>,
+    children: ReusableView<T, V>[],
+    renderChildren: (views: ReusableView<T, V>[]) => W[]
+  ): W,
   layout: Layout<T>,
   collection: Collection<T>,
   getScrollAnchor?(rect: Rect): Key
 }
 
 interface CollectionState<T extends object, V, W> {
-  visibleViews: Set<W>,
+  visibleViews: W[],
   visibleRect: Rect,
   setVisibleRect: (rect: Rect) => void,
   contentSize: Size,
@@ -36,7 +41,7 @@ interface CollectionState<T extends object, V, W> {
 }
 
 export function useCollectionState<T extends object, V, W>(opts: CollectionProps<T, V, W>): CollectionState<T, V, W> {
-  let [visibleViews, setVisibleViews] = useState(new Set<W>());
+  let [visibleViews, setVisibleViews] = useState<W[]>([]);
   let [visibleRect, setVisibleRect] = useState(new Rect());
   let [contentSize, setContentSize] = useState(new Size());
   let [isAnimating, setAnimating] = useState(false);


### PR DESCRIPTION
This allows us to retain actual DOM heirarchy (good for a11y) while still use virtualized scrolling (good for performance).

In order to implement it, CollectionManager still operates on a flattened set of visible keys, but the heirarchy is reconstructed at the end. LayoutInfo objects have a `parentKey` property that's used to do this. LayoutInfos are still positioned absolutely relative to the entire collection, and during rendering their parent's position is subtracted so that this works with the DOM.

![image](https://user-images.githubusercontent.com/19409/76132665-f19e4200-5fc8-11ea-82f0-df03403816b4.png)
