### PR TITLE
Support type to select in ListBox, Menu, and SideNav

### DIFF
--- a/.storybook-v3/config.js
+++ b/.storybook-v3/config.js
@@ -16,7 +16,8 @@ configureActions({
 
 addParameters({
   options: {
-    storySort: (a, b) => a[1].kind.localeCompare(b[1].kind)
+    storySort: (a, b) => a[1].kind.localeCompare(b[1].kind),
+    enableShortcuts: false
   }
 });
 

--- a/packages/@react-aria/i18n/src/useCollator.ts
+++ b/packages/@react-aria/i18n/src/useCollator.ts
@@ -10,8 +10,18 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './context';
-export * from './useMessageFormatter';
-export * from './useDateFormatter';
-export * from './useNumberFormatter';
-export * from './useCollator';
+import {useLocale} from './context';
+
+let cache = new Map<string, Intl.Collator>();
+export function useCollator(options?: Intl.CollatorOptions) {
+  let {locale} = useLocale();
+
+  let cacheKey = locale + (options ? Object.entries(options).sort((a, b) => a[0] < b[0] ? -1 : 1).join() : '');
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey);
+  }
+
+  let formatter = new Intl.Collator(locale, options);
+  cache.set(cacheKey, formatter);
+  return formatter;
+}

--- a/packages/@react-aria/i18n/src/useNumberFormatter.ts
+++ b/packages/@react-aria/i18n/src/useNumberFormatter.ts
@@ -11,13 +11,16 @@
  */
 
 import {useLocale} from './context';
-import {useMemo} from 'react';
 
+let formatterCache = new Map<string, Intl.NumberFormat>();
 export function useNumberFormatter(options?: Intl.NumberFormatOptions) {
   let {locale} = useLocale();
-  let numberFormatter = useMemo(
-    () => new Intl.NumberFormat(locale, options),
-    [locale, options]
-  );
+  let cacheKey = locale + (options ? Object.entries(options).sort((a, b) => a[0] < b[0] ? -1 : 1).join() : '');
+  if (formatterCache.has(cacheKey)) {
+    return formatterCache.get(cacheKey);
+  }
+
+  let numberFormatter = new Intl.NumberFormat(locale, options);
+  formatterCache.set(cacheKey, numberFormatter);
   return numberFormatter;
 }

--- a/packages/@react-aria/selection/package.json
+++ b/packages/@react-aria/selection/package.json
@@ -18,7 +18,9 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@react-aria/i18n": "3.0.0-rc.1",
     "@react-aria/interactions": "^3.0.0-alpha.2",
+    "@react-aria/utils": "3.0.0-rc.1",
     "@react-stately/collections": "^3.0.0-alpha.2",
     "@react-stately/selection": "^3.0.0-alpha.2",
     "@react-types/shared": "^3.0.0-rc.1"

--- a/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
+++ b/packages/@react-aria/selection/src/ListKeyboardDelegate.ts
@@ -17,10 +17,12 @@ import {KeyboardDelegate} from '@react-types/shared';
 export class ListKeyboardDelegate<T> implements KeyboardDelegate {
   private collection: Collection<Node<T>>;
   private ref: RefObject<HTMLElement>;
+  private collator: Intl.Collator;
 
-  constructor(collection: Collection<Node<T>>, ref: RefObject<HTMLElement>) {
+  constructor(collection: Collection<Node<T>>, ref: RefObject<HTMLElement>, collator?: Intl.Collator) {
     this.collection = collection;
     this.ref = ref;
+    this.collator = collator;
   }
 
   getKeyBelow(key: Key) {
@@ -107,5 +109,25 @@ export class ListKeyboardDelegate<T> implements KeyboardDelegate {
     }
 
     return key;
+  }
+
+  getKeyForSearch(search: string, fromKey?: Key) {
+    if (!this.collator) {
+      return null;
+    }
+
+    let collection = this.collection;
+    let key = fromKey ? this.getKeyBelow(fromKey) : this.getFirstKey();
+    while (key) {
+      let item = collection.getItem(key);
+      let substring = item.textValue.slice(0, search.length);
+      if (item.textValue && this.collator.compare(substring, search) === 0) {
+        return key;
+      }
+
+      key = this.getKeyBelow(key);
+    }
+
+    return null;
   }
 }

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -12,7 +12,9 @@
 
 import {FocusEvent, HTMLAttributes, KeyboardEvent, useEffect} from 'react';
 import {KeyboardDelegate} from '@react-types/shared';
+import {mergeProps} from '@react-aria/utils';
 import {MultipleSelectionManager} from '@react-stately/selection';
+import {useTypeSelect} from './useTypeSelect';
 
 type FocusStrategy = 'first' | 'last';
 
@@ -208,11 +210,16 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  let {typeSelectProps} = useTypeSelect({
+    keyboardDelegate: delegate,
+    selectionManager: manager
+  });
+
   return {
-    collectionProps: {
+    collectionProps: mergeProps(typeSelectProps, {
       onKeyDown,
       onFocus,
       onBlur
-    }
+    })
   };
 }

--- a/packages/@react-aria/selection/src/useSelectableList.ts
+++ b/packages/@react-aria/selection/src/useSelectableList.ts
@@ -16,6 +16,7 @@ import {HTMLAttributes, RefObject, useEffect, useMemo} from 'react';
 import {KeyboardDelegate} from '@react-types/shared';
 import {ListKeyboardDelegate} from './ListKeyboardDelegate';
 import {MultipleSelectionManager} from '@react-stately/selection';
+import {useCollator} from '@react-aria/i18n';
 import {useSelectableCollection} from './useSelectableCollection';
 
 interface SelectableListOptions {
@@ -47,7 +48,8 @@ export function useSelectableList(props: SelectableListOptions): SelectableListA
 
   // By default, a KeyboardDelegate is provided which uses the DOM to query layout information (e.g. for page up/page down).
   // When virtualized, the layout object will be passed in as a prop and override this.
-  let delegate = useMemo(() => keyboardDelegate || new ListKeyboardDelegate(collection, ref), [keyboardDelegate, collection, ref]);
+  let collator = useCollator({usage: 'search', sensitivity: 'base'});
+  let delegate = useMemo(() => keyboardDelegate || new ListKeyboardDelegate(collection, ref, collator), [keyboardDelegate, collection, ref, collator]);
 
   // If not virtualized, scroll the focused element into view when the focusedKey changes.
   // When virtualized, CollectionView handles this internally.

--- a/packages/@react-aria/selection/src/useTypeSelect.ts
+++ b/packages/@react-aria/selection/src/useTypeSelect.ts
@@ -1,0 +1,47 @@
+import {HTMLAttributes, KeyboardEvent, useRef} from 'react';
+import {KeyboardDelegate} from '@react-types/shared';
+import {MultipleSelectionManager} from '@react-stately/selection';
+
+interface TypeSelectOptions {
+  keyboardDelegate: KeyboardDelegate,
+  selectionManager: MultipleSelectionManager
+}
+
+interface TypeSelectAria {
+  typeSelectProps: HTMLAttributes<HTMLElement>
+}
+
+export function useTypeSelect(options: TypeSelectOptions): TypeSelectAria {
+  let {keyboardDelegate, selectionManager} = options;
+  let state = useRef({
+    search: '',
+    timeout: null
+  }).current;
+
+  let onKeyPress = (e: KeyboardEvent) => {
+    let character = String.fromCharCode(e.charCode);
+    state.search += character;
+
+    // Use the delegate to find a key to focus.
+    // Prioritize items after the currently focused item, falling back to searching the whole list.
+    let key = keyboardDelegate.getKeyForSearch(state.search, selectionManager.focusedKey);
+    if (!key) {
+      key = keyboardDelegate.getKeyForSearch(state.search);
+    }
+
+    if (key) {
+      selectionManager.setFocusedKey(key);
+    }
+
+    clearTimeout(state.timeout);
+    state.timeout = setTimeout(() => {
+      state.search = '';
+    }, 500);
+  };
+
+  return {
+    typeSelectProps: {
+      onKeyPress: keyboardDelegate.getKeyForSearch ? onKeyPress : null
+    }
+  };
+}

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -26,6 +26,7 @@
     "@babel/runtime": "^7.6.2",
     "@react-aria/collections": "^3.0.0-alpha.1",
     "@react-aria/focus": "^3.0.0-rc.1",
+    "@react-aria/i18n": "3.0.0-rc.1",
     "@react-aria/listbox": "^3.0.0-alpha.1",
     "@react-aria/separator": "^3.0.0-rc.1",
     "@react-aria/utils": "^3.0.0-alpha.1",

--- a/packages/@react-spectrum/listbox/src/ListBox.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBox.tsx
@@ -19,18 +19,21 @@ import React, {ReactElement, useMemo} from 'react';
 import {ReusableView} from '@react-stately/collections';
 import {SpectrumMenuProps} from '@react-types/menu';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
+import {useCollator} from '@react-aria/i18n';
 import {useListBox} from '@react-aria/listbox';
 import {useListState} from '@react-stately/list';
 import {useProvider} from '@react-spectrum/provider';
 
 export function ListBox<T>(props: SpectrumMenuProps<T>) {
   let {scale} = useProvider();
+  let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let layout = useMemo(() => 
     new ListLayout({
       estimatedRowHeight: scale === 'large' ? 48 : 35,
-      estimatedHeadingHeight: scale === 'large' ? 37 : 30
+      estimatedHeadingHeight: scale === 'large' ? 37 : 30,
+      collator
     })
-  , [scale]);
+  , [collator, scale]);
 
   let completeProps = {
     ...props,

--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -431,30 +431,30 @@ storiesOf('ListBox', module)
       <Popover isOpen hideArrow>
         <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
           <Section title="Section 1">
-            <Item>
+            <Item textValue="Copy">
               <Copy size="S" />
               <Text>Copy</Text>
             </Item>
-            <Item>
+            <Item textValue="Cut">
               <Cut size="S" />
               <Text>Cut</Text>
             </Item>
-            <Item>
+            <Item textValue="Paste">
               <Paste size="S" />
               <Text>Paste</Text>
             </Item>
           </Section>
           <Section title="Section 2">
-            <Item>
+            <Item textValue="Puppy">
               <AlignLeft size="S" />
               <Text>Puppy</Text>
               <Text slot="description">Puppy description super long as well geez</Text>
             </Item>
-            <Item>
+            <Item textValue="Doggo with really really really long long long text">
               <AlignCenter size="S" />
               <Text>Doggo with really really really long long long text</Text>
             </Item>
-            <Item>
+            <Item textValue="Floof">
               <AlignRight size="S" />
               <Text>Floof</Text>
             </Item>
@@ -484,7 +484,7 @@ storiesOf('ListBox', module)
 let customOption = (item) => {
   let Icon = iconMap[item.icon];
   return (
-    <Item>
+    <Item textValue={item.name}>
       {item.icon && <Icon size="S" />}
       <Text>{item.name}</Text>
     </Item>

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {cleanup, fireEvent, render, waitForDomChange, within} from '@testing-library/react';
+import {cleanup, fireEvent, render, within} from '@testing-library/react';
 import {Item, ListBox, Section} from '../';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -56,6 +56,8 @@ describe('ListBox', function () {
   beforeAll(function () {
     offsetWidth = jest.spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => 1000);
     offsetHeight = jest.spyOn(window.HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(() => 1000);
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
@@ -68,9 +70,8 @@ describe('ListBox', function () {
     offsetHeight.mockReset();
   });
   
-  it('renders properly', async function () {
+  it('renders properly', function () {
     let tree = renderComponent();
-    await waitForDomChange();
     let listbox = tree.getByRole('listbox');
     expect(listbox).toBeTruthy();
     
@@ -111,9 +112,8 @@ describe('ListBox', function () {
     expect(item3).toBeTruthy();
   });
 
-  it('allows user to change menu item focus via up/down arrow keys', async function () {
+  it('allows user to change menu item focus via up/down arrow keys', function () {
     let tree = renderComponent({autoFocus: true});
-    await waitForDomChange();
     let listbox = tree.getByRole('listbox');
     let options = within(listbox).getAllByRole('option');
     let selectedItem = options[0];
@@ -125,9 +125,8 @@ describe('ListBox', function () {
     expect(document.activeElement).toBe(selectedItem);
   });
 
-  it('wraps focus from first to last/last to first item if up/down arrow is pressed if wrapAround is true', async function () {
+  it('wraps focus from first to last/last to first item if up/down arrow is pressed if wrapAround is true', function () {
     let tree = renderComponent({autoFocus: true, wrapAround: true});
-    await waitForDomChange();
     let listbox = tree.getByRole('listbox');
     let options = within(listbox).getAllByRole('option');
     let firstItem = options[0];
@@ -140,10 +139,9 @@ describe('ListBox', function () {
   });
   
   describe('supports single selection', function () {
-    it('supports defaultSelectedKeys (uncontrolled)', async function () {
+    it('supports defaultSelectedKeys (uncontrolled)', function () {
       // Check that correct menu item is selected by default
       let tree = renderComponent({onSelectionChange, defaultSelectedKeys: ['Blah'], autoFocus: true});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
       let selectedItem = options[3];
@@ -172,10 +170,9 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bleh')).toBeTruthy();
     });
 
-    it('supports selectedKeys (controlled)', async function () {
+    it('supports selectedKeys (controlled)', function () {
       // Check that correct menu item is selected by default
       let tree = renderComponent({onSelectionChange, selectedKeys: ['Blah'], autoFocus: true});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
       let selectedItem = options[3];
@@ -203,9 +200,8 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bleh')).toBeTruthy();
     });
 
-    it('supports using space key to change item selection', async function () {
+    it('supports using space key to change item selection', function () {
       let tree = renderComponent({onSelectionChange});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
     
@@ -225,9 +221,8 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bleh')).toBeTruthy();
     });
 
-    it('supports using click to change item selection', async function () {
+    it('supports using click to change item selection', function () {
       let tree = renderComponent({onSelectionChange});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
     
@@ -247,9 +242,8 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bleh')).toBeTruthy();
     });
     
-    it('supports disabled items', async function () {
+    it('supports disabled items', function () {
       let tree = renderComponent({onSelectionChange, disabledKeys: ['Baz'], autoFocus: true});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       let options = within(listbox).getAllByRole('option');
     
@@ -280,9 +274,8 @@ describe('ListBox', function () {
   });
 
   describe('supports multi selection', function () {
-    it('supports selecting multiple items', async function () {
+    it('supports selecting multiple items', function () {
       let tree = renderComponent({onSelectionChange, selectionMode: 'multiple'});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
       
@@ -313,9 +306,8 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[1][0].has('Bar')).toBeTruthy();
     });
 
-    it('supports multiple defaultSelectedKeys (uncontrolled)', async function () {
+    it('supports multiple defaultSelectedKeys (uncontrolled)', function () {
       let tree = renderComponent({onSelectionChange, selectionMode: 'multiple', defaultSelectedKeys: ['Foo', 'Bar']});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
       
@@ -355,9 +347,8 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bar')).toBeTruthy();
     });
 
-    it('supports multiple selectedKeys (controlled)', async function () {
+    it('supports multiple selectedKeys (controlled)', function () {
       let tree = renderComponent({onSelectionChange, selectionMode: 'multiple', selectedKeys: ['Foo', 'Bar']});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
       
@@ -395,9 +386,8 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bleh')).toBeTruthy();
     });
 
-    it('supports deselection', async function () {
+    it('supports deselection', function () {
       let tree = renderComponent({onSelectionChange, selectionMode: 'multiple', defaultSelectedKeys: ['Foo', 'Bar']});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
       
@@ -434,9 +424,8 @@ describe('ListBox', function () {
       expect(onSelectionChange.mock.calls[0][0].has('Bar')).toBeTruthy();
     });
 
-    it('supports disabledKeys', async function () {
+    it('supports disabledKeys', function () {
       let tree = renderComponent({onSelectionChange, selectionMode: 'multiple', defaultSelectedKeys: ['Foo', 'Bar'], disabledKeys: ['Baz']});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       expect(listbox).toHaveAttribute('aria-multiselectable', 'true');
 
@@ -457,9 +446,8 @@ describe('ListBox', function () {
   });
 
   describe('supports no selection', function () {
-    it('prevents selection of any items', async function () {
+    it('prevents selection of any items', function () {
       let tree = renderComponent({onSelectionChange, selectionMode: 'none'});
-      await waitForDomChange();
       let listbox = tree.getByRole('listbox');
       
       // Make sure nothing is checked by default
@@ -482,6 +470,56 @@ describe('ListBox', function () {
       checkmarks = tree.queryAllByRole('img');
       expect(checkmarks.length).toBe(0);
       expect(onSelectionChange).toBeCalledTimes(0);
+    });
+  });
+
+  describe('supports type to select', function () {
+    it('supports focusing items by typing letters in rapid succession', function () {
+      let tree = renderComponent({autoFocus: true});
+      let listbox = tree.getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(options[1]);
+
+      fireEvent.keyPress(listbox, {charCode: 'l'.charCodeAt(0)});
+      expect(document.activeElement).toBe(options[3]);
+
+      fireEvent.keyPress(listbox, {charCode: 'e'.charCodeAt(0)});
+      expect(document.activeElement).toBe(options[4]);
+    });
+
+    it('resets the search text after a timeout', function () {
+      let tree = renderComponent({autoFocus: true});
+      let listbox = tree.getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(options[1]);
+
+      jest.runAllTimers();
+
+      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(options[2]);
+    });
+
+    it('wraps around when no items past the current one match', function () {
+      let tree = renderComponent({autoFocus: true});
+      let listbox = tree.getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(document.activeElement).toBe(options[0]);
+
+      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyPress(listbox, {charCode: 'l'.charCodeAt(0)});
+      fireEvent.keyPress(listbox, {charCode: 'e'.charCodeAt(0)});
+      expect(document.activeElement).toBe(options[4]);
+
+      jest.runAllTimers();
+
+      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(options[1]);
     });
   });
 });

--- a/packages/@react-spectrum/menu/stories/Menu.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/Menu.stories.tsx
@@ -439,35 +439,35 @@ storiesOf('Menu', module)
       <Popover isOpen hideArrow>
         <Menu onSelectionChange={action('onSelectionChange')}>
           <Section title="Section 1">
-            <Item>
+            <Item textValue="Copy">
               <Copy size="S" />
               <Text>Copy</Text>
               <Keyboard>⌘C</Keyboard>
             </Item>
-            <Item>
+            <Item textValue="Cut">
               <Cut size="S" />
               <Text>Cut</Text>
               <Keyboard>⌘X</Keyboard>
             </Item>
-            <Item>
+            <Item textValue="Paste">
               <Paste size="S" />
               <Text>Paste</Text>
               <Keyboard>⌘V</Keyboard>
             </Item>
           </Section>
           <Section title="Section 2">
-            <Item>
+            <Item textValue="Puppy">
               <AlignLeft size="S" />
               <Text>Puppy</Text>
               <Text slot="description">Puppy description super long as well geez</Text>
             </Item>
-            <Item>
+            <Item textValue="Doggo with really really really long long long text">
               <AlignCenter size="S" />
               <Text>Doggo with really really really long long long text</Text>
               <Text slot="end">Value</Text>
               <ChevronRightMedium slot="keyboard" />
             </Item>
-            <Item>
+            <Item textValue="Floof">
               <AlignRight size="S" />
               <Text>Floof</Text>
             </Item>
@@ -497,7 +497,7 @@ storiesOf('Menu', module)
 let customMenuItem = (item) => {
   let Icon = iconMap[item.icon];
   return (
-    <Item childItems={item.children}>
+    <Item childItems={item.children} textValue={item.name}>
       {item.icon && <Icon size="S" />}
       <Text>{item.name}</Text>
       {item.shortcut && <Keyboard>{item.shortcut}</Keyboard>}

--- a/packages/@react-spectrum/menu/test/Menu.test.js
+++ b/packages/@react-spectrum/menu/test/Menu.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {cleanup, fireEvent, render, waitForDomChange, within} from '@testing-library/react';
+import {cleanup, fireEvent, render, within} from '@testing-library/react';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Item, Menu, Section} from '../';
 import {MenuContext} from '../src/context';
@@ -94,6 +94,8 @@ describe('Menu', function () {
     offsetWidth = jest.spyOn(window.HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(() => 1000);
     offsetHeight = jest.spyOn(window.HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(() => 1000);
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
@@ -156,11 +158,8 @@ describe('Menu', function () {
     Name        | Component | props
     ${'Menu'}   | ${Menu}   | ${{autoFocus: true}}
     ${'V2Menu'} | ${V2Menu} | ${{}}
-  `('$Name allows user to change menu item focus via up/down arrow keys', async function ({Component, props}) {
+  `('$Name allows user to change menu item focus via up/down arrow keys', function ({Component, props}) {
     let tree = renderComponent(Component, {}, props);
-    if (Component === V2Menu) {
-      await waitForDomChange();
-    }
     let menu = tree.getByRole('menu');
     let menuItems = within(menu).getAllByRole('menuitemradio');
     let selectedItem = menuItems[0];
@@ -559,6 +558,65 @@ describe('Menu', function () {
       checkmarks = tree.queryAllByRole('img');
       expect(checkmarks.length).toBe(0);
       expect(onSelectionChange).toBeCalledTimes(0);
+    });
+  });
+
+  describe('supports type to select', function () {
+    it.each`
+      Name        | Component | props
+      ${'Menu'}   | ${Menu}   | ${{autoFocus: true}}
+    `('$Name supports focusing items by typing letters in rapid succession', function ({Component, props}) {
+      let tree = renderComponent(Component, {}, props);
+      let menu = tree.getByRole('menu');
+      let menuItems = within(menu).getAllByRole('menuitemradio');
+      expect(document.activeElement).toBe(menuItems[0]);
+
+      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(menuItems[1]);
+
+      fireEvent.keyPress(menu, {charCode: 'l'.charCodeAt(0)});
+      expect(document.activeElement).toBe(menuItems[3]);
+
+      fireEvent.keyPress(menu, {charCode: 'e'.charCodeAt(0)});
+      expect(document.activeElement).toBe(menuItems[4]);
+    });
+
+    it.each`
+      Name        | Component | props
+      ${'Menu'}   | ${Menu}   | ${{autoFocus: true}}
+    `('$Name resets the search text after a timeout', function ({Component, props}) {
+      let tree = renderComponent(Component, {}, props);
+      let menu = tree.getByRole('menu');
+      let menuItems = within(menu).getAllByRole('menuitemradio');
+      expect(document.activeElement).toBe(menuItems[0]);
+
+      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(menuItems[1]);
+
+      jest.runAllTimers();
+
+      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(menuItems[2]);
+    });
+
+    it.each`
+      Name        | Component | props
+      ${'Menu'}   | ${Menu}   | ${{autoFocus: true}}
+    `('$Name wraps around when no items past the current one match', function ({Component, props}) {
+      let tree = renderComponent(Component, {}, props);
+      let menu = tree.getByRole('menu');
+      let menuItems = within(menu).getAllByRole('menuitemradio');
+      expect(document.activeElement).toBe(menuItems[0]);
+
+      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyPress(menu, {charCode: 'l'.charCodeAt(0)});
+      fireEvent.keyPress(menu, {charCode: 'e'.charCodeAt(0)});
+      expect(document.activeElement).toBe(menuItems[4]);
+
+      jest.runAllTimers();
+
+      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      expect(document.activeElement).toBe(menuItems[1]);
     });
   });
 

--- a/packages/@react-spectrum/sidenav/package.json
+++ b/packages/@react-spectrum/sidenav/package.json
@@ -26,6 +26,7 @@
     "@babel/runtime": "^7.6.2",
     "@react-aria/collections": "^3.0.0-alpha.1",
     "@react-aria/focus": "^3.0.0-alpha.1",
+    "@react-aria/i18n": "3.0.0-rc.1",
     "@react-aria/interactions": "^3.0.0-alpha.1",
     "@react-aria/listbox": "^3.0.0-alpha.1",
     "@react-aria/sidenav": "^3.0.0-alpha.1",

--- a/packages/@react-spectrum/sidenav/src/SideNav.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNav.tsx
@@ -19,6 +19,7 @@ import {ReusableView} from '@react-stately/collections';
 import {SideNavItem} from './SideNavItem';
 import {SideNavSection} from './SideNavSection';
 import styles from '@adobe/spectrum-css-temp/components/sidenav/vars.css';
+import {useCollator} from '@react-aria/i18n';
 import {useSideNav} from '@react-aria/sidenav';
 import {useTreeState} from '@react-stately/tree';
 
@@ -26,7 +27,8 @@ export interface SideNavProps<T> extends CollectionBase<T>, SingleSelectionBase,
 
 export function SideNav<T>(props: SideNavProps<T>) {
   let state = useTreeState({...props, selectionMode: 'single'});
-  let layout = useMemo(() => new ListLayout({rowHeight: 40}), []);
+  let collator = useCollator({usage: 'search', sensitivity: 'base'});
+  let layout = useMemo(() => new ListLayout({rowHeight: 40, collator}), [collator]);
   let {navProps, listProps} = useSideNav(props, state, layout);
   let {styleProps} = useStyleProps(props);
 

--- a/packages/@react-stately/collections/src/CollectionBuilder.ts
+++ b/packages/@react-stately/collections/src/CollectionBuilder.ts
@@ -141,6 +141,7 @@ export class CollectionBuilder<T> {
       value: partialNode.value,
       level: parentNode ? parentNode.level + 1 : 0,
       rendered: partialNode.rendered,
+      textValue: partialNode.textValue,
       wrapper: partialNode.wrapper,
       hasChildNodes: partialNode.hasChildNodes,
       childNodes: iterable(function *() {

--- a/packages/@react-stately/collections/src/Item.ts
+++ b/packages/@react-stately/collections/src/Item.ts
@@ -9,9 +9,16 @@ export function Item<T>(props: ItemProps<T>): ReactElement { // eslint-disable-l
 Item.getCollectionNode = function<T> (props: ItemProps<T>): PartialNode<T> {
   let {childItems, title, children} = props;
 
+  let rendered = props.title || props.children;
+  let textValue = props.textValue || (typeof rendered === 'string' ? rendered : '');
+  if (!textValue) {
+    console.warn('<Item> with non-plain text contents is unsupported by type to select for accessibility. Please add a `textValue` prop.');
+  }
+
   return {
     type: 'item',
-    rendered: props.title || props.children,
+    rendered,
+    textValue,
     hasChildNodes: hasChildItems(props),
     *childNodes() {
       if (childItems) {

--- a/packages/@react-stately/collections/src/types.ts
+++ b/packages/@react-stately/collections/src/types.ts
@@ -32,6 +32,7 @@ export interface Node<T> extends ItemStates {
   hasChildNodes: boolean,
   childNodes: Iterable<Node<T>>,
   rendered: ReactNode,
+  textValue: string,
   index?: number,
   wrapper?: ((element: ReactElement) => ReactElement) | void,
   parentKey?: Key,
@@ -46,6 +47,7 @@ export interface PartialNode<T> {
   element?: ReactElement,
   wrapper?: ((element: ReactElement) => ReactElement) | void,
   rendered?: ReactNode,
+  textValue?: string,
   renderer?: ItemRenderer<T>,
   hasChildNodes?: boolean,
   childNodes?: () => IterableIterator<PartialNode<T>>

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -17,6 +17,7 @@ export interface ItemProps<T> {
   childItems?: Iterable<T>,
   hasChildItems?: boolean,
   children: ReactNode, // CellRenderer??
+  textValue?: string,
   uniqueKey?: Key
 }
 
@@ -108,7 +109,10 @@ export interface KeyboardDelegate {
   getFirstKey?(): Key,
 
   /** Returns the last key, or `null` for none. */
-  getLastKey?(): Key
+  getLastKey?(): Key,
+
+  /** Returns the next key after `fromKey` that matches the given search string, or `null` for none. */
+  getKeyForSearch?(search: string, fromKey?: Key): Key
 }
 
 interface AsyncListOptions<T> {


### PR DESCRIPTION
This adds support for type to select to our collection components, which allows users to start typing the name of an option to jump to it. This is supported automatically for simple `<Item>` elements with only plain text inside. For complex children, a `textValue` prop is required on the `<Item>` to make it support type to select. There's a warning in case the user misses this.

For internationalization support, [Intl.Collator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Collator) is used to do the string comparisons. That handles case folding, ignoring of accents, etc. for us.