### PR TITLE
usePress fixes

### DIFF
--- a/packages/@react-aria/breadcrumbs/test/useBreadcrumbItem.test.js
+++ b/packages/@react-aria/breadcrumbs/test/useBreadcrumbItem.test.js
@@ -30,7 +30,6 @@ describe('useBreadcrumbItem', function () {
     expect(breadcrumbItemProps.role).toBe('link');
     expect(breadcrumbItemProps['aria-disabled']).toBeUndefined();
     expect(typeof breadcrumbItemProps.onKeyDown).toBe('function');
-    expect(typeof breadcrumbItemProps.onKeyUp).toBe('function');
   });
 
   it('handles isCurrent', function () {
@@ -64,6 +63,5 @@ describe('useBreadcrumbItem', function () {
     expect(breadcrumbItemProps.role).toBeUndefined();
     expect(breadcrumbItemProps['aria-disabled']).toBeUndefined();
     expect(typeof breadcrumbItemProps.onKeyDown).toBe('function');
-    expect(typeof breadcrumbItemProps.onKeyUp).toBe('function');
   });
 });

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -186,7 +186,7 @@ export function usePress(props: PressHookProps): PressResult {
         }
       },
       onClick(e) {
-        if (e) {
+        if (e && e.button === 0) {
           e.stopPropagation();
           if (isDisabled) {
             e.preventDefault();
@@ -207,6 +207,11 @@ export function usePress(props: PressHookProps): PressResult {
 
     if (typeof PointerEvent !== 'undefined') {
       pressProps.onPointerDown = (e) => {
+        // Only handle left clicks
+        if (e.button !== 0) {
+          return;
+        }
+
         e.stopPropagation();
         if (!state.isPressed) {
           state.isPressed = true;
@@ -248,7 +253,7 @@ export function usePress(props: PressHookProps): PressResult {
       };
 
       let onPointerUp = (e: PointerEvent) => {
-        if (e.pointerId === state.activePointerId && state.isPressed) {
+        if (e.pointerId === state.activePointerId && state.isPressed && e.button === 0) {
           let rect = state.target.getBoundingClientRect();
           if (e.clientX >= rect.left && e.clientX <= rect.right && e.clientY >= rect.top && e.clientY <= rect.bottom) {
             triggerPressEnd(createEvent(state.target, e), e.pointerType as PointerType);
@@ -276,6 +281,11 @@ export function usePress(props: PressHookProps): PressResult {
       };
     } else {
       pressProps.onMouseDown = (e) => {
+        // Only handle left clicks
+        if (e.button !== 0) {
+          return;
+        }
+
         e.stopPropagation();
         if (state.ignoreEmulatedMouseEvents) {
           e.nativeEvent.preventDefault();
@@ -304,6 +314,11 @@ export function usePress(props: PressHookProps): PressResult {
       };
 
       let onMouseUp = (e: MouseEvent) => {
+        // Only handle left clicks
+        if (e.button !== 0) {
+          return;
+        }
+        
         state.isPressed = false;
         document.removeEventListener('mouseup', onMouseUp, false);
 

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -992,9 +992,6 @@ describe('usePress', function () {
       // Enter key should trigger press events on element with role="link"
       expect(events).toEqual([
         {
-          type: 'click'
-        },
-        {
           type: 'pressstart',
           target: el,
           pointerType: 'keyboard',
@@ -1025,6 +1022,9 @@ describe('usePress', function () {
           ctrlKey: false,
           metaKey: false,
           shiftKey: false
+        },
+        {
+          type: 'click'
         }
       ]);
     });
@@ -1058,9 +1058,6 @@ describe('usePress', function () {
 
       expect(events).toEqual([
         {
-          type: 'click'
-        },
-        {
           type: 'pressstart',
           target: el,
           pointerType: 'keyboard',
@@ -1091,6 +1088,9 @@ describe('usePress', function () {
           ctrlKey: false,
           metaKey: false,
           shiftKey: false
+        },
+        {
+          type: 'click'
         }
       ]);
     });
@@ -1144,6 +1144,105 @@ describe('usePress', function () {
           shiftKey: false
         }
       ]);
+    });
+
+    it('should handle when focus moves between keydown and keyup', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let {getByText} = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPressChange={pressed => addEvent({type: 'presschange', pressed})}
+          onPress={addEvent} />
+      );
+
+      let el = getByText('test');
+      fireEvent.keyDown(el, {key: ' '});
+      fireEvent.keyUp(document.body, {key: ' '});
+
+      fireEvent.keyDown(el, {key: ' '});
+      fireEvent.keyUp(el, {key: ' '});
+
+      expect(events).toEqual([
+        // First sequence. Ensure the key up on the body causes a press end.
+        {
+          type: 'pressstart',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
+          type: 'presschange',
+          pressed: true
+        },
+        {
+          type: 'pressend',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
+          type: 'presschange',
+          pressed: false
+        },
+
+        // Second sequence. Ensure `isPressed` is reset to false on key up.
+        {
+          type: 'pressstart',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
+          type: 'presschange',
+          pressed: true
+        },
+        {
+          type: 'pressend',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
+          type: 'presschange',
+          pressed: false
+        },
+        {
+          type: 'press',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        }
+      ]);
+    });
+
+    it('should ignore repeating keyboard events', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let {getByText} = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPressChange={pressed => addEvent({type: 'presschange', pressed})}
+          onPress={addEvent} />
+      );
+
+      let el = getByText('test');
+      fireEvent.keyDown(el, {key: ' ', repeat: true});
+      fireEvent.keyUp(document.body, {key: ' '});
+
+      expect(events).toEqual([]);
     });
   });
 });

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -25,7 +25,8 @@ function pointerEvent(type, opts) {
   Object.assign(evt, {
     ctrlKey: false,
     metaKey: false,
-    shiftKey: false
+    shiftKey: false,
+    button: opts.button || 0
   }, opts);
   return evt;
 }
@@ -302,6 +303,23 @@ describe('usePress', function () {
         }
       ]);
     });
+
+    it('should only handle left clicks', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let res = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPressChange={pressed => addEvent({type: 'presschange', pressed})}
+          onPress={addEvent} />
+      );
+
+      let el = res.getByText('test');
+      fireEvent(el, pointerEvent('pointerdown', {pointerId: 1, pointerType: 'mouse', button: 1}));
+      fireEvent(el, pointerEvent('pointerup', {pointerId: 1, pointerType: 'mouse', button: 1, clientX: 0, clientY: 0}));
+      expect(events).toEqual([]);
+    });
   });
 
   describe('mouse events', function () {
@@ -518,6 +536,25 @@ describe('usePress', function () {
           shiftKey: true
         }
       ]);
+    });
+
+    it('should only handle left clicks', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let res = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPressChange={pressed => addEvent({type: 'presschange', pressed})}
+          onPress={addEvent} />
+      );
+
+      let el = res.getByText('test');
+      fireEvent.mouseDown(el, {button: 1});
+      fireEvent.mouseUp(el, {button: 1});
+      fireEvent.click(el, {button: 1});
+
+      expect(events).toEqual([]);
     });
   });
 

--- a/packages/@react-aria/link/test/useLink.test.js
+++ b/packages/@react-aria/link/test/useLink.test.js
@@ -29,7 +29,6 @@ describe('useLink', function () {
     expect(linkProps.tabIndex).toBe(0);
     expect(linkProps.id).toBeDefined();
     expect(typeof linkProps.onKeyDown).toBe('function');
-    expect(typeof linkProps.onKeyUp).toBe('function');
   });
 
   it('handles custom children', function () {
@@ -46,7 +45,6 @@ describe('useLink', function () {
     expect(linkProps.tabIndex).toBeUndefined();
     expect(linkProps.id).toBeDefined();
     expect(typeof linkProps.onKeyDown).toBe('function');
-    expect(typeof linkProps.onKeyUp).toBe('function');
   });
 
   it('handles href warning', function () {


### PR DESCRIPTION
* Only handle left clicks. Right clicking or other mouse buttons should be ignored. The browser will likely show a context menu.
* Reset state on key up even if focus moves between key down and key up. This is done by adding the key up handler to the document instead of the element we're listing for press events on.
* Ignore repeating keyboard events (e.g. if you hold down a key). If focus moves while a keyboard event is repeating, the target changes to the newly focused element. We only want to trigger a press event on the first target in a key repeat sequence.
* Adjust keyboard handling for links so that onPressStart and onPressEnd are called at the right time rather than waiting until the click event at the end. This fixes the active state styling of buttons with role=link.