### PR TITLE
(RSP-1593) Manually focusing checkboxes/radios/switches on mouse events for safari

### DIFF
--- a/packages/@react-aria/radio/package.json
+++ b/packages/@react-aria/radio/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-aria/focus": "^3.0.0-rc.1",
+    "@react-aria/interactions": "^3.0.0-rc.1",
     "@react-aria/label": "^3.0.0-rc.1",
     "@react-aria/utils": "^3.0.0-rc.1",
     "@react-stately/radio": "^3.0.0-rc.1",

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -11,9 +11,11 @@
  */
 
 import {AllHTMLAttributes} from 'react';
+import {mergeProps} from '@react-aria/utils';
 import {RadioGroupState} from '@react-stately/radio';
 import {RadioProps} from '@react-types/radio';
 import {useFocusable} from '@react-aria/focus';
+import {usePress} from '@react-aria/interactions';
 
 interface RadioAriaProps extends RadioProps {
   isRequired?: boolean,
@@ -47,7 +49,15 @@ export function useRadio(props: RadioAriaProps, state: RadioGroupState): RadioAr
     setSelectedRadio(value);
   };
 
+  let {pressProps} = usePress({
+    // Safari does not focus buttons automatically when interacting with them, so do it manually
+    onPressStart: (e) => e.target.focus(),
+    onPressEnd: (e) => e.target.focus(),
+    isDisabled
+  });
+
   let {focusableProps} = useFocusable(props);
+  let interactions = mergeProps(pressProps, focusableProps);
 
   return {
     inputProps: {
@@ -60,7 +70,7 @@ export function useRadio(props: RadioAriaProps, state: RadioGroupState): RadioAr
       'aria-checked': checked,
       onChange,
       autoFocus,
-      ...focusableProps
+      ...interactions
     }
   };
 }

--- a/packages/@react-aria/toggle/package.json
+++ b/packages/@react-aria/toggle/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-aria/focus": "^3.0.0-rc.1",
+    "@react-aria/interactions": "^3.0.0-rc.1",
+    "@react-aria/utils": "^3.0.0-rc.1",
     "@react-stately/toggle": "^3.0.0-rc.1",
     "@react-types/switch": "^3.0.0-rc.1",
     "@react-types/shared": "^3.0.0-rc.1"

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -12,9 +12,11 @@
 
 import {DOMProps} from '@react-types/shared';
 import {InputHTMLAttributes} from 'react';
+import {mergeProps} from '@react-aria/utils';
 import {SwitchProps} from '@react-types/switch';
 import {ToggleState} from '@react-stately/toggle';
 import {useFocusable} from '@react-aria/focus';
+import {usePress} from '@react-aria/interactions';
 
 export interface ToggleAria {
   inputProps: InputHTMLAttributes<HTMLInputElement>
@@ -47,7 +49,15 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState): To
   }
   let isInvalid = validationState === 'invalid';
 
+  let {pressProps} = usePress({
+    // Safari does not focus buttons automatically when interacting with them, so do it manually
+    onPressStart: (e) => e.target.focus(),
+    onPressEnd: (e) => e.target.focus(),
+    isDisabled
+  });
+
   let {focusableProps} = useFocusable(props);
+  let interactions = mergeProps(pressProps, focusableProps);
 
   return {
     inputProps: {
@@ -61,7 +71,7 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState): To
       name,
       type: 'checkbox',
       autoFocus,
-      ...focusableProps
+      ...interactions
     }
   };
 }


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1593

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to Switch and Checkbox stories in Safari. Click on the Switch or Checkbox, then press space to toggle selection/active state. Note that it actually works and that the screen doesn't scroll down

Go to RadioGroup stories in Safari. Click on a Radio, then press down/up arrow to change radio selection. Note that it works
