### PR TITLE
Only focus buttons, radios, and checkboxes on press end if focus is on the body

### DIFF
--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -13,7 +13,7 @@
 import {ButtonProps} from '@react-types/button';
 import {chain, mergeProps} from '@react-aria/utils';
 import {RefObject} from 'react';
-import {useDOMPropsResponder, usePress} from '@react-aria/interactions';
+import {useDOMPropsResponder, usePressableInput} from '@react-aria/interactions';
 import {useFocusable} from '@react-aria/focus';
 
 interface AriaButtonProps extends ButtonProps {
@@ -61,10 +61,9 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
     };
   }
 
-  let {pressProps, isPressed} = usePress({
-    // Safari does not focus buttons automatically when interacting with them, so do it manually
-    onPressStart: chain(onPressStart, (e) => e.target.focus()),
-    onPressEnd: chain(onPressEnd, (e) => e.target.focus()),
+  let {pressProps, isPressed} = usePressableInput({
+    onPressStart,
+    onPressEnd,
     onPressChange,
     onPress,
     isDisabled,

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -11,7 +11,7 @@
  */
 
 import {ButtonProps} from '@react-types/button';
-import {chain, mergeProps} from '@react-aria/utils';
+import {mergeProps} from '@react-aria/utils';
 import {RefObject} from 'react';
 import {useDOMPropsResponder, usePressableInput} from '@react-aria/interactions';
 import {useFocusable} from '@react-aria/focus';

--- a/packages/@react-aria/interactions/src/index.ts
+++ b/packages/@react-aria/interactions/src/index.ts
@@ -22,3 +22,4 @@ export * from './useHover';
 export * from './DOMPropsResponder';
 export * from './DOMPropsContext';
 export * from './useDOMPropsResponder';
+export * from './usePressableInput';

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -40,7 +40,7 @@ interface EventBase {
   metaKey: boolean
 }
 
-interface PressResult {
+export interface PressResult {
   isPressed: boolean,
   pressProps: HTMLAttributes<HTMLElement>
 }

--- a/packages/@react-aria/interactions/src/usePressableInput.ts
+++ b/packages/@react-aria/interactions/src/usePressableInput.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {chain} from '@react-aria/utils';
+import {PressEvent} from '@react-types/shared';
+import {PressHookProps, PressResult, usePress} from './usePress';
+
+// Safari does not focus buttons automatically when interacting with them, so we do it manually.
+// See https://bugs.webkit.org/show_bug.cgi?id=22261
+export function usePressableInput(props: PressHookProps): PressResult {
+  let {onPressStart, onPressEnd, ...otherProps} = props;
+  
+  let focusOnPressStart = (e: PressEvent) => {
+    e.target.focus();
+  };
+
+  let focusOnPressEnd = (e: PressEvent) => {
+    // Ensure that focus did not move between press start and press end
+    if (document.activeElement === document.body) {
+      e.target.focus();
+    }
+  };
+
+  return usePress({
+    onPressStart: chain(onPressStart, focusOnPressStart),
+    onPressEnd: chain(onPressEnd, focusOnPressEnd),
+    ...otherProps
+  });
+}

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -15,7 +15,7 @@ import {mergeProps} from '@react-aria/utils';
 import {RadioGroupState} from '@react-stately/radio';
 import {RadioProps} from '@react-types/radio';
 import {useFocusable} from '@react-aria/focus';
-import {usePress, usePressableInput} from '@react-aria/interactions';
+import {usePressableInput} from '@react-aria/interactions';
 
 interface RadioAriaProps extends RadioProps {
   isRequired?: boolean,

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -15,7 +15,7 @@ import {mergeProps} from '@react-aria/utils';
 import {RadioGroupState} from '@react-stately/radio';
 import {RadioProps} from '@react-types/radio';
 import {useFocusable} from '@react-aria/focus';
-import {usePress} from '@react-aria/interactions';
+import {usePress, usePressableInput} from '@react-aria/interactions';
 
 interface RadioAriaProps extends RadioProps {
   isRequired?: boolean,
@@ -49,10 +49,7 @@ export function useRadio(props: RadioAriaProps, state: RadioGroupState): RadioAr
     setSelectedRadio(value);
   };
 
-  let {pressProps} = usePress({
-    // Safari does not focus buttons automatically when interacting with them, so do it manually
-    onPressStart: (e) => e.target.focus(),
-    onPressEnd: (e) => e.target.focus(),
+  let {pressProps} = usePressableInput({
     isDisabled
   });
 

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -16,7 +16,7 @@ import {mergeProps} from '@react-aria/utils';
 import {SwitchProps} from '@react-types/switch';
 import {ToggleState} from '@react-stately/toggle';
 import {useFocusable} from '@react-aria/focus';
-import {usePress} from '@react-aria/interactions';
+import {usePressableInput} from '@react-aria/interactions';
 
 export interface ToggleAria {
   inputProps: InputHTMLAttributes<HTMLInputElement>
@@ -49,10 +49,7 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState): To
   }
   let isInvalid = validationState === 'invalid';
 
-  let {pressProps} = usePress({
-    // Safari does not focus buttons automatically when interacting with them, so do it manually
-    onPressStart: (e) => e.target.focus(),
-    onPressEnd: (e) => e.target.focus(),
+  let {pressProps} = usePressableInput({
     isDisabled
   });
 


### PR DESCRIPTION
Safari moves focus to the body between mouse down and mouse up. If focus was manually moved on mouse down (e.g. opening a menu), then we don't want the button to steal focus back on mouse up.