### PR TITLE
Dialogs aria-labelledby

### DIFF
--- a/packages/@react-aria/dialog/package.json
+++ b/packages/@react-aria/dialog/package.json
@@ -19,7 +19,8 @@
     "react": "^16.8.0"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.2"
+    "@babel/runtime": "^7.6.2",
+    "@react-aria/utils": "^3.0.0-rc.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-aria/dialog/src/useDialog.ts
+++ b/packages/@react-aria/dialog/src/useDialog.ts
@@ -11,6 +11,7 @@
  */
 
 import {AllHTMLAttributes, RefObject, useEffect} from 'react';
+import {useSlotId} from '@react-aria/utils';
 
 export interface DialogProps {
   ref: RefObject<HTMLElement | null>,
@@ -19,10 +20,13 @@ export interface DialogProps {
 
 interface DialogAria {
   dialogProps: AllHTMLAttributes<HTMLElement>
+  titleProps: AllHTMLAttributes<HTMLElement>
 }
 
 export function useDialog(props: DialogProps): DialogAria {
   let {ref, role = 'dialog'} = props;
+  let titleId = useSlotId();
+  titleId = props['aria-label'] ? undefined : titleId;
 
   // Focus the dialog itself on mount, unless a child element is already focused.
   useEffect(() => {
@@ -34,7 +38,11 @@ export function useDialog(props: DialogProps): DialogAria {
   return {
     dialogProps: {
       role,
-      tabIndex: -1
+      tabIndex: -1,
+      'aria-labelledby': props['aria-labelledby'] || titleId
+    },
+    titleProps: {
+      id: titleId
     }
   };
 }

--- a/packages/@react-aria/utils/src/useId.ts
+++ b/packages/@react-aria/utils/src/useId.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {useMemo, useState} from 'react';
+import {useLayoutEffect, useMemo, useState} from 'react';
 
 let map: Map<string, (v: string) => void> = new Map();
 
@@ -43,4 +43,16 @@ export function mergeIds(a: string, b: string): string {
   }
 
   return b;
+}
+
+export function useSlotId(): string {
+  let [id, setId] = useState(useId());
+  useLayoutEffect(() => {
+    let setCurr = map.get(id);
+    if (setCurr && !document.getElementById(id)) {
+      setId(null);
+    }
+  }, [id]);
+
+  return id;
 }

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -78,16 +78,14 @@ let sizeMap = {
 
 function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDialogProps) {
   let ref = useRef();
-  let titleId = useSlotId();
-  titleId = otherProps['aria-label'] ? undefined : titleId;
   let sizeVariant = sizeMap[size];
-  let {dialogProps} = useDialog({ref, role});
+  let {dialogProps, titleProps} = useDialog({ref, role});
   if (!slots) {
     slots = {
       container: {UNSAFE_className: styles['spectrum-Dialog-grid']},
       hero: {UNSAFE_className: styles['spectrum-Dialog-hero']},
       header: {UNSAFE_className: styles['spectrum-Dialog-header']},
-      heading: {UNSAFE_className: styles['spectrum-Dialog-heading'], id: titleId},
+      heading: {UNSAFE_className: styles['spectrum-Dialog-heading'], ...titleProps},
       typeIcon: {UNSAFE_className: styles['spectrum-Dialog-typeIcon']},
       divider: {UNSAFE_className: styles['spectrum-Dialog-divider'], size: 'M'},
       content: {UNSAFE_className: styles['spectrum-Dialog-content']},
@@ -106,7 +104,6 @@ function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDi
           {[`spectrum-Dialog--${sizeVariant}`]: sizeVariant},
           otherProps.className
         )}
-        aria-labelledby={otherProps['aria-labelledby'] || titleId}
         ref={ref}>
         <Grid slots={slots}>
           {children}

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -79,6 +79,7 @@ let sizeMap = {
 function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDialogProps) {
   let ref = useRef();
   let titleId = useSlotId();
+  titleId = otherProps['aria-label'] ? undefined : titleId;
   let sizeVariant = sizeMap[size];
   let {dialogProps} = useDialog({ref, role});
   if (!slots) {

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -105,7 +105,7 @@ function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDi
           {[`spectrum-Dialog--${sizeVariant}`]: sizeVariant},
           otherProps.className
         )}
-        aria-labelledby={titleId}
+        aria-labelledby={otherProps['aria-labelledby'] || titleId}
         ref={ref}>
         <Grid slots={slots}>
           {children}

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -16,7 +16,7 @@ import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DialogContext, DialogContextValue} from './context';
 import {FocusScope} from '@react-aria/focus';
 import {Grid} from '@react-spectrum/layout';
-import {mergeProps, useSlotId} from '@react-aria/utils';
+import {mergeProps} from '@react-aria/utils';
 import React, {useContext, useRef} from 'react';
 import {SpectrumBaseDialogProps, SpectrumDialogProps} from '@react-types/dialog';
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';
@@ -79,7 +79,7 @@ let sizeMap = {
 function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDialogProps) {
   let ref = useRef();
   let sizeVariant = sizeMap[size];
-  let {dialogProps, titleProps} = useDialog({ref, role});
+  let {dialogProps, titleProps} = useDialog({ref, role, ...otherProps});
   if (!slots) {
     slots = {
       container: {UNSAFE_className: styles['spectrum-Dialog-grid']},

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -16,7 +16,7 @@ import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DialogContext, DialogContextValue} from './context';
 import {FocusScope} from '@react-aria/focus';
 import {Grid} from '@react-spectrum/layout';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, useSlotId} from '@react-aria/utils';
 import React, {useContext, useRef} from 'react';
 import {SpectrumBaseDialogProps, SpectrumDialogProps} from '@react-types/dialog';
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';
@@ -78,6 +78,7 @@ let sizeMap = {
 
 function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDialogProps) {
   let ref = useRef();
+  let titleId = useSlotId();
   let sizeVariant = sizeMap[size];
   let {dialogProps} = useDialog({ref, role});
   if (!slots) {
@@ -85,7 +86,7 @@ function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDi
       container: {UNSAFE_className: styles['spectrum-Dialog-grid']},
       hero: {UNSAFE_className: styles['spectrum-Dialog-hero']},
       header: {UNSAFE_className: styles['spectrum-Dialog-header']},
-      heading: {UNSAFE_className: styles['spectrum-Dialog-heading']},
+      heading: {UNSAFE_className: styles['spectrum-Dialog-heading'], id: titleId},
       typeIcon: {UNSAFE_className: styles['spectrum-Dialog-typeIcon']},
       divider: {UNSAFE_className: styles['spectrum-Dialog-divider'], size: 'M'},
       content: {UNSAFE_className: styles['spectrum-Dialog-content']},
@@ -104,6 +105,7 @@ function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDi
           {[`spectrum-Dialog--${sizeVariant}`]: sizeVariant},
           otherProps.className
         )}
+        aria-labelledby={titleId}
         ref={ref}>
         <Grid slots={slots}>
           {children}

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -220,7 +220,6 @@ function render({width = 'auto', isDismissable = undefined, ...props}) {
   );
 }
 
-
 function renderHero({width = 'auto', isDismissable = undefined, ...props}) {
   return (
     <div style={{display: 'flex', width, margin: '100px 0'}}>

--- a/packages/@react-spectrum/dialog/test/Dialog.test.js
+++ b/packages/@react-spectrum/dialog/test/Dialog.test.js
@@ -15,6 +15,8 @@ import {Dialog} from '../';
 import {DialogContext} from '../src/context';
 import {ModalProvider} from '@react-aria/dialog';
 import React from 'react';
+import {Heading} from '@react-spectrum/typography';
+import {Header} from '@react-spectrum/view';
 
 describe('Dialog', function () {
   afterEach(cleanup);
@@ -29,6 +31,8 @@ describe('Dialog', function () {
 
     let dialog = getByRole('dialog');
     expect(document.activeElement).toBe(dialog);
+    // if there is no heading, then we shouldn't auto label
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
   });
 
   it('auto focuses the dialog itself if there is no focusable child', function () {
@@ -91,5 +95,23 @@ describe('Dialog', function () {
 
     let dialog = getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('should be labelled by its header', function () {
+    let {getByRole} = render(
+      <ModalProvider>
+        <DialogContext.Provider value={{type: 'modal'}}>
+          <Dialog>
+            <Heading><Header>The Title</Header></Heading>
+          </Dialog>
+        </DialogContext.Provider>
+      </ModalProvider>
+    );
+
+    let dialog = getByRole('dialog');
+    let heading = getByRole('heading');
+
+    let id = heading.id;
+    expect(dialog).toHaveAttribute('aria-labelledby', id);
   });
 });

--- a/packages/@react-spectrum/dialog/test/Dialog.test.js
+++ b/packages/@react-spectrum/dialog/test/Dialog.test.js
@@ -114,4 +114,26 @@ describe('Dialog', function () {
     let id = heading.id;
     expect(dialog).toHaveAttribute('aria-labelledby', id);
   });
+
+  it('if aria-labelledby is specified, then that takes precedence over the title', function () {
+    let {getByRole} = render(
+      <div>
+        <ModalProvider>
+          <DialogContext.Provider value={{type: 'modal'}}>
+            <Dialog aria-labelledby="batman">
+              <Heading><Header>The Title</Header></Heading>
+            </Dialog>
+          </DialogContext.Provider>
+        </ModalProvider>
+        <span id="batman">Good grammar is essential, Robin.</span>
+      </div>
+    );
+
+    let dialog = getByRole('dialog');
+    let heading = getByRole('heading');
+
+    let id = heading.id;
+    expect(dialog).not.toHaveAttribute('aria-labelledby', id);
+    expect(dialog).toHaveAttribute('aria-labelledby', 'batman');
+  });
 });

--- a/packages/@react-spectrum/dialog/test/Dialog.test.js
+++ b/packages/@react-spectrum/dialog/test/Dialog.test.js
@@ -136,4 +136,21 @@ describe('Dialog', function () {
     expect(dialog).not.toHaveAttribute('aria-labelledby', id);
     expect(dialog).toHaveAttribute('aria-labelledby', 'batman');
   });
+
+  it('if aria-label is specified, then that takes precedence over the title', function () {
+    let {getByRole} = render(
+      <ModalProvider>
+        <DialogContext.Provider value={{type: 'modal'}}>
+          <Dialog aria-label="robin">
+            <Heading><Header>The Title</Header></Heading>
+          </Dialog>
+        </DialogContext.Provider>
+      </ModalProvider>
+    );
+
+    let dialog = getByRole('dialog');
+
+    expect(dialog).not.toHaveAttribute('aria-labelledby');
+    expect(dialog).toHaveAttribute('aria-label', 'robin');
+  });
 });

--- a/packages/@react-spectrum/dialog/test/Dialog.test.js
+++ b/packages/@react-spectrum/dialog/test/Dialog.test.js
@@ -13,10 +13,10 @@
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import {Dialog} from '../';
 import {DialogContext} from '../src/context';
+import {Header} from '@react-spectrum/view';
+import {Heading} from '@react-spectrum/typography';
 import {ModalProvider} from '@react-aria/dialog';
 import React from 'react';
-import {Heading} from '@react-spectrum/typography';
-import {Header} from '@react-spectrum/view';
 
 describe('Dialog', function () {
   afterEach(cleanup);


### PR DESCRIPTION
pass an id through slots to the header, if it successfully renders into the dom, label the dialog with that same id


Closes https://jira.corp.adobe.com/browse/RSP-1583

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->
Run storybook, go to dialog stories
Inspect the title of the dialog and verify that it's id is the same as the role=dialog aria-labelledby

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
