### PR TITLE
Temp no scope hoist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ publish: build
 	lerna publish from-package --yes
 
 build:
-	parcel build packages/@react-{spectrum,aria,stately}/*/ --no-minify --no-scope-hoist
+	parcel build packages/@react-{spectrum,aria,stately}/*/ --no-minify
 
 website:
 	yarn build:docs --public-url /reactspectrum/$$(git rev-parse HEAD)/docs --dist-dir dist/$$(git rev-parse HEAD)/docs

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ publish: build
 	lerna publish from-package --yes
 
 build:
-	parcel build packages/@react-{spectrum,aria,stately}/*/ --no-minify
+	parcel build packages/@react-{spectrum,aria,stately}/*/ --no-minify --no-scope-hoist
 
 website:
 	yarn build:docs --public-url /reactspectrum/$$(git rev-parse HEAD)/docs --dist-dir dist/$$(git rev-parse HEAD)/docs

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chromatic": "CHROMATIC_APP_CODE=x8ktlved8wd chromatic test --build-script-name build-storybook",
     "merge:css": "babel-node --presets @babel/env ./scripts/merge-spectrum-css.js",
     "start:docs": "PARCEL_WORKER_BACKEND=process parcel 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'",
-    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'"
+    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx' --no-scope-hoist"
   },
   "workspaces": [
     "packages/*/*"


### PR DESCRIPTION
Temporary workaround for docs build issue
Closes https://jira.corp.adobe.com/browse/RSP-1613

Verification done in Progress Circle PR
here's the build btw with the no scope hoisting, things aren't perfect (sidenav is out of order) but the individual pages appear to display correctly https://reactspectrum.blob.core.windows.net/reactspectrum/67cdab621d0c186b305d9f2d958294ff541d5232/docs/react-spectrum/Well.html





4:21
this is from this pull https://github.com/adobe-private/react-spectrum-v3/pull/239
4:21
which if you scroll up to the previous docs build, you can see that the pages starting at progress bar are messed up

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
