### PR TITLE
Require pointer down event before pointer up in useInteractOutside

### DIFF
--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -36,6 +36,7 @@ export function useInteractOutside(props: InteractOutsideProps) {
     if (typeof PointerEvent !== 'undefined') {
       let onPointerUp = (e) => {
         if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
+          state.isPointerDown = false;
           onInteractOutside(e);
         }
       };
@@ -52,6 +53,7 @@ export function useInteractOutside(props: InteractOutsideProps) {
         if (state.ignoreEmulatedMouseEvents) {
           state.ignoreEmulatedMouseEvents = false;
         } else if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
+          state.isPointerDown = false;
           onInteractOutside(e);
         }
       };
@@ -59,6 +61,7 @@ export function useInteractOutside(props: InteractOutsideProps) {
       let onTouchEnd = (e) => {
         state.ignoreEmulatedMouseEvents = true;
         if (onInteractOutside && state.isPointerDown && isValidEvent(e, ref)) {
+          state.isPointerDown = false;
           onInteractOutside(e);
         }
       };

--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -20,49 +20,62 @@ interface InteractOutsideProps {
 export function useInteractOutside(props: InteractOutsideProps) {
   let {ref, onInteractOutside} = props;
   let stateRef = useRef({
+    isPointerDown: false,
     ignoreEmulatedMouseEvents: false
   });
   let state = stateRef.current;
 
   useEffect(() => {
+    let onPointerDown = (e) => {
+      if (isValidEvent(e, ref)) {
+        state.isPointerDown = true;
+      }
+    };
+  
     // Use pointer events if available. Otherwise, fall back to mouse and touch events.
     if (typeof PointerEvent !== 'undefined') {
       let onPointerUp = (e) => {
-        if (onInteractOutside && isValidEvent(e, ref)) {
+        if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
           onInteractOutside(e);
         }
       };
 
+      document.addEventListener('pointerdown', onPointerDown, false);
       document.addEventListener('pointerup', onPointerUp, false);
 
       return () => {
+        document.removeEventListener('pointerdown', onPointerDown, false);
         document.removeEventListener('pointerup', onPointerUp, false);
       };
     } else {
       let onMouseUp = (e) => {
         if (state.ignoreEmulatedMouseEvents) {
           state.ignoreEmulatedMouseEvents = false;
-        } else if (onInteractOutside && isValidEvent(e, ref)) {
+        } else if (state.isPointerDown && onInteractOutside && isValidEvent(e, ref)) {
           onInteractOutside(e);
         }
       };
 
       let onTouchEnd = (e) => {
         state.ignoreEmulatedMouseEvents = true;
-        if (onInteractOutside && isValidEvent(e, ref)) {
+        if (onInteractOutside && state.isPointerDown && isValidEvent(e, ref)) {
           onInteractOutside(e);
         }
       };
 
+      document.addEventListener('mousedown', onPointerDown, false);
       document.addEventListener('mouseup', onMouseUp, false);
+      document.addEventListener('touchstart', onPointerDown, false);
       document.addEventListener('touchend', onTouchEnd, false);
 
       return () => {
+        document.removeEventListener('mousedown', onPointerDown, false);
         document.removeEventListener('mouseup', onMouseUp, false);
+        document.removeEventListener('touchstart', onPointerDown, false);
         document.removeEventListener('touchend', onTouchEnd, false);
       };
     }
-  }, [onInteractOutside, ref, state.ignoreEmulatedMouseEvents]);
+  }, [onInteractOutside, ref, state.ignoreEmulatedMouseEvents, state.isPointerDown]);
 }
 
 function isValidEvent(event, ref) {

--- a/packages/@react-aria/interactions/test/useInteractOutside.test.js
+++ b/packages/@react-aria/interactions/test/useInteractOutside.test.js
@@ -47,9 +47,11 @@ describe('useInteractOutside', function () {
       );
 
       let el = res.getByText('test');
+      fireEvent(el, pointerEvent('pointerdown'));
       fireEvent(el, pointerEvent('pointerup'));
       expect(onInteractOutside).not.toHaveBeenCalled();
 
+      fireEvent(document.body, pointerEvent('pointerdown'));
       fireEvent(document.body, pointerEvent('pointerup'));
       expect(onInteractOutside).toHaveBeenCalledTimes(1);
     });
@@ -60,11 +62,26 @@ describe('useInteractOutside', function () {
         <Example onInteractOutside={onInteractOutside} />
       );
 
+      fireEvent(document.body, pointerEvent('pointerdown', {button: 1}));
       fireEvent(document.body, pointerEvent('pointerup', {button: 1}));
       expect(onInteractOutside).not.toHaveBeenCalled();
 
+      fireEvent(document.body, pointerEvent('pointerdown', {button: 0}));
       fireEvent(document.body, pointerEvent('pointerup', {button: 0}));
       expect(onInteractOutside).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire interact outside if there is a pointer up event without a pointer down first', function () {
+      // Fire pointer down before component with useInteractOutside is mounted
+      fireEvent(document.body, pointerEvent('pointerdown'));
+
+      let onInteractOutside = jest.fn();
+      render(
+        <Example onInteractOutside={onInteractOutside} />
+      );
+
+      fireEvent(document.body, pointerEvent('pointerup'));
+      expect(onInteractOutside).not.toHaveBeenCalled();
     });
   });
 
@@ -76,9 +93,11 @@ describe('useInteractOutside', function () {
       );
 
       let el = res.getByText('test');
+      fireEvent.mouseDown(el);
       fireEvent.mouseUp(el);
       expect(onInteractOutside).not.toHaveBeenCalled();
 
+      fireEvent.mouseDown(document.body);
       fireEvent.mouseUp(document.body);
       expect(onInteractOutside).toHaveBeenCalledTimes(1);
     });
@@ -89,11 +108,26 @@ describe('useInteractOutside', function () {
         <Example onInteractOutside={onInteractOutside} />
       );
 
+      fireEvent.mouseDown(document.body, {button: 1});
       fireEvent.mouseUp(document.body, {button: 1});
       expect(onInteractOutside).not.toHaveBeenCalled();
 
+      fireEvent.mouseDown(document.body, {button: 0});
       fireEvent.mouseUp(document.body, {button: 0});
       expect(onInteractOutside).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire interact outside if there is a mouse up event without a mouse down first', function () {
+      // Fire mouse down before component with useInteractOutside is mounted
+      fireEvent.mouseDown(document.body);
+
+      let onInteractOutside = jest.fn();
+      render(
+        <Example onInteractOutside={onInteractOutside} />
+      );
+
+      fireEvent.mouseUp(document.body);
+      expect(onInteractOutside).not.toHaveBeenCalled();
     });
   });
 
@@ -105,9 +139,11 @@ describe('useInteractOutside', function () {
       );
 
       let el = res.getByText('test');
+      fireEvent.touchStart(el);
       fireEvent.touchEnd(el);
       expect(onInteractOutside).not.toHaveBeenCalled();
 
+      fireEvent.touchStart(document.body);
       fireEvent.touchEnd(document.body);
       expect(onInteractOutside).toHaveBeenCalledTimes(1);
     });
@@ -119,13 +155,28 @@ describe('useInteractOutside', function () {
       );
 
       let el = res.getByText('test');
+      fireEvent.touchStart(el);
       fireEvent.touchEnd(el);
       fireEvent.mouseUp(el);
       expect(onInteractOutside).not.toHaveBeenCalled();
 
+      fireEvent.touchStart(document.body);
       fireEvent.touchEnd(document.body);
       fireEvent.mouseUp(document.body);
       expect(onInteractOutside).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire interact outside if there is a touch end event without a touch start first', function () {
+      // Fire mouse down before component with useInteractOutside is mounted
+      fireEvent.touchStart(document.body);
+
+      let onInteractOutside = jest.fn();
+      render(
+        <Example onInteractOutside={onInteractOutside} />
+      );
+
+      fireEvent.touchEnd(document.body);
+      expect(onInteractOutside).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/@react-aria/overlays/test/useOverlay.test.js
+++ b/packages/@react-aria/overlays/test/useOverlay.test.js
@@ -37,6 +37,7 @@ describe('useOverlay', function () {
   it('should hide the overlay when clicking outside if isDismissble is true', function () {
     let onClose = jest.fn();
     render(<Example isOpen onClose={onClose} isDismissable />);
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -44,6 +45,7 @@ describe('useOverlay', function () {
   it('should not hide the overlay when clicking outside if isDismissable is false', function () {
     let onClose = jest.fn();
     render(<Example isOpen onClose={onClose} isDismissable={false} />);
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(onClose).toHaveBeenCalledTimes(0);
   });
@@ -70,12 +72,14 @@ describe('useOverlay', function () {
     render(<Example isOpen onClose={onCloseFirst} isDismissable />);
     let second = render(<Example isOpen onClose={onCloseSecond} isDismissable />);
 
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(onCloseSecond).toHaveBeenCalledTimes(1);
     expect(onCloseFirst).not.toHaveBeenCalled();
 
     second.unmount();
 
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(onCloseFirst).toHaveBeenCalledTimes(1);
   });

--- a/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
+++ b/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
@@ -429,6 +429,7 @@ describe('DialogTrigger', function () {
     expect(modal).toBeVisible();
     await waitForDomChange(); // wait for animation
 
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(modal).toBeVisible();
     expect(onOpenChange).toHaveBeenCalledTimes(1);

--- a/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
+++ b/packages/@react-spectrum/dialog/test/DialogTrigger.test.js
@@ -372,6 +372,7 @@ describe('DialogTrigger', function () {
     expect(dialog).toBeVisible();
     await waitForDomChange(); // wait for animation
 
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(dialog).toBeVisible();
     expect(onOpenChange).toHaveBeenCalledTimes(1);
@@ -458,6 +459,7 @@ describe('DialogTrigger', function () {
     let dialog = getByRole('dialog');
     expect(dialog).toBeVisible();
     await waitForDomChange(); // wait for animation
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(dialog).toBeVisible();
     expect(onOpenChange).toHaveBeenCalledTimes(1);

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -390,6 +390,7 @@ describe('MenuTrigger', function () {
 
       let menu = tree.getByRole('menu');
       expect(menu).toBeTruthy();
+      fireEvent.mouseDown(document.body);
       fireEvent.mouseUp(document.body);
       await waitForDomChange();
       expect(menu).not.toBeInTheDocument();

--- a/packages/@react-spectrum/overlays/test/Modal.test.js
+++ b/packages/@react-spectrum/overlays/test/Modal.test.js
@@ -94,6 +94,7 @@ describe('Modal', function () {
       </Provider>
     );
     await waitForDomChange(); // wait for animation
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/packages/@react-spectrum/overlays/test/Popover.test.js
+++ b/packages/@react-spectrum/overlays/test/Popover.test.js
@@ -134,6 +134,7 @@ describe('Popover', function () {
     it('hides the popover when clicking outside', function () {
       let onClose = jest.fn();
       render(<Popover isOpen onClose={onClose} />);
+      fireEvent.mouseDown(document.body);
       fireEvent.mouseUp(document.body);
       expect(onClose).toHaveBeenCalledTimes(1);
     });

--- a/packages/@react-spectrum/overlays/test/Tray.test.js
+++ b/packages/@react-spectrum/overlays/test/Tray.test.js
@@ -79,6 +79,7 @@ describe('Tray', function () {
       </Provider>
     );
     await waitForDomChange(); // wait for animation
+    fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
     expect(onClose).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
Previously, we only handled pointer up events in useInteractOutside. This meant that if the component that called useInteractOutside was mounted between mouse down and mouse up, it would immediately unmount on mouse up. Now, we require a pointer down event to occur before pointer up while useInteractOutside is mounted so that this doesn't happen.