### PR TITLE
Initial implementation of Picker

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
@@ -26,13 +26,13 @@ governing permissions and limitations under the License.
   }
 
   &.is-invalid {
-    .spectrum-Icon:not(.spectrum-Dropdown-icon):not(.spectrum-Menu-checkmark) {
+    .spectrum-Dropdown-invalidIcon {
       color: var(--spectrum-dropdown-validation-icon-color-error);
     }
 
     &.is-disabled {
       .spectrum-Icon,
-      .spectrum-Icon:not(.spectrum-Dropdown-icon):not(.spectrum-Menu-checkmark) {
+      .spectrum-Dropdown-invalidIcon {
         color: var(--spectrum-dropdown-icon-color-disabled);
       }
     }

--- a/packages/@react-aria/collections/src/ScrollView.tsx
+++ b/packages/@react-aria/collections/src/ScrollView.tsx
@@ -135,7 +135,7 @@ function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
   }, [ref, state.scrollLeft, state.scrollTop, visibleRect.x, visibleRect.y]);
 
   return (
-    <div {...otherProps} style={{position: 'relative', overflow: 'auto'}} ref={ref} onScroll={onScroll}>
+    <div {...otherProps} style={{position: 'relative', overflow: 'auto', ...otherProps.style}} ref={ref} onScroll={onScroll}>
       <div role="presentation" style={{width: contentSize.width, height: contentSize.height, pointerEvents: isScrolling ? 'none' : 'auto', ...innerStyle}}>
         {children}
       </div>

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -53,7 +53,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -74,6 +75,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -106,7 +115,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -186,6 +196,14 @@ describe('usePress', function () {
           pressed: true
         },
         {
+          type: 'pressup',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
           type: 'pressend',
           target: el,
           pointerType: 'mouse',
@@ -216,7 +234,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -259,7 +278,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -280,6 +300,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: true,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -312,7 +340,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -331,7 +360,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -351,6 +381,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -383,7 +421,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -464,6 +503,14 @@ describe('usePress', function () {
           pressed: true
         },
         {
+          type: 'pressup',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
           type: 'pressend',
           target: el,
           pointerType: 'mouse',
@@ -494,7 +541,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -514,6 +562,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'mouse',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: true
         },
         {
           type: 'pressend',
@@ -546,7 +602,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -567,7 +624,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -586,6 +644,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'touch',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -618,7 +684,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -697,6 +764,14 @@ describe('usePress', function () {
           pressed: true
         },
         {
+          type: 'pressup',
+          target: el,
+          pointerType: 'touch',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
           type: 'pressend',
           target: el,
           pointerType: 'touch',
@@ -727,7 +802,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -779,6 +855,14 @@ describe('usePress', function () {
           pressed: true
         },
         {
+          type: 'pressup',
+          target: el,
+          pointerType: 'touch',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
           type: 'pressend',
           target: el,
           pointerType: 'touch',
@@ -809,7 +893,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -854,7 +939,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = getByText('test');
@@ -873,6 +959,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -908,7 +1002,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = getByText('test');
@@ -944,6 +1039,14 @@ describe('usePress', function () {
           pressed: true
         },
         {
+          type: 'pressup',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
           type: 'pressend',
           target: el,
           pointerType: 'keyboard',
@@ -976,7 +1079,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = getByText('test');
@@ -1002,6 +1106,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -1041,7 +1153,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = getByText('test');
@@ -1068,6 +1181,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -1103,7 +1224,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = res.getByText('test');
@@ -1122,6 +1244,14 @@ describe('usePress', function () {
         {
           type: 'presschange',
           pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: true,
+          metaKey: false,
+          shiftKey: false
         },
         {
           type: 'pressend',
@@ -1154,7 +1284,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = getByText('test');
@@ -1205,6 +1336,14 @@ describe('usePress', function () {
           pressed: true
         },
         {
+          type: 'pressup',
+          target: el,
+          pointerType: 'keyboard',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
           type: 'pressend',
           target: el,
           pointerType: 'keyboard',
@@ -1235,7 +1374,8 @@ describe('usePress', function () {
           onPressStart={addEvent}
           onPressEnd={addEvent}
           onPressChange={pressed => addEvent({type: 'presschange', pressed})}
-          onPress={addEvent} />
+          onPress={addEvent}
+          onPressUp={addEvent} />
       );
 
       let el = getByText('test');

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -12,7 +12,7 @@
 
 import {HTMLAttributes, Key, RefObject} from 'react';
 import {ListState} from '@react-stately/list';
-import {usePress} from '@react-aria/interactions';
+import {useHover, usePress} from '@react-aria/interactions';
 import {useSelectableItem} from '@react-aria/selection';
 
 interface OptionProps {
@@ -20,6 +20,8 @@ interface OptionProps {
   isSelected?: boolean,
   key?: Key,
   ref?: RefObject<HTMLElement>,
+  selectOnPressUp?: boolean,
+  focusOnHover?: boolean,
   isVirtualized?: boolean
 }
 
@@ -33,6 +35,8 @@ export function useOption<T>(props: OptionProps, state: ListState<T>): OptionAri
     isDisabled,
     key,
     ref,
+    selectOnPressUp,
+    focusOnHover,
     isVirtualized
   } = props;
 
@@ -51,15 +55,23 @@ export function useOption<T>(props: OptionProps, state: ListState<T>): OptionAri
     selectionManager: state.selectionManager,
     itemKey: key,
     itemRef: ref,
+    selectOnPressUp,
     isVirtualized
   });
 
   let {pressProps} = usePress({...itemProps, isDisabled});
+  let {hoverProps} = useHover({
+    isDisabled: isDisabled || !focusOnHover,
+    onHover() {
+      state.selectionManager.setFocusedKey(key);
+    }
+  });
 
   return {
     optionProps: {
       ...optionProps,
-      ...pressProps
+      ...pressProps,
+      ...hoverProps
     }
   };
 }

--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -13,7 +13,7 @@
 import {AllHTMLAttributes, Key, RefObject} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {TreeState} from '@react-stately/tree';
-import {usePress} from '@react-aria/interactions';
+import {useHover, usePress} from '@react-aria/interactions';
 import {useSelectableItem} from '@react-aria/selection';
 
 interface MenuItemAria {
@@ -79,7 +79,7 @@ export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuI
     }
   };
 
-  let onPress = (e) => {
+  let onPressUp = (e) => {
     if (e.pointerType !== 'keyboard' && closeOnSelect && onClose) {
       onClose();
     }
@@ -88,17 +88,23 @@ export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuI
   let {itemProps} = useSelectableItem({
     selectionManager: state.selectionManager,
     itemKey: key,
-    itemRef: ref
+    itemRef: ref,
+    selectOnPressUp: true
   });
 
-  let {pressProps} = usePress(mergeProps({onPress, onKeyDown, isDisabled}, itemProps));
-  let onMouseOver = () => state.selectionManager.setFocusedKey(key);
+  let {pressProps} = usePress(mergeProps({onPressUp, onKeyDown, isDisabled}, itemProps));
+  let {hoverProps} = useHover({
+    isDisabled,
+    onHover() {
+      state.selectionManager.setFocusedKey(key);
+    }
+  });
 
   return {
     menuItemProps: {
       ...ariaProps,
       ...pressProps,
-      onMouseOver
+      ...hoverProps
     }
   };
 }

--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -24,7 +24,7 @@ interface MenuTriggerAria {
 export function useMenuTrigger(props: MenuTriggerProps, state: MenuTriggerState): MenuTriggerAria {
   let {
     ref,
-    type,
+    type = 'menu' as MenuTriggerProps['type'],
     isDisabled
   } = props;
 
@@ -70,7 +70,7 @@ export function useMenuTrigger(props: MenuTriggerProps, state: MenuTriggerState)
     menuTriggerProps: {
       ...triggerAriaProps,
       id: menuTriggerId,
-      onPress,
+      onPressStart: onPress,
       onKeyDown
     },
     menuProps: {

--- a/packages/@react-aria/menu/test/useMenuTrigger.test.js
+++ b/packages/@react-aria/menu/test/useMenuTrigger.test.js
@@ -40,7 +40,7 @@ describe('useMenuTrigger', function () {
     let {menuTriggerProps, menuProps} = renderMenuTriggerHook({}, state);
     expect(menuTriggerProps['aria-controls']).toBeFalsy();
     expect(menuTriggerProps['aria-expanded']).toBeFalsy();
-    expect(menuTriggerProps['aria-haspopup']).toBeFalsy();
+    expect(menuTriggerProps['aria-haspopup']).toBeTruthy();
     expect(menuProps['aria-labelledby']).toBe(menuTriggerProps.id);
     expect(menuProps.id).toBeTruthy();
   });
@@ -71,8 +71,8 @@ describe('useMenuTrigger', function () {
     };
 
     let {menuTriggerProps} = renderMenuTriggerHook(props, state);
-    expect(typeof menuTriggerProps.onPress).toBe('function');
-    menuTriggerProps.onPress();
+    expect(typeof menuTriggerProps.onPressStart).toBe('function');
+    menuTriggerProps.onPressStart();
     expect(setOpen).toHaveBeenCalledTimes(1);
     expect(setOpen).toHaveBeenCalledWith(!state.isOpen);
     expect(setFocusStrategy).toHaveBeenCalledTimes(1);

--- a/packages/@react-aria/overlays/src/useOverlayTrigger.ts
+++ b/packages/@react-aria/overlays/src/useOverlayTrigger.ts
@@ -53,14 +53,21 @@ export function useOverlayTrigger(props: OverlayTriggerProps): OverlayTriggerAri
     };
   }, [isOpen, onClose, ref]);
 
+  // Aria 1.1 supports multiple values for aria-haspopup other than just menus.
+  // https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup
+  // However, we only add it for menus for now because screen readers often 
+  // announce it as a menu even for other values.
+  let ariaHasPopup = undefined;
+  if (type === 'menu') {
+    ariaHasPopup = true;
+  } else if (type === 'listbox') {
+    ariaHasPopup = 'listbox';
+  }
+
   let overlayId = useId();
   return {
     triggerAriaProps: {
-      // Aria 1.1 supports multiple values for aria-haspopup other than just menus.
-      // https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup
-      // However, we only add it for menus for now because screen readers often 
-      // announce it as a menu even for other values.
-      'aria-haspopup': type === 'menu' ? true : undefined,
+      'aria-haspopup': ariaHasPopup,
       'aria-expanded': isOpen,
       'aria-controls': isOpen ? overlayId : null
     },

--- a/packages/@react-aria/select/index.ts
+++ b/packages/@react-aria/select/index.ts
@@ -10,6 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './ListBox';
-export * from './ListBoxBase';
-export {Item, Section} from '@react-stately/collections';
+export * from './src';

--- a/packages/@react-aria/select/package.json
+++ b/packages/@react-aria/select/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@react-aria/select",
+  "version": "3.0.0-alpha.1",
+  "private": true,
+  "description": "Spectrum UI components in React",
+  "license": "Apache-2.0",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "dist/types.d.ts",
+  "source": "src/index.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe-private/react-spectrum-v3"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.6.2",
+    "@react-aria/interactions": "^3.0.0-rc.1",
+    "@react-aria/label": "^3.0.0-rc.1",
+    "@react-aria/menu": "^3.0.0-alpha.1",
+    "@react-aria/selection": "^3.0.0-alpha.1",
+    "@react-aria/utils": "^3.0.0-rc.1",
+    "@react-stately/select": "^3.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@react-aria/select/src/index.ts
+++ b/packages/@react-aria/select/src/index.ts
@@ -10,6 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './ListBox';
-export * from './ListBoxBase';
-export {Item, Section} from '@react-stately/collections';
+export * from './useSelect';

--- a/packages/@react-aria/select/src/useSelect.ts
+++ b/packages/@react-aria/select/src/useSelect.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {HTMLAttributes, RefObject} from 'react';
+import {KeyboardDelegate} from '@react-types/shared';
+import {mergeProps} from '@react-aria/utils';
+import {PressProps} from '@react-aria/interactions';
+import {SelectState} from '@react-stately/select';
+import {useLabel} from '@react-aria/label';
+import {useMenuTrigger} from '@react-aria/menu';
+import {useTypeSelect} from '@react-aria/selection';
+
+interface SelectProps {
+  triggerRef: RefObject<HTMLElement>,
+  isDisabled?: boolean,
+  keyboardDelegate: KeyboardDelegate
+}
+
+interface SelectAria {
+  labelProps: HTMLAttributes<HTMLElement>,
+  triggerProps: HTMLAttributes<HTMLElement> & PressProps,
+  menuProps: HTMLAttributes<HTMLElement>
+}
+
+export function useSelect<T>(props: SelectProps, state: SelectState<T>): SelectAria {
+  let {
+    triggerRef,
+    isDisabled,
+    keyboardDelegate
+  } = props;
+
+  let {menuTriggerProps, menuProps} = useMenuTrigger(
+    {
+      ref: triggerRef,
+      type: 'listbox',
+      isDisabled
+    },
+    state
+  );
+
+  let {typeSelectProps} = useTypeSelect({
+    keyboardDelegate: keyboardDelegate,
+    selectionManager: state.selectionManager,
+    onTypeSelect(key) {
+      state.setSelectedKey(key);
+    }
+  });
+
+  let {labelProps, fieldProps} = useLabel({
+    ...props,
+    labelElementType: 'span'
+  });
+
+  let triggerProps = mergeProps(mergeProps(menuTriggerProps, fieldProps), typeSelectProps);
+  triggerProps['aria-labelledby'] = `${triggerProps['aria-labelledby']} ${triggerProps.id}`;
+
+  menuProps['aria-labelledby'] = fieldProps['aria-labelledby'];
+
+  return {
+    labelProps,
+    triggerProps,
+    menuProps
+  };
+}

--- a/packages/@react-aria/selection/src/index.ts
+++ b/packages/@react-aria/selection/src/index.ts
@@ -14,3 +14,4 @@ export * from './useSelectableCollection';
 export * from './useSelectableItem';
 export * from './useSelectableList';
 export * from './ListKeyboardDelegate';
+export * from './useTypeSelect';

--- a/packages/@react-aria/selection/src/useTypeSelect.ts
+++ b/packages/@react-aria/selection/src/useTypeSelect.ts
@@ -1,10 +1,11 @@
-import {HTMLAttributes, KeyboardEvent, useRef} from 'react';
+import {HTMLAttributes, Key, KeyboardEvent, useRef} from 'react';
 import {KeyboardDelegate} from '@react-types/shared';
 import {MultipleSelectionManager} from '@react-stately/selection';
 
 interface TypeSelectOptions {
   keyboardDelegate: KeyboardDelegate,
-  selectionManager: MultipleSelectionManager
+  selectionManager: MultipleSelectionManager,
+  onTypeSelect?: (key: Key) => void
 }
 
 interface TypeSelectAria {
@@ -12,14 +13,18 @@ interface TypeSelectAria {
 }
 
 export function useTypeSelect(options: TypeSelectOptions): TypeSelectAria {
-  let {keyboardDelegate, selectionManager} = options;
+  let {keyboardDelegate, selectionManager, onTypeSelect} = options;
   let state = useRef({
     search: '',
     timeout: null
   }).current;
 
-  let onKeyPress = (e: KeyboardEvent) => {
-    let character = String.fromCharCode(e.charCode);
+  let onKeyDown = (e: KeyboardEvent) => {
+    let character = getStringForKey(e.key);
+    if (!character) {
+      return;
+    }
+
     state.search += character;
 
     // Use the delegate to find a key to focus.
@@ -31,6 +36,9 @@ export function useTypeSelect(options: TypeSelectOptions): TypeSelectAria {
 
     if (key) {
       selectionManager.setFocusedKey(key);
+      if (onTypeSelect) {
+        onTypeSelect(key);
+      }
     }
 
     clearTimeout(state.timeout);
@@ -41,7 +49,19 @@ export function useTypeSelect(options: TypeSelectOptions): TypeSelectAria {
 
   return {
     typeSelectProps: {
-      onKeyPress: keyboardDelegate.getKeyForSearch ? onKeyPress : null
+      onKeyDown: keyboardDelegate.getKeyForSearch ? onKeyDown : null
     }
   };
+}
+
+function getStringForKey(key: string) {
+  // If the key is of length 1, it is an ASCII value.
+  // Otherwise, if there are no ASCII characters in the key name,
+  // it is a Unicode character.
+  // See https://www.w3.org/TR/uievents-key/
+  if (key.length === 1 || !/^[A-Z]/i.test(key)) {
+    return key;
+  }
+
+  return '';
 }

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -21,6 +21,7 @@ import {useButton} from '@react-aria/button';
 
 interface FieldButtonProps extends ButtonProps {
   isQuiet?: boolean,
+  isActive?: boolean,
   icon?: ReactElement,
   validationState?: 'valid' | 'invalid'
 }
@@ -36,6 +37,7 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
     icon,
     children,
     autoFocus,
+    isActive,
     ...otherProps
   } = props;
   let domRef = useFocusableRef(ref);
@@ -53,15 +55,15 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
             'spectrum-FieldButton',
             {
               'spectrum-FieldButton--quiet': isQuiet,
-              'is-active': isPressed,
+              'is-active': isActive || isPressed,
               'is-disabled': isDisabled,
               'is-invalid': validationState === 'invalid'
             },
             styleProps.className
           )
         }>
-        {cloneElement(icon, {size: 'S'})}
-        <span className={classNames(styles, 'spectrum-Button-label')}>{children}</span>
+        {icon && cloneElement(icon, {size: 'S'})}
+        {children}
       </ElementType>
     </FocusRing>
   );

--- a/packages/@react-spectrum/listbox/src/ListBox.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBox.tsx
@@ -10,90 +10,22 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
-import {CollectionItem, CollectionView} from '@react-aria/collections';
-import {ListBoxOption} from './ListBoxOption';
-import {ListBoxSection} from './ListBoxSection';
-import {ListLayout, Node} from '@react-stately/collections';
-import React, {ReactElement, useMemo} from 'react';
-import {ReusableView} from '@react-stately/collections';
+import {ListBoxBase, useListBoxLayout} from './ListBoxBase';
+import React from 'react';
 import {SpectrumMenuProps} from '@react-types/menu';
-import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
-import {useCollator} from '@react-aria/i18n';
-import {useListBox} from '@react-aria/listbox';
 import {useListState} from '@react-stately/list';
-import {useProvider} from '@react-spectrum/provider';
 
 export function ListBox<T>(props: SpectrumMenuProps<T>) {
-  let {scale} = useProvider();
-  let collator = useCollator({usage: 'search', sensitivity: 'base'});
-  let layout = useMemo(() => 
-    new ListLayout({
-      estimatedRowHeight: scale === 'large' ? 48 : 35,
-      estimatedHeadingHeight: scale === 'large' ? 37 : 30,
-      collator
-    })
-  , [collator, scale]);
-
-  let completeProps = {
+  let state = useListState({
     ...props,
     selectionMode: props.selectionMode || 'single'
-  };
-
-  let state = useListState(completeProps);
-  let {listBoxProps} = useListBox({...completeProps, keyboardDelegate: layout, isVirtualized: true}, state);
-  let {styleProps} = useStyleProps(completeProps);
-
-  // This overrides collection view's renderWrapper to support heirarchy of items in sections.
-  // The header is extracted from the children so it can receive ARIA labeling properties.
-  type View = ReusableView<Node<T>, unknown>;
-  let renderWrapper = (parent: View, reusableView: View, children: View[], renderChildren: (views: View[]) => ReactElement[]) => {
-    if (reusableView.viewType === 'section') {
-      return (
-        <ListBoxSection
-          key={reusableView.key}
-          state={state}
-          reusableView={reusableView}
-          header={children.find(c => c.viewType === 'header')}>
-          {renderChildren(children.filter(c => c.viewType === 'item'))}
-        </ListBoxSection>
-      );
-    }
-
-    return (
-      <CollectionItem 
-        key={reusableView.key}
-        reusableView={reusableView}
-        parent={parent} />
-    );
-  };
+  });
+  let layout = useListBoxLayout(state);
 
   return (
-    <CollectionView
-      {...filterDOMProps(completeProps)}
-      {...styleProps}
-      {...listBoxProps}
-      focusedKey={state.selectionManager.focusedKey}
-      sizeToFit="height"
-      className={
-        classNames(
-          styles, 
-          'spectrum-Menu',
-          styleProps.className
-        )
-      }
-      layout={layout}
-      collection={state.collection}
-      renderWrapper={renderWrapper}>
-      {(type, item) => {
-        if (type === 'item') {
-          return (
-            <ListBoxOption
-              item={item}
-              state={state} />
-          );
-        }
-      }}
-    </CollectionView>
+    <ListBoxBase
+      {...props}
+      state={state}
+      layout={layout} />
   );
 }

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
+import {CollectionItem, CollectionView} from '@react-aria/collections';
+import {DOMProps, StyleProps} from '@react-types/shared';
+import {FocusStrategy} from '@react-types/menu';
+import {ListBoxOption} from './ListBoxOption';
+import {ListBoxSection} from './ListBoxSection';
+import {ListLayout, Node} from '@react-stately/collections';
+import {ListState} from '@react-stately/list';
+import React, {ReactElement, useMemo} from 'react';
+import {ReusableView} from '@react-stately/collections';
+import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
+import {useCollator} from '@react-aria/i18n';
+import {useListBox} from '@react-aria/listbox';
+import {useProvider} from '@react-spectrum/provider';
+
+interface ListBoxBaseProps<T> extends DOMProps, StyleProps {
+  layout: ListLayout<T>,
+  state: ListState<T>,
+  autoFocus?: boolean,
+  focusStrategy?: FocusStrategy,
+  wrapAround?: boolean,
+  selectOnPressUp?: boolean,
+  focusOnPointerEnter?: boolean
+}
+
+export function useListBoxLayout<T>(state: ListState<T>) {
+  let {scale} = useProvider();
+  let collator = useCollator({usage: 'search', sensitivity: 'base'});
+  let layout = useMemo(() => 
+    new ListLayout({
+      estimatedRowHeight: scale === 'large' ? 48 : 35,
+      estimatedHeadingHeight: scale === 'large' ? 37 : 30,
+      collator
+    })
+  , [collator, scale]);
+
+  layout.collection = state.collection;
+  return layout;
+}
+
+export function ListBoxBase<T>(props: ListBoxBaseProps<T>) {
+  let {layout, state, selectOnPressUp, focusOnPointerEnter} = props;
+  let {listBoxProps} = useListBox({
+    ...props,
+    keyboardDelegate: layout,
+    isVirtualized: true
+  }, state);
+  let {styleProps} = useStyleProps(props);
+
+  // This overrides collection view's renderWrapper to support heirarchy of items in sections.
+  // The header is extracted from the children so it can receive ARIA labeling properties.
+  type View = ReusableView<Node<T>, unknown>;
+  let renderWrapper = (parent: View, reusableView: View, children: View[], renderChildren: (views: View[]) => ReactElement[]) => {
+    if (reusableView.viewType === 'section') {
+      return (
+        <ListBoxSection
+          key={reusableView.key}
+          state={state}
+          reusableView={reusableView}
+          header={children.find(c => c.viewType === 'header')}>
+          {renderChildren(children.filter(c => c.viewType === 'item'))}
+        </ListBoxSection>
+      );
+    }
+
+    return (
+      <CollectionItem 
+        key={reusableView.key}
+        reusableView={reusableView}
+        parent={parent} />
+    );
+  };
+
+  return (
+    <CollectionView
+      {...filterDOMProps(props)}
+      {...styleProps}
+      {...listBoxProps}
+      focusedKey={state.selectionManager.focusedKey}
+      sizeToFit="height"
+      className={
+        classNames(
+          styles, 
+          'spectrum-Menu',
+          styleProps.className
+        )
+      }
+      layout={layout}
+      collection={state.collection}
+      renderWrapper={renderWrapper}>
+      {(type, item) => {
+        if (type === 'item') {
+          return (
+            <ListBoxOption
+              item={item}
+              state={state}
+              selectOnPressUp={selectOnPressUp}
+              focusOnHover={focusOnPointerEnter} />
+          );
+        }
+      }}
+    </CollectionView>
+  );
+}

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -24,13 +24,17 @@ import {useRef} from 'react';
 
 interface OptionProps<T> {
   item: Node<T>,
-  state: ListState<T>
+  state: ListState<T>,
+  selectOnPressUp?: boolean,
+  focusOnHover?: boolean
 }
 
 export function ListBoxOption<T>(props: OptionProps<T>) {
   let {
     item,
-    state
+    state,
+    selectOnPressUp,
+    focusOnHover
   } = props;
 
   let {
@@ -47,6 +51,8 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
       isDisabled,
       key,
       ref,
+      selectOnPressUp,
+      focusOnHover: focusOnHover,
       isVirtualized: true
     },
     state

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -480,13 +480,13 @@ describe('ListBox', function () {
       let options = within(listbox).getAllByRole('option');
       expect(document.activeElement).toBe(options[0]);
 
-      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(listbox, {key: 'B'});
       expect(document.activeElement).toBe(options[1]);
 
-      fireEvent.keyPress(listbox, {charCode: 'l'.charCodeAt(0)});
+      fireEvent.keyDown(listbox, {key: 'L'});
       expect(document.activeElement).toBe(options[3]);
 
-      fireEvent.keyPress(listbox, {charCode: 'e'.charCodeAt(0)});
+      fireEvent.keyDown(listbox, {key: 'E'});
       expect(document.activeElement).toBe(options[4]);
     });
 
@@ -496,12 +496,12 @@ describe('ListBox', function () {
       let options = within(listbox).getAllByRole('option');
       expect(document.activeElement).toBe(options[0]);
 
-      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(listbox, {key: 'B'});
       expect(document.activeElement).toBe(options[1]);
 
       jest.runAllTimers();
 
-      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(listbox, {key: 'B'});
       expect(document.activeElement).toBe(options[2]);
     });
 
@@ -511,14 +511,14 @@ describe('ListBox', function () {
       let options = within(listbox).getAllByRole('option');
       expect(document.activeElement).toBe(options[0]);
 
-      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
-      fireEvent.keyPress(listbox, {charCode: 'l'.charCodeAt(0)});
-      fireEvent.keyPress(listbox, {charCode: 'e'.charCodeAt(0)});
+      fireEvent.keyDown(listbox, {key: 'B'});
+      fireEvent.keyDown(listbox, {key: 'L'});
+      fireEvent.keyDown(listbox, {key: 'E'});
       expect(document.activeElement).toBe(options[4]);
 
       jest.runAllTimers();
 
-      fireEvent.keyPress(listbox, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(listbox, {key: 'B'});
       expect(document.activeElement).toBe(options[1]);
     });
   });

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -11,6 +11,7 @@
  */
 
 import {DOMRefValue} from '@react-types/shared';
+import {FocusScope} from '@react-aria/focus';
 import {FocusStrategy, SpectrumMenuTriggerProps} from '@react-types/menu';
 import {MenuContext} from './context';
 import {Overlay, Popover} from '@react-spectrum/overlays';
@@ -47,7 +48,6 @@ export function MenuTrigger(props: SpectrumMenuTriggerProps) {
   let {menuTriggerProps, menuProps} = useMenuTrigger(
     {
       ref: menuTriggerRef,
-      type: 'menu',
       isDisabled
     },
     {
@@ -75,32 +75,20 @@ export function MenuTrigger(props: SpectrumMenuTriggerProps) {
     autoFocus: true,
     wrapAround: true
   };
-
-  let triggerProps = {
-    ...menuTriggerProps,
-    ref: menuTriggerRef,
-    isPressed: isOpen
-  };
-
-  let popoverProps = {
-    ...overlayProps,
-    ref: menuPopoverRef,
-    placement, 
-    hideArrow: true,
-    onClose
-  };
    
   return (
     <Fragment>
       <Provider isDisabled={isDisabled}>
-        <PressResponder {...triggerProps}>
+        <PressResponder {...menuTriggerProps} ref={menuTriggerRef} isPressed={isOpen}>
           {menuTrigger}
         </PressResponder>
       </Provider>
       <MenuContext.Provider value={menuContext}>
         <Overlay isOpen={isOpen} ref={containerRef}>
-          <Popover {...popoverProps}>
-            {menu}
+          <Popover {...overlayProps} ref={menuPopoverRef} hideArrow placement={placement} onClose={onClose}>
+            <FocusScope restoreFocus>
+              {menu}
+            </FocusScope>
           </Popover>
         </Overlay>
       </MenuContext.Provider>

--- a/packages/@react-spectrum/menu/test/Menu.test.js
+++ b/packages/@react-spectrum/menu/test/Menu.test.js
@@ -209,6 +209,7 @@ describe('Menu', function () {
       // Select a different menu item via enter
       let nextSelectedItem = menuItems[4];
       fireEvent.keyDown(nextSelectedItem, {key: 'Enter', code: 13, charCode: 13});
+      fireEvent.keyUp(nextSelectedItem, {key: 'Enter', code: 13, charCode: 13});
       expect(nextSelectedItem).toHaveAttribute('aria-checked', 'true');
       itemText = within(nextSelectedItem).getByText('Bleh');
       expect(itemText).toBeTruthy();
@@ -243,6 +244,7 @@ describe('Menu', function () {
       // Select a different menu item via enter
       let nextSelectedItem = menuItems[4];
       fireEvent.keyDown(nextSelectedItem, {key: 'Enter', code: 13, charCode: 13});
+      fireEvent.keyUp(nextSelectedItem, {key: 'Enter', code: 13, charCode: 13});
       expect(nextSelectedItem).toHaveAttribute('aria-checked', 'false');
       expect(selectedItem).toHaveAttribute('aria-checked', 'true');
       checkmark = within(selectedItem).getByRole('img');
@@ -268,6 +270,7 @@ describe('Menu', function () {
       // Trigger a menu item via space
       let item = menuItems[4];
       fireEvent.keyDown(item, {key: ' ', code: 32, charCode: 32});
+      fireEvent.keyUp(item, {key: ' ', code: 32, charCode: 32});
       if (Component === Menu) {
         expect(item).toHaveAttribute('aria-checked', 'true');
         let checkmark = within(item).getByRole('img');
@@ -571,13 +574,13 @@ describe('Menu', function () {
       let menuItems = within(menu).getAllByRole('menuitemradio');
       expect(document.activeElement).toBe(menuItems[0]);
 
-      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(menu, {key: 'B'});
       expect(document.activeElement).toBe(menuItems[1]);
 
-      fireEvent.keyPress(menu, {charCode: 'l'.charCodeAt(0)});
+      fireEvent.keyDown(menu, {key: 'L'});
       expect(document.activeElement).toBe(menuItems[3]);
 
-      fireEvent.keyPress(menu, {charCode: 'e'.charCodeAt(0)});
+      fireEvent.keyDown(menu, {key: 'E'});
       expect(document.activeElement).toBe(menuItems[4]);
     });
 
@@ -590,12 +593,12 @@ describe('Menu', function () {
       let menuItems = within(menu).getAllByRole('menuitemradio');
       expect(document.activeElement).toBe(menuItems[0]);
 
-      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(menu, {key: 'B'});
       expect(document.activeElement).toBe(menuItems[1]);
 
       jest.runAllTimers();
 
-      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(menu, {key: 'B'});
       expect(document.activeElement).toBe(menuItems[2]);
     });
 
@@ -608,14 +611,14 @@ describe('Menu', function () {
       let menuItems = within(menu).getAllByRole('menuitemradio');
       expect(document.activeElement).toBe(menuItems[0]);
 
-      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
-      fireEvent.keyPress(menu, {charCode: 'l'.charCodeAt(0)});
-      fireEvent.keyPress(menu, {charCode: 'e'.charCodeAt(0)});
+      fireEvent.keyDown(menu, {key: 'B'});
+      fireEvent.keyDown(menu, {key: 'L'});
+      fireEvent.keyDown(menu, {key: 'E'});
       expect(document.activeElement).toBe(menuItems[4]);
 
       jest.runAllTimers();
 
-      fireEvent.keyPress(menu, {charCode: 'b'.charCodeAt(0)});
+      fireEvent.keyDown(menu, {key: 'B'});
       expect(document.activeElement).toBe(menuItems[1]);
     });
   });

--- a/packages/@react-spectrum/picker/index.ts
+++ b/packages/@react-spectrum/picker/index.ts
@@ -10,6 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './ListBox';
-export * from './ListBoxBase';
-export {Item, Section} from '@react-stately/collections';
+export * from './src';

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@react-spectrum/picker",
+  "version": "3.0.0-alpha.1",
+  "private": true,
+  "description": "Spectrum UI components in React",
+  "license": "Apache-2.0",
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "dist/types.d.ts",
+  "source": "src/index.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "targets": {
+    "main": {
+      "includeNodeModules": ["@adobe/spectrum-css-temp"]
+    },
+    "module": {
+      "includeNodeModules": ["@adobe/spectrum-css-temp"]
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe-private/react-spectrum-v3"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.6.2",
+    "@react-aria/focus": "^3.0.0-rc.1",
+    "@react-aria/overlays": "^3.0.0-alpha.1",
+    "@react-aria/select": "^3.0.0-alpha.1",
+    "@react-aria/utils": "^3.0.0-alpha.1",
+    "@react-spectrum/button": "^3.0.0-rc.1",
+    "@react-spectrum/label": "^3.0.0-rc.1",
+    "@react-spectrum/listbox": "^3.0.0-alpha.1",
+    "@react-spectrum/overlays": "^3.0.0-alpha.1",
+    "@react-spectrum/provider": "^3.0.0-alpha.1",
+    "@react-spectrum/utils": "^3.0.0-alpha.1",
+    "@react-stately/select": "^3.0.0-alpha.1",
+    "@spectrum-icons/ui": "^3.0.0-rc.1"
+  },
+  "devDependencies": {
+    "@adobe/spectrum-css-temp": "^3.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import AlertMedium from '@spectrum-icons/ui/AlertMedium';
+import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
+import {classNames, filterDOMProps, unwrapDOMRef, useDOMRef, useMediaQuery, useStyleProps} from '@react-spectrum/utils';
+import {DOMRef, DOMRefValue, FocusableRefValue, LabelPosition} from '@react-types/shared';
+import {FieldButton} from '@react-spectrum/button';
+import {FocusScope} from '@react-aria/focus';
+import {Label} from '@react-spectrum/label';
+import labelStyles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';
+import {ListBoxBase, useListBoxLayout} from '@react-spectrum/listbox';
+import {mergeProps} from '@react-aria/utils';
+import {Overlay, Popover, Tray} from '@react-spectrum/overlays';
+import {Placement} from '@react-types/overlays';
+import React, {ReactElement, useRef} from 'react';
+import {SpectrumPickerProps} from '@react-types/select';
+import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
+import {useOverlayPosition} from '@react-aria/overlays';
+import {useProviderProps} from '@react-spectrum/provider';
+import {useSelect} from '@react-aria/select';
+import {useSelectState} from '@react-stately/select';
+
+function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
+  props = useProviderProps(props);
+  let {
+    isDisabled,
+    direction = 'bottom',
+    align = 'start',
+    shouldFlip = true,
+    placeholder = 'Select an item',
+    validationState,
+    isQuiet,
+    label,
+    labelPosition = 'top' as LabelPosition,
+    labelAlign,
+    isRequired,
+    necessityIndicator
+  } = props;
+
+  let {styleProps} = useStyleProps(props);
+  let state = useSelectState(props);
+  let domRef = useDOMRef(ref);
+
+  let containerRef = useRef<DOMRefValue<HTMLDivElement>>();
+  let popoverRef = useRef<HTMLDivElement>();
+  let triggerRef = useRef<FocusableRefValue<HTMLElement>>();
+
+  // We create the listbox layout in Picker and pass it to ListBoxBase below
+  // so that the layout information can be cached even while the listbox is not mounted.
+  // We also use the layout as the keyboard delegate for type to select.
+  let layout = useListBoxLayout(state);
+  let {labelProps, triggerProps, menuProps} = useSelect({
+    ...props,
+    triggerRef: unwrapDOMRef(triggerRef),
+    keyboardDelegate: layout
+  }, state);
+
+  let {overlayProps, placement} = useOverlayPosition({
+    containerRef: unwrapDOMRef(containerRef),
+    targetRef: unwrapDOMRef(triggerRef),
+    overlayRef: popoverRef,
+    placement: `${direction} ${align}` as Placement,
+    shouldFlip: shouldFlip,
+    isOpen: state.isOpen
+  });
+
+  // On small screen devices, the listbox is rendered in a tray, otherwise a popover.
+  let isMobile = useMediaQuery('(max-width: 700px)');
+  let listbox = (
+    <FocusScope restoreFocus>
+      <ListBoxBase
+        {...menuProps}
+        autoFocus
+        wrapAround
+        selectOnPressUp
+        focusOnPointerEnter
+        focusStrategy={state.focusStrategy}
+        layout={layout}
+        state={state}
+        width={isMobile ? '100%' : undefined} />
+    </FocusScope>
+  );
+
+  let overlay;
+  if (isMobile) {
+    overlay = (
+      <Tray isOpen={state.isOpen} onClose={() => state.setOpen(false)}>
+        {listbox}
+      </Tray>
+    );
+  } else {
+    overlay = (
+      <Popover {...overlayProps} ref={popoverRef} placement={placement} hideArrow onClose={() => state.setOpen(false)}>
+        {listbox}
+      </Popover>
+    );
+  }
+
+  // Get the selected item to render in the field button
+  let selectedItem = state.selectedKey
+    ? state.collection.getItem(state.selectedKey)
+    : null;
+
+  let picker = (
+    <div
+      className={
+        classNames(
+          styles,
+          'spectrum-Dropdown',
+          {'is-invalid': validationState === 'invalid'},
+          styleProps.className
+        )
+      }>
+      <FieldButton
+        {...filterDOMProps(props)}
+        {...triggerProps}
+        ref={triggerRef}
+        isActive={state.isOpen}
+        isQuiet={isQuiet}
+        isDisabled={isDisabled}
+        validationState={validationState}
+        UNSAFE_className={classNames(styles, 'spectrum-Dropdown-trigger')}>
+        <span
+          className={
+            classNames(
+              styles,
+              'spectrum-Dropdown-label',
+              {'is-placeholder': !selectedItem}
+            )
+           }>
+          {selectedItem ? selectedItem.rendered : placeholder}
+        </span>
+        {validationState === 'invalid' && 
+          <AlertMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-invalidIcon')} />
+        }
+        <ChevronDownMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-icon')} />
+      </FieldButton>
+      <Overlay isOpen={state.isOpen} ref={containerRef}>
+        {overlay}
+      </Overlay>
+    </div>
+  );
+
+  if (label) {
+    let labelWrapperClass = classNames(
+      labelStyles,
+      'spectrum-Field',
+      {
+        'spectrum-Field--positionTop': labelPosition === 'top',
+        'spectrum-Field--positionSide': labelPosition === 'side'
+      },
+      styleProps.className
+    );
+
+    picker = React.cloneElement(picker, mergeProps(picker.props, {
+      className: classNames(labelStyles, 'spectrum-Field-field')
+    }));
+
+    return (
+      <div 
+        {...styleProps}
+        ref={domRef}
+        className={labelWrapperClass}>
+        <Label
+          {...labelProps}
+          labelPosition={labelPosition}
+          labelAlign={labelAlign}
+          isRequired={isRequired}
+          necessityIndicator={necessityIndicator}
+          elementType="span">
+          {label}
+        </Label>
+        {picker}
+      </div>
+    );
+  }
+
+  return React.cloneElement(picker, mergeProps(picker.props, {
+    ...styleProps,
+    ref: domRef
+  }));
+}
+
+// forwardRef doesn't support generic parameters, so cast the result to the correct type
+// https://stackoverflow.com/questions/58469229/react-with-typescript-generics-while-using-react-forwardref
+const _Picker = React.forwardRef(Picker) as <T>(props: SpectrumPickerProps<T> & {ref?: DOMRef<HTMLDivElement>}) => ReactElement;
+export {_Picker as Picker};

--- a/packages/@react-spectrum/picker/src/index.ts
+++ b/packages/@react-spectrum/picker/src/index.ts
@@ -10,6 +10,5 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './ListBox';
-export * from './ListBoxBase';
+export * from './Picker';
 export {Item, Section} from '@react-stately/collections';

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Item, Picker, Section} from '../';
+import React from 'react';
+import {storiesOf} from '@storybook/react';
+
+let flatOptions = [
+  {name: 'Aardvark'},
+  {name: 'Kangaroo'},
+  {name: 'Snake'},
+  {name: 'Danni'},
+  {name: 'Devon'},
+  {name: 'Ross'},
+  {name: 'Puppy'},
+  {name: 'Doggo'},
+  {name: 'Floof'}
+];
+
+let withSection = [
+  {name: 'Animals', children: [
+    {name: 'Aardvark'},
+    {name: 'Kangaroo'},
+    {name: 'Snake'}
+  ]},
+  {name: 'People', children: [
+    {name: 'Danni'},
+    {name: 'Devon'},
+    {name: 'Ross'}
+  ]}
+];
+
+
+storiesOf('Picker', module)
+  .add(
+    'default',
+    () => (
+      <Picker label="Test">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'sections',
+    () => (
+      <Picker label="Test">
+        <Section title="Animals">
+          <Item>Aardvark</Item>
+          <Item>Kangaroo</Item>
+          <Item>Snake</Item>
+        </Section>
+        <Section title="People">
+          <Item>Danni</Item>
+          <Item>Devon</Item>
+          <Item>Ross</Item>
+        </Section>
+      </Picker>
+    )
+  )
+  .add(
+    'dynamic',
+    () => (
+      <Picker label="Test" items={flatOptions} itemKey="name">
+        {item => <Item>{item.name}</Item>}
+      </Picker>
+    )
+  )
+  .add(
+    'dynamic with sections',
+    () => (
+      <Picker label="Test" items={withSection} itemKey="name">
+        {item => (
+          <Section items={item.children} title={item.name}>
+            {item => <Item>{item.name}</Item>}
+          </Section>
+        )}
+      </Picker>
+    )
+  )
+  .add(
+    'isDisabled',
+    () => (
+      <Picker label="Test" isDisabled>
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet',
+    () => (
+      <Picker isQuiet label="Test">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'labelAlign: end',
+    () => (
+      <Picker label="Test" labelAlign="end">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'labelPosition: side',
+    () => (
+      <Picker label="Test" labelPosition="side">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isRequired',
+    () => (
+      <Picker label="Test" isRequired>
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isRequired, necessityIndicator: label',
+    () => (
+      <Picker label="Test" isRequired necessityIndicator="label">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'optional, necessityIndicator: label',
+    () => (
+      <Picker label="Test" necessityIndicator="label">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'validationState: invalid',
+    () => (
+      <Picker label="Test" validationState="invalid">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  );

--- a/packages/@react-spectrum/sidenav/src/SideNav.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNav.tsx
@@ -31,6 +31,8 @@ export function SideNav<T>(props: SpectrumSideNavProps<T>) {
   let {navProps, listProps} = useSideNav(props, state, layout);
   let {styleProps} = useStyleProps(props);
 
+  layout.collection = state.collection;
+
   // This overrides collection view's renderWrapper to support heirarchy of items in sections.
   // The header is extracted from the children so it can receive ARIA labeling properties.
   type View = ReusableView<Node<T>, unknown>;

--- a/packages/@react-stately/collections/src/useCollectionState.ts
+++ b/packages/@react-stately/collections/src/useCollectionState.ts
@@ -49,7 +49,10 @@ export function useCollectionState<T extends object, V, W>(opts: CollectionProps
 
   collectionManager.delegate = {
     setVisibleViews,
-    setVisibleRect,
+    setVisibleRect(rect) {
+      collectionManager.visibleRect = rect;
+      setVisibleRect(rect);
+    },
     setContentSize,
     renderView: opts.renderView,
     renderWrapper: opts.renderWrapper,
@@ -70,7 +73,10 @@ export function useCollectionState<T extends object, V, W>(opts: CollectionProps
     collectionManager,
     visibleViews,
     visibleRect,
-    setVisibleRect,
+    setVisibleRect(rect) {
+      collectionManager.visibleRect = rect;
+      setVisibleRect(rect);
+    },
     contentSize,
     isAnimating
   };

--- a/packages/@react-stately/select/index.ts
+++ b/packages/@react-stately/select/index.ts
@@ -10,6 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './ListBox';
-export * from './ListBoxBase';
-export {Item, Section} from '@react-stately/collections';
+export * from './src';

--- a/packages/@react-stately/select/package.json
+++ b/packages/@react-stately/select/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@react-stately/select",
+  "version": "3.0.0-alpha.1",
+  "description": "Spectrum UI components in React",
+  "license": "Apache-2.0",
+  "private": true,
+  "main": "dist/main.js",
+  "module": "dist/module.js",
+  "types": "dist/types.d.ts",
+  "source": "src/index.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe-private/react-spectrum-v3"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.6.2",
+    "@react-stately/collections": "^3.0.0-alpha.1",
+    "@react-stately/list": "^3.0.0-alpha.1",
+    "@react-stately/selection": "^3.0.0-alpha.1",
+    "@react-stately/utils": "^3.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/@react-stately/select/src/index.ts
+++ b/packages/@react-stately/select/src/index.ts
@@ -10,6 +10,4 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './ListBox';
-export * from './ListBoxBase';
-export {Item, Section} from '@react-stately/collections';
+export * from './useSelectState';

--- a/packages/@react-stately/select/src/useSelectState.ts
+++ b/packages/@react-stately/select/src/useSelectState.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Collection, Node} from '@react-stately/collections';
+import {FocusStrategy} from '@react-types/menu';
+import {Key, useMemo, useState} from 'react';
+import {SelectionManager} from '@react-stately/selection';
+import {SelectProps} from '@react-types/select';
+import {useControlledState} from '@react-stately/utils';
+import {useListState} from '@react-stately/list'; // TODO: move
+
+export interface SelectState<T> {
+  collection: Collection<Node<T>>,
+  disabledKeys: Set<Key>,
+  selectionManager: SelectionManager,
+  selectedKey: Key,
+  setSelectedKey: (key: Key) => void,
+  isOpen: boolean,
+  setOpen: (isOpen: boolean) => void,
+  toggle(focusStrategy?: FocusStrategy): void,
+  focusStrategy: FocusStrategy,
+  setFocusStrategy: (focusStrategy: FocusStrategy) => void
+}
+
+export function useSelectState<T>(props: SelectProps<T>): SelectState<T>  {
+  let [selectedKey, setSelectedKey] = useControlledState(props.selectedKey, props.defaultSelectedKey, props.onSelectionChange);
+  let selectedKeys = useMemo(() => selectedKey != null ? [selectedKey] : [], [selectedKey]);
+  let {collection, disabledKeys, selectionManager} = useListState({
+    ...props,
+    selectionMode: 'single',
+    selectedKeys,
+    onSelectionChange: (keys) => {
+      setSelectedKey(keys.values().next().value);
+      setOpen(false);
+    }
+  });
+
+  // TODO: move to useMenuTriggerState
+  let [isOpen, setOpen] = useControlledState(props.isOpen, props.defaultOpen || false, props.onOpenChange);
+  let [focusStrategy, setFocusStrategy] = useState('first' as FocusStrategy);
+
+  return {
+    collection,
+    disabledKeys,
+    selectionManager,
+    selectedKey,
+    setSelectedKey,
+    isOpen,
+    setOpen,
+    focusStrategy,
+    setFocusStrategy,
+    toggle(focusStrategy = 'first') {
+      setFocusStrategy(focusStrategy);
+      setOpen(isOpen => !isOpen);
+    }
+  };
+}

--- a/packages/@react-stately/selection/src/useMultipleSelectionState.ts
+++ b/packages/@react-stately/selection/src/useMultipleSelectionState.ts
@@ -14,14 +14,16 @@ import {MultipleSelection} from '@react-types/shared';
 import {MultipleSelectionState} from './types';
 import {Selection} from './Selection';
 import {useControlledState} from '@react-stately/utils';
-import {useRef, useState} from 'react';
+import {useMemo, useRef, useState} from 'react';
 
 export function useMultipleSelectionState(props: MultipleSelection): MultipleSelectionState  {
   let isFocused = useRef(false);
   let [focusedKey, setFocusedKey] = useState(null);
+  let selectedKeysProp = useMemo(() => props.selectedKeys ? new Selection(props.selectedKeys) : undefined, [props.selectedKeys]);
+  let defaultSelectedKeys = useMemo(() => props.defaultSelectedKeys ? new Selection(props.defaultSelectedKeys) : new Selection(), [props.defaultSelectedKeys]);
   let [selectedKeys, setSelectedKeys] = useControlledState(
-    props.selectedKeys ? new Selection(props.selectedKeys) : undefined,
-    props.defaultSelectedKeys ? new Selection(props.defaultSelectedKeys) : new Selection(),
+    selectedKeysProp,
+    defaultSelectedKeys,
     props.onSelectionChange
   );
 

--- a/packages/@react-types/menu/src/index.d.ts
+++ b/packages/@react-types/menu/src/index.d.ts
@@ -26,19 +26,19 @@ export interface MenuTriggerState {
 export interface MenuTriggerProps {
   ref?: RefObject<HTMLElement | null>,
   type?: 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid',
-  isDisabled?: boolean
-} 
-
-export interface SpectrumMenuTriggerProps extends MenuTriggerProps {
-  children: ReactElement[],
   trigger?: 'press' | 'longPress',
   align?: 'start' | 'end',
   direction?: 'bottom' | 'top', // left right?
+  closeOnSelect?: boolean,
+  isDisabled?: boolean,
   isOpen?: boolean,
   defaultOpen?: boolean,
   onOpenChange?: (isOpen: boolean) => void,
-  shouldFlip?: boolean,
-  closeOnSelect?: boolean
+  shouldFlip?: boolean
+}
+
+export interface SpectrumMenuTriggerProps extends MenuTriggerProps {
+  children: ReactElement[]
 }
 
 export interface MenuProps<T> extends CollectionBase<T>, Expandable, MultipleSelection {

--- a/packages/@react-types/select/package.json
+++ b/packages/@react-types/select/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@react-types/select",
+  "version": "3.0.0-alpha.1",
+  "description": "Spectrum UI components in React",
+  "license": "Apache-2.0",
+  "types": "src/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adobe-private/react-spectrum-v3"
+  },
+  "dependencies": {
+    "@react-types/shared": "^3.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "react": "^16.8.0"
+  }
+}

--- a/packages/@react-types/select/src/index.d.ts
+++ b/packages/@react-types/select/src/index.d.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Alignment, CollectionBase, DimensionValue, DOMProps, InputBase, LabelableProps, SingleSelection, SpectrumLabelableProps, StyleProps, TextInputBase} from '@react-types/shared';
+
+export interface SelectProps<T> extends CollectionBase<T>, InputBase, LabelableProps, TextInputBase, SingleSelection {
+  isOpen?: boolean,
+  defaultOpen?: boolean,
+  onOpenChange?: (isOpen: boolean) => void,
+  shouldFlip?: boolean
+}
+
+export interface SpectrumPickerProps<T> extends SelectProps<T>, SpectrumLabelableProps, DOMProps, StyleProps {
+  isQuiet?: boolean,
+  align?: Alignment,
+  direction?: 'bottom' | 'top',
+  menuWidth?: DimensionValue
+}

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2020 Adobe. All rights reserved.
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
@@ -10,6 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
+
 import {Key, ReactElement, ReactNode} from 'react';
 
 export interface ItemProps<T> {

--- a/packages/@react-types/shared/src/events.d.ts
+++ b/packages/@react-types/shared/src/events.d.ts
@@ -30,7 +30,7 @@ export type FocusEvent = BaseEvent<ReactFocusEvent<any>>;
 export type PointerType = 'mouse' | 'pen' | 'touch' | 'keyboard';
 
 export interface PressEvent {
-  type: 'pressstart' | 'pressend' | 'press',
+  type: 'pressstart' | 'pressend' | 'pressup' | 'press',
   pointerType: PointerType,
   target: HTMLElement,
   shiftKey: boolean,
@@ -75,7 +75,8 @@ export interface PressEvents {
   onPress?: (e: PressEvent) => void,
   onPressStart?: (e: PressEvent) => void,
   onPressEnd?: (e: PressEvent) => void,
-  onPressChange?: (isPressed: boolean) => void
+  onPressChange?: (isPressed: boolean) => void,
+  onPressUp?: (e: PressEvent) => void
 }
 
 export interface FocusableProps extends FocusEvents, KeyboardEvents {

--- a/packages/@react-types/shared/src/inputs.d.ts
+++ b/packages/@react-types/shared/src/inputs.d.ts
@@ -21,10 +21,7 @@ export interface InputBase extends FocusableProps {
    * Often paired with the `necessityIndicator` prop to add a visual indicator to the input.
    */
   isRequired?: boolean,
-  /** 
-   * Whether the input should display its "valid" or "invalid" visual styling. 
-   * @default "valid"
-   */
+  /** Whether the input should display its "valid" or "invalid" visual styling. */
   validationState?: ValidationState,
   /** Whether the input can be selected but not changed by the user. */
   isReadOnly?: boolean


### PR DESCRIPTION
This is an initial version of the `Picker` component, along with the `useSelect` aria hook and `useSelectState` stately hook. See individual commit messages for some details about related changes.

A few notable new features:

* You can type to select when focus is on the field button, without opening the menu. This is similar to how a native `<select>` works.
* The menu opens on mouse down rather than on mouse up, and you can drag over an item with your mouse still down and release to select that item. Also similar to how a native `<select>` works.

I also had to refactor ListBox into ListBoxBase so that Picker can access it directly. This is to allow the collection state and the layout to be held in the Picker rather than the ListBox. This enables type to select without opening the menu, along with layout info to be cached rather than recomputed every time the ListBox is mounted.

There is still a bunch left to do, including tests and a few more features and bug fixes. Just wanted to get an initial implementation in first and iterate on that rather than a giant PR.