### PR TITLE
Dialog docs v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "plop": "plop",
     "chromatic": "CHROMATIC_APP_CODE=x8ktlved8wd chromatic test --build-script-name build-storybook",
     "merge:css": "babel-node --presets @babel/env ./scripts/merge-spectrum-css.js",
-    "start:docs": "PARCEL_WORKER_BACKEND=process parcel 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx' --no-cache",
-    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'"
+    "start:docs": "PARCEL_WORKER_BACKEND=process parcel 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'",
+    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'  --no-scope-hoist"
   },
   "workspaces": [
     "packages/*/*"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "chromatic": "CHROMATIC_APP_CODE=x8ktlved8wd chromatic test --build-script-name build-storybook",
     "merge:css": "babel-node --presets @babel/env ./scripts/merge-spectrum-css.js",
     "start:docs": "PARCEL_WORKER_BACKEND=process parcel 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'",
-    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'  --no-scope-hoist"
+    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx' --no-scope-hoist"
   },
   "workspaces": [
     "packages/*/*"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "plop": "plop",
     "chromatic": "CHROMATIC_APP_CODE=x8ktlved8wd chromatic test --build-script-name build-storybook",
     "merge:css": "babel-node --presets @babel/env ./scripts/merge-spectrum-css.js",
-    "start:docs": "PARCEL_WORKER_BACKEND=process parcel 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'",
-    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx' --no-scope-hoist"
+    "start:docs": "PARCEL_WORKER_BACKEND=process parcel 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx' --no-cache",
+    "build:docs": "PARCEL_WORKER_BACKEND=process parcel build 'packages/@react-spectrum/*/docs/*.mdx' 'packages/dev/docs/pages/*.mdx'"
   },
   "workspaces": [
     "packages/*/*"

--- a/packages/@react-spectrum/dialog/docs/Dialog.mdx
+++ b/packages/@react-spectrum/dialog/docs/Dialog.mdx
@@ -10,29 +10,50 @@ governing permissions and limitations under the License. -->
 import {Layout} from '@react-spectrum/docs';
 export default Layout;
 
-import docs from 'docs:@react-spectrum/COMPONENT_NAME';
+import docs from 'docs:@react-spectrum/dialog';
 import {HeaderInfo, PropTable} from '@react-spectrum/docs';
 import packageData from '../package.json';
 
 ```jsx import
-import {Component} from '@react-spectrum/COMPONENT_NAME';
+import {ActionButton, Button} from '@react-spectrum/button';
+import {Content, Footer, Header} from '@react-spectrum/view';
+import {Divider, DialogTrigger} from '@react-spectrum/divider';
+import {Dialog} from '@react-spectrum/dialog';
+import {Heading, Text} from '@react-spectrum/typography';
 ```
 
 # Component Name
 
-<p>{docs.exports.Component.description}</p>
+<p>{docs.exports.Dialog.description}</p>
 
 <HeaderInfo
   packageData={packageData}
-  componentNames={['Component']}
+  componentNames={['Dialog']}
   sourceData={[
-    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/button/'}
+    {type: 'Spectrum', url: 'https://spectrum.adobe.com/page/dialog/'}
   ]} />
 
 ## Example
 
 ```tsx example
-<Button variant="cta">Button</Button>
+<div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>
+<DialogTrigger>
+  <ActionButton>Trigger</ActionButton>
+  {(close) => (
+    <Dialog>
+      <Header><Heading>The Heading</Heading></Header>
+      <Divider />
+      <Content>
+        <Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text>
+      </Content>
+      <Footer>
+        <Button variant="secondary" onPress={close}>Cancel</Button>
+        <Button variant="cta" onPress={close}>Confirm</Button>
+      </Footer>
+    </Dialog>
+  )}
+</DialogTrigger>
+</div>
 ```
 
 ## Content
@@ -65,7 +86,7 @@ import {Component} from '@react-spectrum/COMPONENT_NAME';
 
 ## Props
 
-<PropTable component={docs.exports.Component} links={docs.links} />
+<PropTable component={docs.exports.Dialog} links={docs.links} />
 
 ## Visual Options
 

--- a/packages/@react-spectrum/dialog/docs/Dialog.mdx
+++ b/packages/@react-spectrum/dialog/docs/Dialog.mdx
@@ -22,7 +22,7 @@ import {Divider} from '@react-spectrum/divider';
 import {Heading, Text} from '@react-spectrum/typography';
 ```
 
-# Component Name
+# Dialog
 
 <p>{docs.exports.Dialog.description}</p>
 

--- a/packages/@react-spectrum/dialog/docs/Dialog.mdx
+++ b/packages/@react-spectrum/dialog/docs/Dialog.mdx
@@ -17,8 +17,8 @@ import packageData from '../package.json';
 ```jsx import
 import {ActionButton, Button} from '@react-spectrum/button';
 import {Content, Footer, Header} from '@react-spectrum/view';
-import {Divider, DialogTrigger} from '@react-spectrum/divider';
-import {Dialog} from '@react-spectrum/dialog';
+import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
+import {Divider} from '@react-spectrum/divider';
 import {Heading, Text} from '@react-spectrum/typography';
 ```
 
@@ -36,7 +36,6 @@ import {Heading, Text} from '@react-spectrum/typography';
 ## Example
 
 ```tsx example
-<div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>
 <DialogTrigger>
   <ActionButton>Trigger</ActionButton>
   {(close) => (
@@ -53,7 +52,6 @@ import {Heading, Text} from '@react-spectrum/typography';
     </Dialog>
   )}
 </DialogTrigger>
-</div>
 ```
 
 ## Content

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -22,6 +22,10 @@ import {SpectrumBaseDialogProps, SpectrumDialogProps} from '@react-types/dialog'
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';
 import {useDialog, useModalDialog} from '@react-aria/dialog';
 
+/**
+ * Dialogs display important information that users need to acknowledge.
+ * They appear over the interface and block further interactions.
+ */
 export function Dialog(props: SpectrumDialogProps) {
   props = useSlotProps(props);
   let {

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -43,7 +43,7 @@ export interface SpectrumDialogProps extends DOMProps, StyleProps {
    * see [slots](./Slots.html).
    */
   slots?: Slots,
-  /** How size of the Dialog will be determined. */
+  /** The size of the Dialog. Only applies to "modal" type Dialogs. */
   size?: 'S' | 'M' | 'L' | 'fullscreen' | 'fullscreenTakeover',
   /** Whether the Dialog is [dismissable](#dismissable). */
   isDismissable?: boolean,

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -36,10 +36,20 @@ export interface SpectrumBaseDialogProps extends HTMLAttributes<HTMLElement> {
 }
 
 export interface SpectrumDialogProps extends DOMProps, StyleProps {
+  /** The contents as semantic elements to display in the dialog. */
   children: ReactNode,
+  /**
+   * [Slots](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)
+   * defining semantic names for dialog children.
+   */
   slots?: Slots,
+  /** How wide the dialog should be or make fullscreen. */
   size?: 'S' | 'M' | 'L' | 'fullscreen' | 'fullscreenTakeover',
-  isDismissable?: boolean, // adds close button and enables clicking on background
+  /**
+   * Whether the dialog adds a close button (AlertButton with a CrossLarge icon).
+   * Weather the dialog is dismissable by clicking on background.
+   */
+  isDismissable?: boolean,
   onDismiss?: () => void,
   role?: 'dialog' | 'alertdialog'
 }

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -46,8 +46,8 @@ export interface SpectrumDialogProps extends DOMProps, StyleProps {
   /** How wide the dialog should be or make fullscreen. */
   size?: 'S' | 'M' | 'L' | 'fullscreen' | 'fullscreenTakeover',
   /**
-   * Whether the dialog adds a close button (AlertButton with a CrossLarge icon).
-   * Weather the dialog is dismissable by clicking on background.
+   * Whether the dialog adds a close button.
+   * Whether the dialog is dismissable by clicking on background.
    */
   isDismissable?: boolean,
   onDismiss?: () => void,

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -39,8 +39,7 @@ export interface SpectrumDialogProps extends DOMProps, StyleProps {
   /** The contents of the Dialog. */
   children: ReactNode,
   /**
-   * Object containing the props that each Dialog child receives,
-   * see [slots](./Slots.html).
+   * Replaces the default slots used within Dialog.
    */
   slots?: Slots,
   /** The size of the Dialog. Only applies to "modal" type Dialogs. */

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -36,19 +36,16 @@ export interface SpectrumBaseDialogProps extends HTMLAttributes<HTMLElement> {
 }
 
 export interface SpectrumDialogProps extends DOMProps, StyleProps {
-  /** The contents as semantic elements to display in the dialog. */
+  /** The contents of the dialog. */
   children: ReactNode,
   /**
-   * [Slots](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot)
-   * defining semantic names for dialog children.
+   * Object containing the props that each Dialog child receives,
+   * see [slots](./Slots.html).
    */
   slots?: Slots,
   /** How wide the dialog should be or make fullscreen. */
   size?: 'S' | 'M' | 'L' | 'fullscreen' | 'fullscreenTakeover',
-  /**
-   * Whether the dialog adds a close button.
-   * Whether the dialog is dismissable by clicking on background.
-   */
+  /** Whether the dialog is [dismissable](#dismissable). */
   isDismissable?: boolean,
   onDismiss?: () => void,
   role?: 'dialog' | 'alertdialog'

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -36,16 +36,16 @@ export interface SpectrumBaseDialogProps extends HTMLAttributes<HTMLElement> {
 }
 
 export interface SpectrumDialogProps extends DOMProps, StyleProps {
-  /** The contents of the dialog. */
+  /** The contents of the Dialog. */
   children: ReactNode,
   /**
    * Object containing the props that each Dialog child receives,
    * see [slots](./Slots.html).
    */
   slots?: Slots,
-  /** How wide the dialog should be or make fullscreen. */
+  /** How size of the Dialog will be determined. */
   size?: 'S' | 'M' | 'L' | 'fullscreen' | 'fullscreenTakeover',
-  /** Whether the dialog is [dismissable](#dismissable). */
+  /** Whether the Dialog is [dismissable](#dismissable). */
   isDismissable?: boolean,
   onDismiss?: () => void,
   role?: 'dialog' | 'alertdialog'

--- a/packages/dev/docs/src/template.mdx
+++ b/packages/dev/docs/src/template.mdx
@@ -39,14 +39,6 @@ import {Component} from '@react-spectrum/COMPONENT_NAME';
 
 *If the component has a children prop that accepts any type of content (e.g. `ReactNode`), include this section. Please include a note about how to internationalize the content.*
 
-### Accessibility
-
-*If the component has accessibility needs, include this section.*
-
-### Internationalization
-
-*If this component has content, cover how to internationalize the content, include this section.*
-
 ## Value
 
 *If the component displays or allows a user to input a value, include this section.*


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1536

Initial version of the dialog docs.
Added a dialog documentation page, with valid links and an example. It will have followup work for the remaining parts.
Added typescript interface JSDocs.

## 📝 Test Instructions:
review dialog documentation page 

## 🧢 Your Team:
RSP