### PR TITLE
RSP-1572 Update Menu accessibility spec with groups

### DIFF
--- a/specs/accessibility/List.mdx
+++ b/specs/accessibility/List.mdx
@@ -92,6 +92,10 @@ Having selection follow focus can be very helpful in some circumstances and can 
     - All options that are not selected have [`aria-selected`](https://www.w3.org/TR/wai-aria-1.1/#aria-selected) set to `false`.
 - If the complete set of available options is not present in the DOM due to dynamic loading as the user scrolls, their [`aria-setsize`](https://www.w3.org/TR/wai-aria-1.1/#aria-setsize) and [`aria-posinset`](https://www.w3.org/TR/wai-aria-1.1/#aria-posinset) attributes are set appropriately.
 - If options are arranged horizontally, the element with role `listbox` has [`aria-orientation`](https://www.w3.org/TR/wai-aria-1.1/#aria-orientation) set to `horizontal`. The default value of `aria-orientation` for `listbox` is `vertical`.
+- Options in a listbox may be divided into groups, like an [`optgroup`](https://www.w3.org/TR/html52/sec-forms.html#the-optgroup-element) in an HTML `select`:
+    - To define a labelled group, options should be contained within an element with the role of [`group`](https://www.w3.org/TR/wai-aria-1.1/#group).
+    The group element should be labelled using [`aria-label`](https://www.w3.org/TR/wai-aria-1.1/#aria-label) or with [`aria-labelledby`](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby) referencing a visible text element heading, included as a child of the group, by `id`.
+    Since a listbox does not normally expect a text node or heading as a descendant, this visible text element heading should be removed from the accessibility tree as a standalone accessibility object using [`aria-hidden`](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden).
 
 ## v2 Implementation details
 In React Spectrum, `List` does not provide for dynamic item selection when `onSelect` is called on a `ListItem` instance. The `selected` state is a controlled prop on `ListItem`.  The [`SelectList`](https://react-spectrum.corp.adobe.com/components/SelectList), [`Select`](https://react-spectrum.corp.adobe.com/components/Select), and [`Menu`](https://react-spectrum.corp.adobe.com/components/Menu) components implement dynamic item selection, and are more likely to be used as standalone components.

--- a/specs/accessibility/Menu.mdx
+++ b/specs/accessibility/Menu.mdx
@@ -123,7 +123,12 @@ When reading the following descriptions, also keep in mind that:
   - Each item in the menu has `tabindex` set to `-1`, except in a menubar, where the first item has `tabindex` set to 0.
 - When a [`menuitemcheckbox`](https://www.w3.org/TR/wai-aria-1.1/#menuitemcheckbox) or [`menuitemradio`](https://www.w3.org/TR/wai-aria-1.1/#menuitemradio) is checked, [`aria-checked`](https://www.w3.org/TR/wai-aria-1.1/#aria-checked) is set to `true`.
 - When a menu item is disabled, [`aria-disabled`](https://www.w3.org/TR/wai-aria-1.1/#aria-disabled) is set to true.
-- Items in a menu may be divided into groups by placing an element with a role of [separator](https://www.w3.org/TR/wai-aria-1.1/#separator) between groups. For example, this technique should be used when a menu contains a set of [`menuitemradio`](https://www.w3.org/TR/wai-aria-1.1/#menuitemradio) items.
+- Items in a menu may be divided into groups:
+    - The simplest to define a group is by placing an element with a role of [separator](https://www.w3.org/TR/wai-aria-1.1/#separator) between groups.
+    For example, this technique should be used when a menu contains a set of [`menuitemradio`](https://www.w3.org/TR/wai-aria-1.1/#menuitemradio) items.
+    - To define a labelled group, items should be contained within an element with the role of [`group`](https://www.w3.org/TR/wai-aria-1.1/#group).
+    The group element should be labelled using [`aria-label`](https://www.w3.org/TR/wai-aria-1.1/#aria-label) or with [`aria-labelledby`](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby) referencing a visible text element heading, included as a child of the group, by `id`.
+    Since a `menu` does not normally expect a text node or heading as a descendant, this visible text element heading should be removed from the accessibility tree as a standalone accessibility object using [`aria-hidden`](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden).
 - All [separators](https://www.w3.org/TR/wai-aria-1.1/#separator) should have [`aria-orientation`](https://www.w3.org/TR/wai-aria-1.1/#aria-orientation) consistent with the separator's orientation.
 - If a `menubar` has a visible label, the element with role `menubar` has [`aria-labelledby`](https://www.w3.org/TR/wai-aria-1.1/#aria-labelledby) set to a value that refers to the labelling element. Otherwise, the `menubar` element has a label provided by [`aria-label`](https://www.w3.org/TR/wai-aria-1.1/#aria-label).
 - If a `menubar` is vertically oriented, it has [`aria-orientation`](https://www.w3.org/TR/wai-aria-1.1/#aria-orientation) set to `vertical`. The default value of `aria-orientation` for a `menubar` is `horizontal`.


### PR DESCRIPTION
Update Menu and List accessibility specs to support groups.


Closes https://jira.corp.adobe.com/browse/RSP-1572

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [RSP-1572](https://jira.corp.adobe.com/browse/RSP-1572).
- Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Review accessibility specs for Menu and List under WAI-ARIA properties.

## 🧢 Your Team:

Accessibility
