### PR TITLE
Use slots for button children instead of icon prop

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -91,6 +91,7 @@ governing permissions and limitations under the License.
   .spectrum-Icon {
     max-block-size: 100%;
     flex-shrink: 0;
+    order: 0; /* always be before the label, regardless of DOM order */
   }
 }
 
@@ -119,12 +120,13 @@ governing permissions and limitations under the License.
     box-shadow: none;
   }
 
+  /* there should be space between the icon and text no matter the DOM order */ 
   .spectrum-Icon + .spectrum-Button-label {
     margin-inline-start: var(--spectrum-button-primary-text-gap);
   }
 
   .spectrum-Button-label + .spectrum-Icon {
-    margin-inline-start: calc(var(--spectrum-button-primary-text-gap) / 2);
+    margin-inline-end: var(--spectrum-button-primary-text-gap);
   }
 }
 
@@ -142,9 +144,7 @@ a.spectrum-ActionButton {
 
   height: var(--spectrum-actionbutton-height);
   min-width: var(--spectrum-actionbutton-min-width);
-
-  /* Use icon padding by default as it's smaller */
-  padding: 0 calc(var(--spectrum-actionbutton-icon-padding-x) - var(--spectrum-actionbutton-border-size));
+  padding: 0;
 
   border-width: var(--spectrum-actionbutton-border-size);
   border-radius: var(--spectrum-actionbutton-border-radius);
@@ -152,24 +152,33 @@ a.spectrum-ActionButton {
   font-size: var(--spectrum-actionbutton-text-size);
   font-weight: var(--spectrum-actionbutton-text-font-weight);
 
-  .spectrum-Icon + .spectrum-ActionButton-label {
-    /* Have icon padding on the left */
+  /* icon should always have padding at the start */
+  .spectrum-Icon {
     padding-inline-start: var(--spectrum-actionbutton-icon-padding-x);
-
-    /* Have text padding on the right */
-    padding-inline-end: calc(var(--spectrum-actionbutton-text-padding-x) - var(--spectrum-actionbutton-icon-padding-x));
   }
 
-  .spectrum-Icon--sizeS:only-child {
-    /* Position absolutely to avoid layout errors introduced by padding */
-    position: absolute;
-    top: calc(50% - calc(var(--spectrum-actionbutton-icon-size) / 2));
-    left: calc(50% - calc(var(--spectrum-actionbutton-icon-size) / 2));
+  /* label should always have padding at the end */
+  .spectrum-ActionButton-label {
+    padding-inline-end: var(--spectrum-actionbutton-text-padding-x);
   }
 
+  /* icon + text buttons should have padding between the text and icon no matter the order */
+  .spectrum-Icon + .spectrum-ActionButton-label {
+    padding-inline-start: var(--spectrum-actionbutton-icon-padding-x);
+  }
+
+  .spectrum-ActionButton-label + .spectrum-Icon {
+    padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
+  }
+
+  /* text only buttons should have padding at the start */
   .spectrum-ActionButton-label:only-child {
-    /* Add padding for text only buttons */
-    padding: 0 calc(var(--spectrum-actionbutton-text-padding-x) - var(--spectrum-actionbutton-icon-padding-x));
+    padding-inline-start: var(--spectrum-actionbutton-text-padding-x);
+  }
+
+  /* icon only buttons should have padding at the end */
+  .spectrum-Icon:only-child {
+    padding-inline-end: var(--spectrum-actionbutton-icon-padding-x);
   }
 }
 
@@ -187,6 +196,7 @@ a.spectrum-ActionButton {
 .spectrum-Button-label {
   align-self: center;
   justify-self: center;
+  order: 1; /* always be after the icon, regardless of DOM order */
 
   /* Fixes horizontal alignment of text in anchor buttons */
   text-align: center;

--- a/packages/@react-aria/utils/src/mergeProps.ts
+++ b/packages/@react-aria/utils/src/mergeProps.ts
@@ -29,6 +29,9 @@ export function mergeProps<T extends Props, U extends Props>(a: T, b: U): T & U 
     } else if (key === 'className' && typeof a.className === 'string' && typeof b.className === 'string') {
       res[key] = classNames(a.className, b.className);
 
+    } else if (key === 'UNSAFE_className' && typeof a.UNSAFE_className === 'string' && typeof b.UNSAFE_className === 'string') {
+      res[key] = classNames(a.UNSAFE_className, b.UNSAFE_className);
+
     } else if (key === 'id' && a.id && b.id) {
       res.id = mergeIds(a.id, b.id);
 

--- a/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
+++ b/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
@@ -23,6 +23,7 @@ import React from 'react';
 import RegionSelect  from '@spectrum-icons/workflow/RegionSelect';
 import Select  from '@spectrum-icons/workflow/Select';
 import {storiesOf} from '@storybook/react';
+import {Text} from '@react-spectrum/typography';
 import Undo from '@spectrum-icons/workflow/Undo';
 
 storiesOf('ActionGroup', module)
@@ -112,26 +113,26 @@ const items =
 
 const itemsWithIcons =
   [
-    {children: 'React', icon: <CheckmarkCircle />},
-    {children: 'Add', icon: <Add />},
-    {children: 'Delete', icon: <Delete />},
-    {children: 'Bell', icon: <Bell />},
-    {children: 'Camera', icon: <Camera />},
-    {children: 'Undo', icon: <Undo />}
+    {children: <><CheckmarkCircle /><Text>React</Text></>},
+    {children: <><Add /><Text>Add</Text></>},
+    {children: <><Delete /><Text>Delete</Text></>},
+    {children: <><Bell /><Text>Bell</Text></>},
+    {children: <><Camera /><Text>Camera</Text></>},
+    {children: <><Undo /><Text>Undo</Text></>}
   ];
 
 const toolIcons =
   [
-    {icon: <Brush />},
-    {icon: <Select />},
-    {icon: <RegionSelect />}
+    {children: <Brush />},
+    {children: <Select />},
+    {children: <RegionSelect />}
   ];
 
 const toolIconsAffordance =
   [
-    {icon: <Brush />, holdAffordance: true},
-    {icon: <Select />, holdAffordance: true},
-    {icon: <RegionSelect />, holdAffordance: true}
+    {children: <Brush />, holdAffordance: true},
+    {children: <Select />, holdAffordance: true},
+    {children: <RegionSelect />, holdAffordance: true}
   ];
 
 function render(props = {}, items: any = itemsWithIcons) {

--- a/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
+++ b/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
@@ -12,7 +12,6 @@
 
 import {ActionButton} from '@react-spectrum/button';
 import {ActionGroup} from '../';
-import Brush from '@spectrum-icons/workflow/Brush';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -279,7 +278,7 @@ describe('ActionGroup', function () {
     let {getByTestId} = render(
       <Provider theme={theme} locale="de-DE">
         <ActionGroup>
-          <ActionButton UNSAFE_className={'test-class'} icon={<Brush />} data-testid="button-1">Click me</ActionButton>
+          <ActionButton UNSAFE_className={'test-class'} data-testid="button-1">Click me</ActionButton>
         </ActionGroup>
       </Provider>
     );

--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -176,9 +176,9 @@ const Menu = React.forwardRef((props: MenuProps) => {
     <DialogTrigger type="popover">
       <ActionButton
         aria-label="…"
-        icon={<FolderBreadcrumb />}
         isDisabled={isDisabled}
         isQuiet>
+        <FolderBreadcrumb />
         {label && React.cloneElement(label, {isCurrent: undefined})}
       </ActionButton>
       <Dialog>

--- a/packages/@react-spectrum/button/docs/Button.mdx
+++ b/packages/@react-spectrum/button/docs/Button.mdx
@@ -42,9 +42,16 @@ Buttons can have a label, and icon, or both. An icon is provided by passing an i
 A visible label can be provided by passing children.
 
 ```tsx example
+import {Text} from '@react-spectrum/typography';
+
 <Button variant="primary">Label only</Button>
-<Button variant="primary" icon={<Bell />}>Icon + Label</Button>
-<Button variant="primary" icon={<Bell />} aria-label="Icon only" />
+<Button variant="primary">
+  <Bell />
+  <Text>Icon + Label</Text>
+</Button>
+<Button variant="primary" aria-label="Icon only">
+  <Bell />
+</Button>
 ```
 
 ### Accessibility

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -32,6 +32,7 @@
     "@react-aria/button": "^3.0.0-rc.1",
     "@react-aria/focus": "^3.0.0-rc.1",
     "@react-aria/utils": "^3.0.0-rc.1",
+    "@react-spectrum/typography": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-rc.1",
     "@react-types/button": "^3.0.0-rc.1",
     "@react-types/shared": "^3.0.0-rc.1",

--- a/packages/@react-spectrum/button/src/ActionButton.tsx
+++ b/packages/@react-spectrum/button/src/ActionButton.tsx
@@ -10,13 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
 import CornerTriangle from '@spectrum-icons/ui/CornerTriangle';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
-import React, {cloneElement} from 'react';
+import React from 'react';
 import {SpectrumActionButtonProps} from '@react-types/button';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
+import {Text} from '@react-spectrum/typography';
 import {useButton} from '@react-aria/button';
 import {useProviderProps} from '@react-spectrum/provider';
 
@@ -29,7 +30,6 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef) {
     isSelected,
     isDisabled,
     isEmphasized,
-    icon,
     children,
     holdAffordance,
     autoFocus,
@@ -66,18 +66,20 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef) {
             groupClassName
           )
         }>
-        {icon && cloneElement(
-          icon,
-          {
-            size: 'S',
-            UNSAFE_className: classNames(
-              styles,
-              'spectrum-Icon',
-              icon.props.UNSAFE_className
-            )
-          }
-        )}
-        <span className={classNames(styles, 'spectrum-ActionButton-label')}>{children}</span>
+        <SlotProvider
+          slots={{
+            icon: {
+              size: 'S',
+              UNSAFE_className: classNames(styles, 'spectrum-Icon')
+            },
+            text: {
+              UNSAFE_className: classNames(styles, 'spectrum-ActionButton-label')
+            }
+          }}>
+          {typeof children === 'string' 
+            ? <Text>{children}</Text> 
+            : children}
+        </SlotProvider>
         {holdAffordance &&
           <CornerTriangle UNSAFE_className={classNames(styles, 'spectrum-ActionButton-hold')} />
         }

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -10,12 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
-import React, {cloneElement} from 'react';
+import React from 'react';
 import {SpectrumButtonProps} from '@react-types/button';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
+import {Text} from '@react-spectrum/typography';
 import {useButton} from '@react-aria/button';
 import {useProviderProps} from '@react-spectrum/provider';
 
@@ -33,7 +34,6 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
     variant,
     isQuiet,
     isDisabled,
-    icon,
     autoFocus,
     ...otherProps
   } = props;
@@ -66,18 +66,20 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
             styleProps.className
           )
         }>
-        {icon && cloneElement(
-          icon,
-          {
-            size: 'S',
-            UNSAFE_className: classNames(
-              styles,
-              'spectrum-Icon',
-              icon.props && icon.props.UNSAFE_className
-            )
-          }
-        )}
-        <span className={classNames(styles, 'spectrum-Button-label')}>{children}</span>
+        <SlotProvider
+          slots={{
+            icon: {
+              size: 'S',
+              UNSAFE_className: classNames(styles, 'spectrum-Icon')
+            },
+            text: {
+              UNSAFE_className: classNames(styles, 'spectrum-Button-label')
+            }
+          }}>
+          {typeof children === 'string' 
+            ? <Text>{children}</Text> 
+            : children}
+        </SlotProvider>
       </ElementType>
     </FocusRing>
   );

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -11,11 +11,11 @@
  */
 
 import {ButtonProps} from '@react-types/button';
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
-import React, {cloneElement, ReactElement} from 'react';
+import React from 'react';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {useButton} from '@react-aria/button';
 
@@ -33,7 +33,6 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
     isQuiet,
     isDisabled,
     validationState,
-    icon,
     children,
     autoFocus,
     ...otherProps
@@ -60,8 +59,15 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
             styleProps.className
           )
         }>
-        {cloneElement(icon, {size: 'S'})}
-        <span className={classNames(styles, 'spectrum-Button-label')}>{children}</span>
+        <SlotProvider
+          slots={{
+            icon: {
+              size: 'S',
+              UNSAFE_className: classNames(styles, 'spectrum-Icon')
+            }
+          }}>
+          {children}
+        </SlotProvider>
       </ElementType>
     </FocusRing>
   );

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -21,7 +21,6 @@ import {useButton} from '@react-aria/button';
 
 interface FieldButtonProps extends ButtonProps {
   isQuiet?: boolean,
-  icon?: ReactElement,
   validationState?: 'valid' | 'invalid'
 }
 

--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -39,8 +39,8 @@ storiesOf('Button/ActionButton', module)
           onPressStart={action('pressstart')}
           onPressEnd={action('pressend')}
           isDisabled>
-          <Add />
           <Text>Disabled</Text>
+          <Add />
         </ActionButton>
       </div>
     )

--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -15,6 +15,7 @@ import {ActionButton} from '../';
 import Add from '@spectrum-icons/workflow/Add';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
+import {Text} from '@react-spectrum/typography';
 
 storiesOf('Button/ActionButton', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
@@ -24,11 +25,45 @@ storiesOf('Button/ActionButton', module)
   )
   .add(
     'icon',
-    () => render({icon: <Add />})
+    () => (
+      <div>
+        <ActionButton
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}>
+          <Add />
+          <Text>Default</Text>
+        </ActionButton>
+        <ActionButton
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isDisabled>
+          <Add />
+          <Text>Disabled</Text>
+        </ActionButton>
+      </div>
+    )
   )
   .add(
     'icon only',
-    () => renderNoText({icon: <Add />})
+    () => (
+      <div>
+        <ActionButton
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}>
+          <Add />
+        </ActionButton>
+        <ActionButton
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isDisabled>
+          <Add />
+        </ActionButton>
+      </div>
+    )
   )
   .add(
     'holdAffordance',
@@ -81,24 +116,6 @@ function render(props = {}) {
         {...props}>
         Disabled
       </ActionButton>
-    </div>
-  );
-}
-
-function renderNoText(props = {}) {
-  return (
-    <div>
-      <ActionButton
-        onPress={action('press')}
-        onPressStart={action('pressstart')}
-        onPressEnd={action('pressend')}
-        {...props} />
-      <ActionButton
-        onPress={action('press')}
-        onPressStart={action('pressstart')}
-        onPressEnd={action('pressend')}
-        isDisabled
-        {...props} />
     </div>
   );
 }

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -15,6 +15,7 @@ import Bell from '@spectrum-icons/workflow/Bell';
 import {Button} from '../';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
+import {Text} from '@react-spectrum/typography';
 
 storiesOf('Button', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
@@ -24,7 +25,36 @@ storiesOf('Button', module)
   )
   .add(
     'with icon',
-    () => render({icon: <Bell />, variant: 'primary'})
+    () => (
+      <div>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          variant="primary">
+          <Bell />
+          <Text>Default</Text>
+        </Button>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isDisabled
+          variant="primary">
+          <Bell />
+          <Text>Disabled</Text>
+        </Button>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isQuiet
+          variant="primary">
+          <Bell />
+          <Text>Quiet</Text>
+        </Button>
+      </div>
+    )
   )
   .add(
     'variant: overBackground',

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -41,8 +41,8 @@ storiesOf('Button', module)
           onPressEnd={action('pressend')}
           isDisabled
           variant="primary">
-          <Bell />
           <Text>Disabled</Text>
+          <Bell />
         </Button>
         <Button
           onPress={action('press')}

--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -16,7 +16,6 @@ import React from 'react';
 import {testSlotsAPI, triggerPress} from '@react-spectrum/test-utils';
 import V2Button from '@react/react-spectrum/Button';
 
-let FakeIcon = (props) => <svg {...props}><path d="M 10,150 L 70,10 L 130,150 z" /></svg>;
 /**
  * Logic Button has no tests outside of this file because functionally it is identical
  * to Button right now. The only difference is the class names, and since we aren't

--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -162,18 +162,6 @@ describe('Button', function () {
   // the spec https://www.w3.org/TR/WCAG20-TECHS/SCR35.html
 
   it.each`
-    Component      | props
-    ${ActionButton}| ${{icon: <FakeIcon role="status" />}}
-    ${Button}      | ${{icon: <FakeIcon role="status" />}}
-    ${V2Button}    | ${{icon: <FakeIcon role="status" />}}
-  `('v2/3 parity accepts an icon as a prop', function ({Component, props}) {
-    let {getByRole} = render(<Component {...props} />);
-
-    let icon = getByRole('status');
-    expect(icon).not.toBeNull();
-  });
-
-  it.each`
     Name                | Component
     ${'ActionButton'}   | ${ActionButton}
     ${'Button'}         | ${Button}

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -72,14 +72,16 @@ export function CalendarBase(props: CalendarBaseProps) {
           {...prevButtonProps}
           UNSAFE_className={classNames(styles, 'spectrum-Calendar-prevMonth')}
           isQuiet
-          isDisabled={props.isDisabled}
-          icon={direction === 'rtl' ? <ChevronRight /> : <ChevronLeft />} />
+          isDisabled={props.isDisabled}>
+          {direction === 'rtl' ? <ChevronRight /> : <ChevronLeft />}
+        </ActionButton>
         <ActionButton
           {...nextButtonProps}
           UNSAFE_className={classNames(styles, 'spectrum-Calendar-nextMonth')}
           isQuiet
-          isDisabled={props.isDisabled}
-          icon={direction === 'rtl' ? <ChevronLeft /> : <ChevronRight />} />
+          isDisabled={props.isDisabled}>
+          {direction === 'rtl' ? <ChevronLeft /> : <ChevronRight />}
+        </ActionButton>
       </div>
       <div
         {...calendarBodyProps}

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -98,8 +98,9 @@ export function DatePicker(props: SpectrumDatePickerProps) {
             UNSAFE_className={classNames(styles, 'spectrum-FieldButton')}
             isQuiet={isQuiet}
             validationState={state.validationState}
-            icon={<CalendarIcon />}
-            isDisabled={isDisabled || isReadOnly} />
+            isDisabled={isDisabled || isReadOnly}>
+            <CalendarIcon />
+          </FieldButton>
           <Dialog UNSAFE_className={classNames(datepickerStyles, 'react-spectrum-Datepicker-dialog')} {...dialogProps}>
             <Calendar
               autoFocus

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -117,8 +117,9 @@ export function DateRangePicker(props: SpectrumDateRangePickerProps) {
             UNSAFE_className={classNames(styles, 'spectrum-FieldButton')}
             isQuiet={isQuiet}
             validationState={state.validationState}
-            icon={<CalendarIcon />}
-            isDisabled={isDisabled || isReadOnly} />
+            isDisabled={isDisabled || isReadOnly}>
+            <CalendarIcon />
+          </FieldButton>
           <Dialog UNSAFE_className={classNames(datepickerStyles, 'react-spectrum-Datepicker-dialog')} {...dialogProps}>
             <RangeCalendar
               autoFocus

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -57,7 +57,15 @@ export function Dialog(props: SpectrumDialogProps) {
     return (
       <ModalDialog {...allProps} size={size}>
         {children}
-        {isDismissable && <ActionButton slot="closeButton" isQuiet icon={<CrossLarge size="L" />} aria-label="dismiss" onPress={onDismiss} />}
+        {isDismissable && 
+          <ActionButton 
+            slot="closeButton"
+            isQuiet
+            aria-label="dismiss"
+            onPress={onDismiss}>
+            <CrossLarge size="L" />
+          </ActionButton>
+        }
       </ModalDialog>
     );
   }

--- a/packages/@react-spectrum/divider/stories/Divider.stories.tsx
+++ b/packages/@react-spectrum/divider/stories/Divider.stories.tsx
@@ -59,9 +59,9 @@ storiesOf('Divider', module)
 function renderVertical(props = {}) {
   return (
     <section style={{display: 'flex'}}>
-      <ActionButton icon={<Properties />} aria-label="Properties" isQuiet />
+      <ActionButton aria-label="Properties" isQuiet><Properties /></ActionButton>
       <Divider orientation="vertical" {...props} />
-      <ActionButton icon={<Select />} aria-label="Select" isQuiet />
+      <ActionButton aria-label="Select" isQuiet><Select /></ActionButton>
     </section>
   );
 }

--- a/packages/@react-spectrum/layout/src/Grid.tsx
+++ b/packages/@react-spectrum/layout/src/Grid.tsx
@@ -14,7 +14,7 @@ import {
   classNames,
   filterDOMProps,
   gridStyleProps,
-  SlotContext,
+  SlotProvider,
   useSlotProps,
   useStyleProps
 } from '@react-spectrum/utils';
@@ -35,9 +35,9 @@ export const Grid = React.forwardRef((props: GridProps, ref: RefObject<HTMLEleme
 
   return (
     <div {...filterDOMProps(otherProps)} {...styleProps} ref={ref} className={classNames({}, styleProps.className, slots && slots.container && slots.container.UNSAFE_className)}>
-      <SlotContext.Provider value={slots}>
+      <SlotProvider slots={slots}>
         {children}
-      </SlotContext.Provider>
+      </SlotProvider>
     </div>
   );
 });

--- a/packages/@react-spectrum/layout/stories/Grid.stories.tsx
+++ b/packages/@react-spectrum/layout/stories/Grid.stories.tsx
@@ -41,7 +41,7 @@ function render(props:GridProps) {
       <Header slot="title">
         <Flex justifyContent="space-between" alignItems="center">
           <Heading>Thor Odinson</Heading>
-          <ActionButton isQuiet icon={<More />} />
+          <ActionButton isQuiet><More /></ActionButton>
         </Flex>
       </Header>
       <Divider size="S" />

--- a/packages/@react-spectrum/utils/src/Slots.tsx
+++ b/packages/@react-spectrum/utils/src/Slots.tsx
@@ -11,9 +11,9 @@
  */
 
 import {mergeProps} from '@react-aria/utils';
-import React, {useContext} from 'react';
+import React, {useContext, useMemo} from 'react';
 
-export let SlotContext = React.createContext(null);
+let SlotContext = React.createContext(null);
 
 export function useSlotProps(props: any, defaultSlot?: string): any {
   let slot = props.slot || defaultSlot;
@@ -26,6 +26,26 @@ export function cssModuleToSlots(cssModule) {
     acc[slot] = {UNSAFE_className: cssModule[slot]};
     return acc;
   }, {});
+}
+
+export function SlotProvider(props) {
+  let parentSlots = useContext(SlotContext) || {};
+  let {slots = {}, children} = props;
+
+  // Merge props for each slot from parent context and props
+  let value = useMemo(() => 
+    Object.keys(parentSlots)
+      .concat(Object.keys(slots))
+      .reduce((o, p) => ({
+        ...o,
+        [p]: mergeProps(parentSlots[p] || {}, slots[p] || {})}), {})
+      , [parentSlots, slots]);
+
+  return (
+    <SlotContext.Provider value={value}>
+      {children}
+    </SlotContext.Provider>
+  );
 }
 
 export function ClearSlots(props) {

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -11,7 +11,7 @@
  */
 
 import {DOMProps, FocusableProps, HoverEvents, PressEvents, StyleProps} from '@react-types/shared';
-import {JSXElementConstructor, ReactElement, ReactNode} from 'react';
+import {JSXElementConstructor, ReactNode} from 'react';
 
 export interface ButtonProps extends DOMProps, StyleProps, PressEvents, HoverEvents, FocusableProps {
   /** Whether the button is disabled */
@@ -30,8 +30,6 @@ export interface ButtonProps extends DOMProps, StyleProps, PressEvents, HoverEve
 }
 
 export interface SpectrumButtonProps extends ButtonProps {
-  /** An icon to display in the button */
-  icon?: ReactElement,
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */
   variant: 'cta' | 'overBackground' | 'primary' | 'secondary' | 'negative',
   /** Whether the button should be displayed with a quiet style. */
@@ -39,7 +37,6 @@ export interface SpectrumButtonProps extends ButtonProps {
 }
 
 export interface SpectrumActionButtonProps extends ButtonProps {
-  icon?: ReactElement,
   isQuiet?: boolean,
   isSelected?: boolean,
   isEmphasized?: boolean,

--- a/packages/dev/docs/src/client.js
+++ b/packages/dev/docs/src/client.js
@@ -95,7 +95,9 @@ function Hamburger() {
   }, []);
 
   return (
-    <ActionButton icon={<ShowMenu />} onPress={onPress} />
+    <ActionButton onPress={onPress}>
+      <ShowMenu />
+    </ActionButton>
   );
 }
 

--- a/specs/api/Button.md
+++ b/specs/api/Button.md
@@ -18,13 +18,11 @@ interface ButtonBase extends DOMProps, StyleProps, PressEvents, FocusableProps {
 }
 
 interface Button extends ButtonBase {
-  icon?: ReactElement,
   variant: 'cta' | 'overBackground' | 'primary' | 'secondary' | 'negative', // no default, must choose
   isQuiet?: boolean
 }
 
 interface ActionButton extends ButtonBase {
-  icon?: ReactElement,
   isQuiet?: boolean,
   isSelected?: boolean,
   holdAffordance?: boolean,


### PR DESCRIPTION
This removes the `icon` prop from button components and uses slots to accept an icon and a label (via `<Text>`) as children. If a string is passed, it is automatically wrapped in `<Text>` so it gets the proper label class name.

One question is whether we need to switch to CSS Grid for this so that the order of the children doesn't affect the layout. @snowystinger thoughts?