### PR TITLE
Fixing ProgressBar Indeterminate Animation

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/accordion/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/accordion/index.css
@@ -98,8 +98,8 @@ governing permissions and limitations under the License.
 
       position: absolute;
       left: 0;
-      top: calc(-1 * var(--spectrum-accordion-item-border-size));
-      bottom: calc(-1 * var(--spectrum-accordion-item-border-size));
+      top: calc(var(--spectrum-accordion-item-border-size) * -1);
+      bottom: calc(var(--spectrum-accordion-item-border-size) * -1);
 
       width: var(--spectrum-accordion-item-border-size-key-focus);
     }

--- a/packages/@adobe/spectrum-css-temp/components/barloader/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/barloader/index.css
@@ -102,7 +102,7 @@ governing permissions and limitations under the License.
 
 @keyframes indeterminate-loop-ltr {
   from {
-    transform: translate(calc(-1 * var(--spectrum-barloader-large-indeterminate-fill-width)));
+    transform: translate(calc(var(--spectrum-barloader-large-indeterminate-fill-width) * -1));
   }
   to {
     transform: translate(var(--spectrum-barloader-large-width));
@@ -114,6 +114,6 @@ governing permissions and limitations under the License.
     transform: translate(var(--spectrum-barloader-large-width));
   }
   to {
-    transform: translate(calc(-1 * var(--spectrum-barloader-large-width)));
+    transform: translate(calc(var(--spectrum-barloader-large-width) * -1));
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -180,7 +180,7 @@ a.spectrum-ActionButton {
 }
 
 [dir='rtl'] .spectrum-ActionButton-hold {
-  transform: rotate(90deg); 
+  transform: rotate(90deg);
 }
 
 .spectrum-ActionButton-label,
@@ -350,8 +350,8 @@ a.spectrum-ActionButton {
   }
 
   &.spectrum-ActionButton + .spectrum-ActionButton {
-    margin-inline-start: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-    margin-inline-end: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
+    margin-inline-start: calc(var(--spectrum-actionbutton-border-size) * -1 / 2);
+    margin-inline-end: calc(var(--spectrum-actionbutton-border-size) * -1 / 2);
   }
 
   &.spectrum-ActionButton {
@@ -360,13 +360,13 @@ a.spectrum-ActionButton {
     &:first-child {
       border-start-start-radius: var(--spectrum-actionbutton-border-radius);
       border-end-start-radius: var(--spectrum-actionbutton-border-radius);
-      margin-inline-end: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
+      margin-inline-end: calc(var(--spectrum-actionbutton-border-size) * -1 / 2);
     }
 
     &:last-child {
       border-start-end-radius: var(--spectrum-actionbutton-border-radius);
       border-end-end-radius: var(--spectrum-actionbutton-border-radius);
-      margin-inline-start: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
+      margin-inline-start: calc(var(--spectrum-actionbutton-border-size) * -1 / 2);
       margin-inline-end: 0;
     }
   }

--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -142,7 +142,7 @@ governing permissions and limitations under the License.
 
   /* this is kinda dumb, but needed for the keyboard focus rings so they don't get clipped. is there a better way to treat this */
   padding: 0 var(--spectrum-global-dimension-size-25);
-  margin: 0 calc(-1 * var(--spectrum-global-dimension-size-25));
+  margin: 0 calc(var(--spectrum-global-dimension-size-25) * -1);
 }
 
 

--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -132,5 +132,5 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-Dropdown-popover--quiet {
-  margin-left: calc(-1 * calc(var(--spectrum-dropdown-quiet-popover-offset-x) + var(--spectrum-popover-border-size)));
+  margin-left: calc(calc(var(--spectrum-dropdown-quiet-popover-offset-x) + var(--spectrum-popover-border-size)) * -1);
 }

--- a/packages/@adobe/spectrum-css-temp/components/dropindicator/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropindicator/index.css
@@ -31,15 +31,15 @@ governing permissions and limitations under the License.
 
   &:before,
   &:after {
-    top: calc(-1 * var(--spectrum-dropindicator-circle-size) / 2 + var(--spectrum-dropindicator-border-size) / 2);
+    top: calc(var(--spectrum-dropindicator-circle-size) * -1 / 2 + var(--spectrum-dropindicator-border-size) / 2);
   }
 
   &:before {
-    left: calc(-1 * var(--spectrum-dropindicator-circle-size));
+    left: calc(var(--spectrum-dropindicator-circle-size) * -1);
   }
 
   &:after {
-    right: calc(-1 * var(--spectrum-dropindicator-circle-size));
+    right: calc(var(--spectrum-dropindicator-circle-size) * -1);
   }
 }
 
@@ -49,14 +49,14 @@ governing permissions and limitations under the License.
 
   &:before,
   &:after {
-    left: calc(-1 * var(--spectrum-dropindicator-circle-size) / 2 + var(--spectrum-dropindicator-border-size) / 2);
+    left: calc(var(--spectrum-dropindicator-circle-size) * -1 / 2 + var(--spectrum-dropindicator-border-size) / 2);
   }
 
   &:before {
-    top: calc(-1 * var(--spectrum-dropindicator-circle-size));
+    top: calc(var(--spectrum-dropindicator-circle-size) * -1);
   }
 
   &:after {
-    bottom: calc(-1 * var(--spectrum-dropindicator-circle-size));
+    bottom: calc(var(--spectrum-dropindicator-circle-size) * -1);
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/overlay/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/overlay/index.css
@@ -41,7 +41,7 @@ governing permissions and limitations under the License.
 }
 
 %spectrum-overlay--top--open {
-  transform: translateY(calc(-1 * var(--spectrum-overlay-animation-distance)));
+  transform: translateY(calc(var(--spectrum-overlay-animation-distance) * -1));
 }
 
 %spectrum-overlay--right--open {
@@ -49,5 +49,5 @@ governing permissions and limitations under the License.
 }
 
 %spectrum-overlay--left--open {
-  transform: translateX(calc(-1 * var(--spectrum-overlay-animation-distance)));
+  transform: translateX(calc(var(--spectrum-overlay-animation-distance) * -1));
 }

--- a/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/searchwithin/index.css
@@ -42,7 +42,7 @@ governing permissions and limitations under the License.
 
   .spectrum-Textfield {
     flex: 1;
-    margin-left: calc(-1 * var(--spectrum-textfield-border-size)); /* hides left border */
+    margin-left: calc(var(--spectrum-textfield-border-size) * -1); /* hides left border */
     border-top-left-radius: var(--spectrum-searchwithin-border-radius);
     border-bottom-left-radius: var(--spectrum-searchwithin-border-radius);
 

--- a/packages/@adobe/spectrum-css-temp/components/slider/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/slider/index.css
@@ -419,7 +419,7 @@ governing permissions and limitations under the License.
   }
   &::after {
     left: calc(var(--spectrum-slider-tick-mark-width) * -1);
-    transform: rotate(calc(-1 * var(--spectrum-dial-min-max-tick-angles)));
+    transform: rotate(calc(var(--spectrum-dial-min-max-tick-angles) * -1));
   }
 }
 
@@ -435,7 +435,7 @@ governing permissions and limitations under the License.
   right: var(--spectrum-dial-handle-position);
   bottom: var(--spectrum-dial-handle-position);
   border-radius: var(--spectrum-dial-border-radius);
-  transform: rotate(calc(-1 * var(--spectrum-dial-min-max-tick-angles)));
+  transform: rotate(calc(var(--spectrum-dial-min-max-tick-angles) * -1));
   cursor: pointer;
   cursor: grab;
 

--- a/packages/@adobe/spectrum-css-temp/components/slider/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/slider/skin.css
@@ -119,8 +119,8 @@ governing permissions and limitations under the License.
     background-position:
       0 0,
       0 var(--spectrum-global-dimension-static-size-100),
-      var(--spectrum-global-dimension-static-size-100) calc(-1 * var(--spectrum-global-dimension-static-size-100)),
-      calc(-1 * var(--spectrum-global-dimension-static-size-100)) 0;
+      var(--spectrum-global-dimension-static-size-100) calc(var(--spectrum-global-dimension-static-size-100) * -1),
+      calc(var(--spectrum-global-dimension-static-size-100) * -1) 0;
     z-index: 0;
   }
   .spectrum-Slider-track {

--- a/packages/@adobe/spectrum-css-temp/components/splitview/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/splitview/index.css
@@ -98,7 +98,7 @@ governing permissions and limitations under the License.
     /* half of (height + vertical border - handle width) * -1 (for negative opposite) */
     top: calc(((var(--spectrum-rail-gripper-width) + (2 * var(--spectrum-rail-gripper-border-width-horizontal)) - var(--spectrum-rail-handle-width)) / 2) * -1);
 
-    transform: translate(calc(-1 * var(--spectrum-splitview-vertical-gripper-width)), 0);
+    transform: translate(calc(var(--spectrum-splitview-vertical-gripper-width) * -1), 0);
     left: var(--spectrum-splitview-vertical-gripper-width);
     width: var(--spectrum-rail-gripper-height); /* same as default height */
     height: var(--spectrum-rail-gripper-width); /* same as default width */

--- a/packages/@adobe/spectrum-css-temp/components/steplist/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/steplist/index.css
@@ -162,7 +162,7 @@ governing permissions and limitations under the License.
   width: var(--spectrum-steplist-marker-hitArea);
   height: var(--spectrum-steplist-marker-hitArea);
 
-  margin-left: calc(-1 * calc(var(--spectrum-steplist-marker-hitArea) / 2));
+  margin-left: calc(calc(var(--spectrum-steplist-marker-hitArea) / 2) * -1);
 }
 
 /* Circle step marker */
@@ -173,8 +173,8 @@ governing permissions and limitations under the License.
   position: absolute;
   top: 50%;
   left: 50%;
-  margin-top: calc(-1 * calc(var(--spectrum-steplist-marker-diameter) / 2));
-  margin-left: calc(-1 * calc(var(--spectrum-steplist-marker-diameter) / 2));
+  margin-top: calc(calc(var(--spectrum-steplist-marker-diameter) / 2) * -1);
+  margin-left: calc(calc(var(--spectrum-steplist-marker-diameter) / 2) * -1);
 
   width: var(--spectrum-steplist-marker-diameter);
   height: var(--spectrum-steplist-marker-diameter);
@@ -195,7 +195,7 @@ governing permissions and limitations under the License.
 
   box-sizing: content-box;
   width: calc(calc(var(--spectrum-steplist-step-width) * 1.5) - calc(var(--spectrum-steplist-marker-diameter) * 2));
-  bottom: calc(-1 * calc(var(--spectrum-steplist-segment-height) / 2));
+  bottom: calc(calc(var(--spectrum-steplist-segment-height) / 2) * -1);
 
   /* Default is dashed */
   border-bottom-width: var(--spectrum-steplist-segment-height);
@@ -232,7 +232,7 @@ governing permissions and limitations under the License.
     right: 0;
 
     margin-left: 0;
-    margin-right: calc(-1 * calc(var(--spectrum-steplist-marker-hitArea) / 2));
+    margin-right: calc(calc(var(--spectrum-steplist-marker-hitArea) / 2) * -1);
   }
 
   .spectrum-Steplist-segment {
@@ -262,6 +262,6 @@ governing permissions and limitations under the License.
 
     /* Override last-child bits */
     margin-right: 0;
-    margin-left: calc(-1 * calc(var(--spectrum-steplist-marker-hitArea) / 2));
+    margin-left: calc(calc(var(--spectrum-steplist-marker-hitArea) / 2) * -1);
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/tabs/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tabs/index.css
@@ -78,8 +78,8 @@ governing permissions and limitations under the License.
 
     height: var(--spectrum-tabs-focus-ring-height);
     margin-top: calc(calc(var(--spectrum-tabs-focus-ring-height) / -2) + calc(var(--spectrum-tabs-rule-height) / 2));
-    left: calc(-1 * var(--spectrum-tabs-focus-ring-padding-x));
-    right: calc(-1 * var(--spectrum-tabs-focus-ring-padding-x));
+    left: calc(var(--spectrum-tabs-focus-ring-padding-x) * -1);
+    right: calc(var(--spectrum-tabs-focus-ring-padding-x) * -1);
     border: var(--spectrum-tabs-focus-ring-size) solid transparent;
     border-radius: var(--spectrum-tabs-focus-ring-border-radius);
 
@@ -145,7 +145,7 @@ governing permissions and limitations under the License.
     bottom: 0;
     height: var(--spectrum-tabs-rule-height);
 
-    bottom: calc(-1 * var(--spectrum-tabs-rule-height));
+    bottom: calc(var(--spectrum-tabs-rule-height) * -1);
   }
 
 
@@ -177,8 +177,8 @@ governing permissions and limitations under the License.
 
     &::before {
       /* padding is included in click area of tab items, so only need to offset by the size of the focus ring's border */
-      left: calc(-1 * var(--spectrum-tabs-focus-ring-size));
-      right: calc(-1 * var(--spectrum-tabs-focus-ring-size));
+      left: calc(var(--spectrum-tabs-focus-ring-size) * -1);
+      right: calc(var(--spectrum-tabs-focus-ring-size) * -1);
       margin-top: calc(calc(var(--spectrum-tabs-focus-ring-height) / -2));
     }
   }
@@ -201,6 +201,6 @@ governing permissions and limitations under the License.
     left: 0px;
     width: var(--spectrum-tabs-vertical-rule-width);
 
-    left: calc(-1 * var(--spectrum-tabs-vertical-rule-width));
+    left: calc(var(--spectrum-tabs-vertical-rule-width) * -1);
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/tags/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tags/index.css
@@ -47,7 +47,7 @@ governing permissions and limitations under the License.
 
   > .spectrum-Tags-itemIcon {
     margin-inline-end: var(--spectrum-tag-icon-padding-x);
-    margin-inline-start: calc(-1 * var(--spectrum-tag-deletable-border-size-key-focus));
+    margin-inline-start: calc(var(--spectrum-tag-deletable-border-size-key-focus) * -1);
   }
 
   .spectrum-Tags-itemClearButton {

--- a/packages/@adobe/spectrum-css-temp/components/tooltip/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tooltip/index.css
@@ -78,7 +78,7 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--left {
   .spectrum-Tooltip-tip {
     top: 50%;
-    margin-top: calc(-1 * var(--spectrum-tooltip-tip-width));
+    margin-top: calc(var(--spectrum-tooltip-tip-width) * -1);
   }
 }
 
@@ -129,7 +129,7 @@ governing permissions and limitations under the License.
 .spectrum-Tooltip--top {
   .spectrum-Tooltip-tip {
     left: 50%;
-    margin-left: calc(-1 * var(--spectrum-tooltip-tip-width));
+    margin-left: calc(var(--spectrum-tooltip-tip-width) * -1);
   }
 }
 
@@ -196,7 +196,7 @@ governing permissions and limitations under the License.
 
   .spectrum-Tooltip--bottom {
     top: 100%;
-    transform: translate(-50%, calc(-1 * var(--spectrum-tooltip-tip-margin)));
+    transform: translate(-50%, calc(var(--spectrum-tooltip-tip-margin) * -1));
   }
 
   .spectrum-Tooltip--top {
@@ -221,7 +221,7 @@ governing permissions and limitations under the License.
   &:focus .spectrum-Tooltip.spectrum-Tooltip--top,
   &.is-focused .spectrum-Tooltip.spectrum-Tooltip--top,
   *:focus .spectrum-Tooltip.spectrum-Tooltip--top {
-    transform: translate(-50%, calc(-1 * var(--spectrum-tooltip-tip-margin)));
+    transform: translate(-50%, calc(var(--spectrum-tooltip-tip-margin) * -1));
   }
 
   &:hover .spectrum-Tooltip.spectrum-Tooltip--left,

--- a/packages/@adobe/spectrum-css-temp/components/treeview/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/treeview/index.css
@@ -75,7 +75,7 @@ governing permissions and limitations under the License.
     z-index: -1; /* make sure we don't block clicks on chevron */
 
     /* Position correctly since top is not defined */
-    margin-top: calc(-1 * var(--spectrum-treeview-item-padding-y));
+    margin-top: calc(var(--spectrum-treeview-item-padding-y) * -1);
 
     height: var(--spectrum-treeview-item-height);
 
@@ -92,9 +92,9 @@ governing permissions and limitations under the License.
   position: relative;
 
   left: var(--spectrum-global-dimension-size-125);
-  top: calc(-1 * var(--spectrum-global-dimension-size-65));
-  margin-left: calc(-1 * calc(var(--spectrum-global-dimension-size-400) + var(--spectrum-global-dimension-size-25)));
-  margin-bottom: calc(-1 * var(--spectrum-global-dimension-size-125));
+  top: calc(var(--spectrum-global-dimension-size-65) * -1);
+  margin-left: calc(calc(var(--spectrum-global-dimension-size-400) + var(--spectrum-global-dimension-size-25)) * -1);
+  margin-bottom: calc(var(--spectrum-global-dimension-size-125) * -1);
 
   padding: var(--spectrum-global-dimension-size-125);
 


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1584

The problem showed up when we switched postcss from v6 to v7. Changing order for how css calc() makes a variable negative fixed it; calc(-1*var()) to calc(var()*-1).

## 📝 Test Instructions:

confirm that progress bar indeterminate works.
check that RTL works

## 🧢 Your Team:
RSP
