### PR TITLE
Support complex menu items in Picker

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -39,7 +39,7 @@ governing permissions and limitations under the License.
       background-color: transparent;
     }
 
-    & + .spectrum-Dropdown-icon {
+    & + .spectrum-Dropdown-chevron {
       position: absolute;
       right: var(--spectrum-dropdown-padding-x);
       top: 50%;
@@ -79,7 +79,7 @@ governing permissions and limitations under the License.
 }
 
 /* Only apply margin to the icon if there's a label */
-.spectrum-Dropdown-label + .spectrum-Dropdown-icon {
+.spectrum-Dropdown-label + .spectrum-Dropdown-chevron {
   margin-left: var(--spectrum-dropdown-icon-margin-left);
 }
 
@@ -88,15 +88,16 @@ governing permissions and limitations under the License.
 }
 
 /* Only apply margin if there's a label */
-.spectrum-Dropdown-label ~ .spectrum-Dropdown-icon {
+.spectrum-Dropdown-label ~ .spectrum-Dropdown-chevron {
   margin-left: var(--spectrum-dropdown-icon-margin-left);
 }
 
-.spectrum-Dropdown-icon {
+.spectrum-Dropdown-chevron {
   display: inline-block;
   position: relative;
   vertical-align: top;
   transition: color var(--spectrum-global-animation-duration-100) ease-out;
+  flex-shrink: 0;
 
   /* Fix Safari 10 bug where align-items is ignored inside of buttons */
   margin-top: calc(calc(var(--spectrum-dropdown-height) - calc(var(--spectrum-dropdown-border-size) * 2) - var(--spectrum-icon-chevron-down-medium-height)) / 2);
@@ -107,18 +108,18 @@ governing permissions and limitations under the License.
 
 /* Error icons */
 .spectrum-Dropdown-trigger {
-  .spectrum-Icon:not(.spectrum-Dropdown-icon) {
+  .spectrum-Dropdown-invalidIcon {
     /* Fix Safari 10 bug where align-items is ignored inside of buttons */
-  margin-top: calc(calc(var(--spectrum-dropdown-height) - calc(var(--spectrum-dropdown-border-size) * 2) - var(--spectrum-dropdown-icon-size)) / 2);
+    margin-top: calc(calc(var(--spectrum-dropdown-height) - calc(var(--spectrum-dropdown-border-size) * 2) - var(--spectrum-dropdown-icon-size)) / 2);
     margin-bottom: calc(calc(var(--spectrum-dropdown-height) - calc(var(--spectrum-dropdown-border-size) * 2) - var(--spectrum-dropdown-icon-size)) / 2);
   }
 
-  .spectrum-Dropdown-label + .spectrum-Icon:not(.spectrum-Dropdown-icon) {
+  .spectrum-Dropdown-label + .spectrum-Dropdown-invalidIcon {
     margin-left: var(--spectrum-dropdown-icon-margin-left);
   }
 }
 
-.spectrum-Icon + .spectrum-Dropdown-icon {
+.spectrum-Icon + .spectrum-Dropdown-chevron {
   margin-left: var(--spectrum-dropdown-icon-gap);
 }
 

--- a/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Dropdown {
   .spectrum-Dropdown-trigger:hover {
-    .spectrum-Dropdown-icon {
+    .spectrum-Dropdown-chevron {
       color: var(--spectrum-dropdown-icon-color-hover);
     }
   }
@@ -41,7 +41,7 @@ governing permissions and limitations under the License.
   &.is-disabled {
     &,
     .spectrum-Dropdown-trigger:hover {
-      .spectrum-Dropdown-icon {
+      .spectrum-Dropdown-chevron {
         color: var(--spectrum-dropdown-icon-color-disabled);
       }
     }
@@ -53,7 +53,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Dropdown-icon {
+.spectrum-Dropdown-chevron {
   color: var(--spectrum-dropdown-icon-color);
 }
 
@@ -74,7 +74,7 @@ governing permissions and limitations under the License.
   .spectrum-Dropdown-label.is-placeholder {
     color: var(--spectrum-dropdown-placeholder-text-color-key-focus);
   }
-  .spectrum-Dropdown-icon {
+  .spectrum-Dropdown-chevron {
     color: var(--spectrum-dropdown-icon-color-key-focus)
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -56,16 +56,6 @@ governing permissions and limitations under the License.
     margin-block-end: var(--spectrum-menu-margin-x);
   }
 
-  &.is-selectable {
-    .spectrum-Menu-item {
-      padding-inline-end: var(--spectrum-selectlist-option-selectable-padding-right);
-
-      &.is-selected {
-        padding-inline-end: calc(var(--spectrum-selectlist-option-padding) - var(--spectrum-popover-border-size));
-      }
-    }
-  }
-
   &:focus {
     outline: none;
   }
@@ -123,6 +113,7 @@ governing permissions and limitations under the License.
 .spectrum-Menu-checkmark {
   display: none;
   align-self: center;
+  justify-self: end;
   grid-area: checkmark;
 }
 
@@ -171,11 +162,18 @@ governing permissions and limitations under the License.
     ". .    .            .         .     .            .";
 }
 
+.spectrum-Menu-item.is-selectable {
+  .spectrum-Menu-itemGrid {
+    grid-template-columns: calc(var(--spectrum-selectlist-option-padding) - var(--spectrum-selectlist-border-size-key-focus)) auto 1fr calc(var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-selectlist-option-icon-padding-x)) auto auto var(--spectrum-selectlist-option-padding);
+  }
+}
+
 /* Added .spectrum-Menu so paddings from component styles are overriden */
 .spectrum-Menu .spectrum-Menu-end {
   grid-area: end;
   justify-self: end;
   align-self: center;
+  padding-inline-start: var(--spectrum-global-dimension-size-125);
 }
 .spectrum-Menu-icon {
   grid-area: icon;

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -58,6 +58,10 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
     state
   );
 
+  let contents = typeof rendered === 'string'
+    ? <Text>{rendered}</Text>
+    : rendered;
+
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
       <div
@@ -83,12 +87,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
             icon: {UNSAFE_className: styles['spectrum-Menu-icon']},
             description: {UNSAFE_className: styles['spectrum-Menu-description']}
           }}>
-          {!Array.isArray(rendered) && (
-            <Text>
-              {rendered}
-            </Text>
-          )}
-          {Array.isArray(rendered) && rendered}
+          {contents}
           {isSelected && 
             <CheckmarkMedium
               slot="checkmark"
@@ -99,7 +98,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
                 )
               } />
           }
-        </Grid>  
+        </Grid>
       </div>
     </FocusRing>
   );

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -72,7 +72,8 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
           'spectrum-Menu-item',
           {
             'is-disabled': isDisabled,
-            'is-selected': isSelected
+            'is-selected': isSelected,
+            'is-selectable': state.selectionManager.selectionMode !== 'none'
           }
         )}>
         <Grid

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -61,6 +61,10 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
     state
   );
 
+  let contents = typeof rendered === 'string'
+    ? <Text>{rendered}</Text>
+    : rendered;
+
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
       <li
@@ -88,12 +92,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
             description: {UNSAFE_className: styles['spectrum-Menu-description']},
             keyboard: {UNSAFE_className: styles['spectrum-Menu-keyboard']}
           }}>
-          {!Array.isArray(rendered) && (
-            <Text>
-              {rendered}
-            </Text>
-          )}
-          {Array.isArray(rendered) && rendered}
+          {contents}
           {isSelected && 
             <CheckmarkMedium 
               slot="checkmark" 
@@ -104,7 +103,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
                 )
               } />
           }
-        </Grid>  
+        </Grid>
       </li>
     </FocusRing>
   );

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -75,7 +75,8 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
           'spectrum-Menu-item',
           {
             'is-disabled': isDisabled,
-            'is-selected': isSelected
+            'is-selected': isSelected,
+            'is-selectable': state.selectionManager.selectionMode !== 'none'
           }
         )}>
         <Grid

--- a/packages/@react-spectrum/menu/stories/Menu.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/Menu.stories.tsx
@@ -17,7 +17,6 @@ import AlignLeft from '@spectrum-icons/workflow/AlignLeft';
 import AlignRight from '@spectrum-icons/workflow/AlignRight';
 import Blower from '@spectrum-icons/workflow/Blower';
 import Book from '@spectrum-icons/workflow/Book';
-import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
 import {Content, Header} from '@react-spectrum/view';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
@@ -460,12 +459,12 @@ storiesOf('Menu', module)
               <AlignLeft size="S" />
               <Text>Puppy</Text>
               <Text slot="description">Puppy description super long as well geez</Text>
+              <Keyboard>⌘P</Keyboard>
             </Item>
             <Item textValue="Doggo with really really really long long long text">
               <AlignCenter size="S" />
               <Text>Doggo with really really really long long long text</Text>
               <Text slot="end">Value</Text>
-              <ChevronRightMedium slot="keyboard" />
             </Item>
             <Item textValue="Floof">
               <AlignRight size="S" />

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -33,6 +33,7 @@
     "@react-spectrum/listbox": "^3.0.0-alpha.1",
     "@react-spectrum/overlays": "^3.0.0-alpha.1",
     "@react-spectrum/provider": "^3.0.0-alpha.1",
+    "@react-spectrum/typography": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-alpha.1",
     "@react-stately/select": "^3.0.0-alpha.1",
     "@spectrum-icons/ui": "^3.0.0-rc.1"

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -12,7 +12,7 @@
 
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
-import {classNames, filterDOMProps, unwrapDOMRef, useDOMRef, useMediaQuery, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, unwrapDOMRef, useDOMRef, useMediaQuery, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef, DOMRefValue, FocusableRefValue, LabelPosition} from '@react-types/shared';
 import {FieldButton} from '@react-spectrum/button';
 import {FocusScope} from '@react-aria/focus';
@@ -25,6 +25,7 @@ import {Placement} from '@react-types/overlays';
 import React, {ReactElement, useRef} from 'react';
 import {SpectrumPickerProps} from '@react-types/select';
 import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
+import {Text} from '@react-spectrum/typography';
 import {useOverlayPosition} from '@react-aria/overlays';
 import {useProviderProps} from '@react-spectrum/provider';
 import {useSelect} from '@react-aria/select';
@@ -111,6 +112,11 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
     ? state.collection.getItem(state.selectedKey)
     : null;
 
+  let contents = selectedItem ? selectedItem.rendered : placeholder;
+  if (typeof contents === 'string') {
+    contents = <Text>{contents}</Text>;
+  }
+
   let picker = (
     <div
       className={
@@ -130,20 +136,24 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
         isDisabled={isDisabled}
         validationState={validationState}
         UNSAFE_className={classNames(styles, 'spectrum-Dropdown-trigger')}>
-        <span
-          className={
-            classNames(
-              styles,
-              'spectrum-Dropdown-label',
-              {'is-placeholder': !selectedItem}
-            )
-           }>
-          {selectedItem ? selectedItem.rendered : placeholder}
-        </span>
+        <SlotProvider
+          slots={{
+            icon: {UNSAFE_className: classNames(styles, 'spectrum-Icon'), size: 'S'},
+            text: {UNSAFE_className: classNames(
+            styles,
+            'spectrum-Dropdown-label',
+            {'is-placeholder': !selectedItem}
+          )},
+            description: {
+              isHidden: true
+            }
+          }}>
+          {contents}
+        </SlotProvider>
         {validationState === 'invalid' && 
           <AlertMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-invalidIcon')} />
         }
-        <ChevronDownMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-icon')} />
+        <ChevronDownMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-chevron')} />
       </FieldButton>
       <Overlay isOpen={state.isOpen} ref={containerRef}>
         {overlay}

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -10,9 +10,16 @@
  * governing permissions and limitations under the License.
  */
 
+import AlignCenter from '@spectrum-icons/workflow/AlignCenter';
+import AlignLeft from '@spectrum-icons/workflow/AlignLeft';
+import AlignRight from '@spectrum-icons/workflow/AlignRight';
+import Copy from '@spectrum-icons/workflow/Copy';
+import Cut from '@spectrum-icons/workflow/Cut';
 import {Item, Picker, Section} from '../';
+import Paste from '@spectrum-icons/workflow/Paste';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
+import {Text} from '@react-spectrum/typography';
 
 let flatOptions = [
   {name: 'Aardvark'},
@@ -165,6 +172,42 @@ storiesOf('Picker', module)
         <Item>One</Item>
         <Item>Two</Item>
         <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'complex items',
+    () => (
+      <Picker label="Test">
+        <Section title="Section 1">
+          <Item textValue="Copy">
+            <Copy size="S" />
+            <Text>Copy</Text>
+          </Item>
+          <Item textValue="Cut">
+            <Cut size="S" />
+            <Text>Cut</Text>
+          </Item>
+          <Item textValue="Paste">
+            <Paste size="S" />
+            <Text>Paste</Text>
+          </Item>
+        </Section>
+        <Section title="Section 2">
+          <Item textValue="Puppy">
+            <AlignLeft size="S" />
+            <Text>Puppy</Text>
+            <Text slot="description">Puppy description super long as well geez</Text>
+          </Item>
+          <Item textValue="Doggo with really really really long long long text">
+            <AlignCenter size="S" />
+            <Text>Doggo with really really really long long long text</Text>
+          </Item>
+          <Item textValue="Floof">
+            <AlignRight size="S" />
+            <Text>Floof</Text>
+          </Item>
+        </Section>
       </Picker>
     )
   );

--- a/packages/@react-stately/collections/src/CollectionBuilder.ts
+++ b/packages/@react-stately/collections/src/CollectionBuilder.ts
@@ -138,6 +138,7 @@ export class CollectionBuilder<T> {
     let node: Node<T> = {
       type: partialNode.type,
       key: partialNode.key,
+      parentKey: parentNode ? parentNode.key : null,
       value: partialNode.value,
       level: parentNode ? parentNode.level + 1 : 0,
       rendered: partialNode.rendered,

--- a/packages/@react-stately/collections/src/TreeCollection.ts
+++ b/packages/@react-stately/collections/src/TreeCollection.ts
@@ -22,19 +22,18 @@ export class TreeCollection<T> implements Collection<Node<T>> {
   constructor(nodes: Iterable<Node<T>>) {
     this.iterable = nodes;
 
-    let visit = (node: Node<T>, parentKey: Key) => {
-      node.parentKey = parentKey;
+    let visit = (node: Node<T>) => {
       this.keyMap.set(node.key, node);
 
       if (node.childNodes && (node.type === 'section' || node.isExpanded)) {
         for (let child of node.childNodes) {
-          visit(child, node.key);
+          visit(child);
         }
       }
     };
 
     for (let node of nodes) {
-      visit(node, null);
+      visit(node);
     }
 
     let last: Node<T>;


### PR DESCRIPTION
This adds support for complex menu items to be selected in Picker. Icons and labels are displayed, and description text is hidden.

Also now always reserves space for the checkmark in menu items when selectable even when not selected so that the content doesn't shift when it is selected.

<img src="https://user-images.githubusercontent.com/19409/77013565-81c77a00-692d-11ea-80e8-d87a666997ca.png" width="200">
