### PR TITLE
Use aria-labelledby and aria-describedby for complex menu items

### DIFF
--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -14,6 +14,7 @@ import {HTMLAttributes, Key, RefObject} from 'react';
 import {ListState} from '@react-stately/list';
 import {useHover, usePress} from '@react-aria/interactions';
 import {useSelectableItem} from '@react-aria/selection';
+import {useSlotId} from '@react-aria/utils';
 
 interface OptionProps {
   isDisabled?: boolean,
@@ -26,7 +27,9 @@ interface OptionProps {
 }
 
 interface OptionAria {
-  optionProps: HTMLAttributes<HTMLElement>
+  optionProps: HTMLAttributes<HTMLElement>,
+  labelProps: HTMLAttributes<HTMLElement>,
+  descriptionProps: HTMLAttributes<HTMLElement>
 }
 
 export function useOption<T>(props: OptionProps, state: ListState<T>): OptionAria {
@@ -40,10 +43,15 @@ export function useOption<T>(props: OptionProps, state: ListState<T>): OptionAri
     isVirtualized
   } = props;
 
+  let labelId = useSlotId();
+  let descriptionId = useSlotId();
+
   let optionProps = {
     role: 'option',
     'aria-disabled': isDisabled,
-    'aria-selected': isSelected
+    'aria-selected': isSelected,
+    'aria-labelledby': labelId,
+    'aria-describedby': descriptionId
   };
 
   if (isVirtualized) {
@@ -72,6 +80,12 @@ export function useOption<T>(props: OptionProps, state: ListState<T>): OptionAri
       ...optionProps,
       ...pressProps,
       ...hoverProps
+    },
+    labelProps: {
+      id: labelId
+    },
+    descriptionProps: {
+      id: descriptionId
     }
   };
 }

--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -10,14 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import {AllHTMLAttributes, Key, RefObject} from 'react';
-import {mergeProps} from '@react-aria/utils';
+import {HTMLAttributes, Key, RefObject} from 'react';
+import {mergeProps, useSlotId} from '@react-aria/utils';
 import {TreeState} from '@react-stately/tree';
 import {useHover, usePress} from '@react-aria/interactions';
 import {useSelectableItem} from '@react-aria/selection';
 
 interface MenuItemAria {
-  menuItemProps: AllHTMLAttributes<HTMLElement>
+  menuItemProps: HTMLAttributes<HTMLElement>,
+  labelProps: HTMLAttributes<HTMLElement>,
+  descriptionProps: HTMLAttributes<HTMLElement>,
+  keyboardShortcutProps: HTMLAttributes<HTMLElement>
 }
 
 interface MenuState<T> extends TreeState<T> {}
@@ -50,9 +53,15 @@ export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuI
     role = 'menuitemcheckbox';
   }
 
+  let labelId = useSlotId();
+  let descriptionId = useSlotId();
+  let keyboardId = useSlotId();
+
   let ariaProps = {
     'aria-disabled': isDisabled,
-    role
+    role,
+    'aria-labelledby': labelId,
+    'aria-describedby': [descriptionId, keyboardId].filter(Boolean).join(' ')
   };
 
   if (state.selectionManager.selectionMode !== 'none') {
@@ -105,6 +114,15 @@ export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuI
       ...ariaProps,
       ...pressProps,
       ...hoverProps
+    },
+    labelProps: {
+      id: labelId
+    },
+    descriptionProps: {
+      id: descriptionId
+    },
+    keyboardShortcutProps: {
+      id: keyboardId
     }
   };
 }

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -45,7 +45,7 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
   } = item;
 
   let ref = useRef<HTMLDivElement>();
-  let {optionProps} = useOption(
+  let {optionProps, labelProps, descriptionProps} = useOption(
     {
       isSelected,
       isDisabled,
@@ -79,9 +79,9 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
             )
           }
           slots={{
-            text: {UNSAFE_className: styles['spectrum-Menu-itemLabel']},
+            text: {UNSAFE_className: styles['spectrum-Menu-itemLabel'], ...labelProps},
             icon: {UNSAFE_className: styles['spectrum-Menu-icon']},
-            description: {UNSAFE_className: styles['spectrum-Menu-description']}
+            description: {UNSAFE_className: styles['spectrum-Menu-description'], ...descriptionProps}
           }}>
           {!Array.isArray(rendered) && (
             <Text>

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -10,11 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
+import Bell from '@spectrum-icons/workflow/Bell';
 import {cleanup, fireEvent, render, within} from '@testing-library/react';
 import {Item, ListBox, Section} from '../';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import scaleMedium from '@adobe/spectrum-css-temp/vars/spectrum-medium-unique.css';
+import {Text} from '@react-spectrum/typography';
 import themeLight from '@adobe/spectrum-css-temp/vars/spectrum-light-unique.css';
 import {triggerPress} from '@react-spectrum/test-utils';
 
@@ -521,5 +523,27 @@ describe('ListBox', function () {
       fireEvent.keyDown(listbox, {key: 'B'});
       expect(document.activeElement).toBe(options[1]);
     });
+  });
+
+  it('supports complex options with aria-labelledby and aria-describedby', function () {
+    let tree = render(
+      <Provider theme={theme}>
+        <ListBox>
+          <Item>
+            <Bell />
+            <Text>Label</Text>
+            <Text slot="description">Description</Text>
+          </Item>
+        </ListBox>
+      </Provider>
+    );
+
+    let listbox = tree.getByRole('listbox');
+    let option = within(listbox).getByRole('option');
+    let label = within(listbox).getByText('Label');
+    let description = within(listbox).getByText('Description');
+    
+    expect(option).toHaveAttribute('aria-labelledby', label.id);
+    expect(option).toHaveAttribute('aria-describedby', description.id);
   });
 });

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -48,7 +48,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
   } = item;
 
   let ref = useRef<HTMLLIElement>();
-  let {menuItemProps} = useMenuItem(
+  let {menuItemProps, labelProps, descriptionProps, keyboardShortcutProps} = useMenuItem(
     {
       isSelected,
       isDisabled,
@@ -82,11 +82,11 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
             )
           }
           slots={{
-            text: {UNSAFE_className: styles['spectrum-Menu-itemLabel']},
-            end: {UNSAFE_className: styles['spectrum-Menu-end']},
+            text: {UNSAFE_className: styles['spectrum-Menu-itemLabel'], ...labelProps},
+            end: {UNSAFE_className: styles['spectrum-Menu-end'], ...descriptionProps},
             icon: {UNSAFE_className: styles['spectrum-Menu-icon']},
-            description: {UNSAFE_className: styles['spectrum-Menu-description']},
-            keyboard: {UNSAFE_className: styles['spectrum-Menu-keyboard']}
+            description: {UNSAFE_className: styles['spectrum-Menu-description'], ...descriptionProps},
+            keyboard: {UNSAFE_className: styles['spectrum-Menu-keyboard'], ...keyboardShortcutProps}
           }}>
           {!Array.isArray(rendered) && (
             <Text>

--- a/packages/@react-spectrum/menu/test/Menu.test.js
+++ b/packages/@react-spectrum/menu/test/Menu.test.js
@@ -10,9 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+import Bell from '@spectrum-icons/workflow/Bell';
 import {cleanup, fireEvent, render, within} from '@testing-library/react';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Item, Menu, Section} from '../';
+import {Keyboard, Text} from '@react-spectrum/typography';
 import {MenuContext} from '../src/context';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -645,5 +647,29 @@ describe('Menu', function () {
 
     let dialog = tree.getByRole('dialog');
     expect(dialog).toBeVisible();
+  });
+
+  it('supports complex menu items with aria-labelledby and aria-describedby', function () {
+    let tree = render(
+      <Provider theme={theme}>
+        <Menu id={menuId} selectionMode="none">
+          <Item>
+            <Bell />
+            <Text>Label</Text>
+            <Text slot="description">Description</Text>
+            <Keyboard>⌘V</Keyboard>
+          </Item>
+        </Menu>
+      </Provider>
+    );
+
+    let menu = tree.getByRole('menu');
+    let menuItem = within(menu).getByRole('menuitem');
+    let label = within(menu).getByText('Label');
+    let description = within(menu).getByText('Description');
+    let keyboard = within(menu).getByText('⌘V');
+    
+    expect(menuItem).toHaveAttribute('aria-labelledby', label.id);
+    expect(menuItem).toHaveAttribute('aria-describedby', `${description.id} ${keyboard.id}`);
   });
 });


### PR DESCRIPTION
This uses `aria-labelledby` and `aria-describedby` to provide better labeling of complex menu items and listbox options for accessibility. Before this change, all of the text of the menu item or option was concatenated together without break to form the accessibility label for the item. This resulted in confusing sounding items when used with a screen reader, because label text, description, keyboard shortcuts and more were read as one.

Now we use `aria-labelledby` to point to the just the main label text for the item, and `aria-describedby` to point to the description of the item, the value in key/value menu items, and the keyboard shortcut for the item. All of these are optional, so we use `useSlotId` to generate an id and pass this through the slot context to the proper child.