### PR TITLE
Close menu and focus correct element when tabbing out

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -280,6 +280,8 @@ function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boole
             if ((node as HTMLElement).matches(TABBABLE_ELEMENT_SELECTOR)) {
               return NodeFilter.FILTER_ACCEPT;
             }
+
+            return NodeFilter.FILTER_SKIP;
           }
         },
         false

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -47,7 +47,7 @@ export function FocusScope(props: FocusScopeProps) {
   let endRef = useRef<HTMLSpanElement>();
   let scopeRef = useRef<HTMLElement[]>([]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     // Find all rendered nodes between the sentinels and add them to the scope.
     let node = startRef.current.nextSibling;
     let nodes = [];

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -254,6 +254,7 @@ function useAutoFocus(scopeRef: RefObject<HTMLElement[]>, autoFocus: boolean) {
 function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boolean, contain: boolean) {
   // useLayoutEffect instead of useEffect so the active element is saved synchronously instead of asynchronously.
   useLayoutEffect(() => {
+    let scope = scopeRef.current;
     let nodeToRestore = document.activeElement as HTMLElement;
 
     // Handle the Tab key so that tabbing out of the scope goes to the next element
@@ -266,7 +267,7 @@ function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boole
       }
 
       let focusedElement = document.activeElement as HTMLElement;
-      if (!isElementInScope(focusedElement, scopeRef.current)) {
+      if (!isElementInScope(focusedElement, scope)) {
         return;
       }
 
@@ -290,7 +291,7 @@ function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boole
 
       // If there is no next element, or it is outside the current scope, move focus to the
       // next element after the node to restore to instead.
-      if ((!nextElement || !isElementInScope(nextElement, scopeRef.current)) && nodeToRestore) {
+      if ((!nextElement || !isElementInScope(nextElement, scope)) && nodeToRestore) {
         walker.currentNode = nodeToRestore;
         nextElement = (e.shiftKey ? walker.previousNode() : walker.nextNode()) as HTMLElement;
 
@@ -313,7 +314,7 @@ function useRestoreFocus(scopeRef: RefObject<HTMLElement[]>, restoreFocus: boole
         document.removeEventListener('keydown', onKeyDown, false);
       }
 
-      if (restoreFocus && nodeToRestore && isElementInScope(document.activeElement, scopeRef.current)) {
+      if (restoreFocus && nodeToRestore && isElementInScope(document.activeElement, scope)) {
         requestAnimationFrame(() => {
           if (document.body.contains(nodeToRestore)) {
             focusElement(nodeToRestore);

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -285,6 +285,73 @@ describe('FocusScope', function () {
 
       expect(document.activeElement).toBe(outside);
     });
+
+    it('should move focus to the next element after the previously focused node on Tab', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <button data-testid="trigger" />
+            <input data-testid="after" />
+            {show &&
+              <FocusScope restoreFocus autoFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      trigger.focus();
+      
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      let input3 = getByTestId('input3');
+      input3.focus();
+
+      fireEvent.keyDown(input3, {key: 'Tab'});
+      expect(document.activeElement).toBe(getByTestId('after'));
+    });
+
+    it('should move focus to the previous element after the previously focused node on Shift+Tab', function () {
+      function Test({show}) {
+        return (
+          <div>
+            <input data-testid="before" />
+            <button data-testid="trigger" />
+            <input data-testid="after" />
+            {show &&
+              <FocusScope restoreFocus autoFocus>
+                <input data-testid="input1" />
+                <input data-testid="input2" />
+                <input data-testid="input3" />
+              </FocusScope>
+            }
+          </div>
+        );
+      }
+
+      let {getByTestId, rerender} = render(<Test />);
+
+      let trigger = getByTestId('trigger');
+      trigger.focus();
+      
+      rerender(<Test show />);
+
+      let input1 = getByTestId('input1');
+      expect(document.activeElement).toBe(input1);
+
+      fireEvent.keyDown(input1, {key: 'Tab', shiftKey: true});
+      expect(document.activeElement).toBe(getByTestId('before'));
+    });
   });
 
   describe('auto focus', function () {

--- a/packages/@react-aria/interactions/src/useFocusWithin.ts
+++ b/packages/@react-aria/interactions/src/useFocusWithin.ts
@@ -37,41 +37,36 @@ export function useFocusWithin(props: FocusWithinProps): FocusWithinResult {
     return {focusWithinProps: {}};
   }
 
-  let onFocus, onBlur;
-  if (props.onFocusWithin || props.onFocusWithinChange) {
-    onFocus = createEventHandler((e: FocusEvent) => {
-      if (props.onFocusWithin) {
-        props.onFocusWithin(e);
+  let onFocus = createEventHandler((e: FocusEvent) => {
+    if (props.onFocusWithin) {
+      props.onFocusWithin(e);
+    }
+
+    if (!state.isFocusWithin) {
+      if (props.onFocusWithinChange) {
+        props.onFocusWithinChange(true);
       }
 
-      if (!state.isFocusWithin) {
-        if (props.onFocusWithinChange) {
-          props.onFocusWithinChange(true);
-        }
+      state.isFocusWithin = true;
+    }
+  });
 
-        state.isFocusWithin = true;
+  let onBlur = createEventHandler((e: FocusEvent) => {
+    // We don't want to trigger onBlurWithin and then immediately onFocusWithin again 
+    // when moving focus inside the element. Only trigger if the currentTarget doesn't 
+    // include the relatedTarget (where focus is moving).
+    if (state.isFocusWithin && !e.currentTarget.contains(e.relatedTarget as HTMLElement)) {
+      if (props.onBlurWithin) {
+        props.onBlurWithin(e);
       }
-    });
-  }
 
-  if (props.onBlurWithin || props.onFocusWithinChange) {
-    onBlur = createEventHandler((e: FocusEvent) => {
-      // We don't want to trigger onBlurWithin and then immediately onFocusWithin again 
-      // when moving focus inside the element. Only trigger if the currentTarget doesn't 
-      // include the relatedTarget (where focus is moving).
-      if (state.isFocusWithin && !e.currentTarget.contains(e.relatedTarget as HTMLElement)) {
-        if (props.onBlurWithin) {
-          props.onBlurWithin(e);
-        }
-
-        if (props.onFocusWithinChange) {
-          props.onFocusWithinChange(false);
-        }
-
-        state.isFocusWithin = false;
+      if (props.onFocusWithinChange) {
+        props.onFocusWithinChange(false);
       }
-    });
-  }
+
+      state.isFocusWithin = false;
+    }
+  });
   
   return {
     focusWithinProps: {

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -34,7 +34,7 @@ interface PressState {
 }
 
 interface EventBase {
-  target: EventTarget,
+  currentTarget: EventTarget,
   shiftKey: boolean,
   ctrlKey: boolean,
   metaKey: boolean
@@ -102,7 +102,7 @@ export function usePress(props: PressHookProps): PressResult {
         onPressStart({
           type: 'pressstart',
           pointerType,
-          target: originalEvent.target as HTMLElement,
+          target: originalEvent.currentTarget as HTMLElement,
           shiftKey: originalEvent.shiftKey,
           metaKey: originalEvent.metaKey,
           ctrlKey: originalEvent.ctrlKey
@@ -127,7 +127,7 @@ export function usePress(props: PressHookProps): PressResult {
         onPressEnd({
           type: 'pressend',
           pointerType,
-          target: originalEvent.target as HTMLElement,
+          target: originalEvent.currentTarget as HTMLElement,
           shiftKey: originalEvent.shiftKey,
           metaKey: originalEvent.metaKey,
           ctrlKey: originalEvent.ctrlKey
@@ -144,7 +144,7 @@ export function usePress(props: PressHookProps): PressResult {
         onPress({
           type: 'press',
           pointerType,
-          target: originalEvent.target as HTMLElement,
+          target: originalEvent.currentTarget as HTMLElement,
           shiftKey: originalEvent.shiftKey,
           metaKey: originalEvent.metaKey,
           ctrlKey: originalEvent.ctrlKey
@@ -161,7 +161,7 @@ export function usePress(props: PressHookProps): PressResult {
         onPressUp({
           type: 'pressup',
           pointerType,
-          target: originalEvent.target as HTMLElement,
+          target: originalEvent.currentTarget as HTMLElement,
           shiftKey: originalEvent.shiftKey,
           metaKey: originalEvent.metaKey,
           ctrlKey: originalEvent.ctrlKey
@@ -180,7 +180,7 @@ export function usePress(props: PressHookProps): PressResult {
           // after which focus moved to the current element. Ignore these events and
           // only handle the first key down event.
           if (!state.isPressed && !e.repeat) {
-            state.target = e.target as HTMLElement;
+            state.target = e.currentTarget as HTMLElement;
             state.isPressed = true;
             triggerPressStart(e, 'keyboard');
 
@@ -502,7 +502,7 @@ function getTouchById(
 
 function createEvent(target: HTMLElement, e: EventBase): EventBase {
   return {
-    target,
+    currentTarget: target,
     shiftKey: e.shiftKey,
     ctrlKey: e.ctrlKey,
     metaKey: e.metaKey

--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {AllHTMLAttributes, useRef} from 'react';
+import {AllHTMLAttributes} from 'react';
 import {MenuTriggerProps, MenuTriggerState} from '@react-types/menu';
 import {PressProps, useFocusWithin} from '@react-aria/interactions';
 import {useId} from '@react-aria/utils';
@@ -76,7 +76,7 @@ export function useMenuTrigger(props: MenuTriggerProps, state: MenuTriggerState)
     menuTriggerProps: {
       ...triggerAriaProps,
       id: menuTriggerId,
-      onPressStart(e) {
+      onPressStart() {
         // Wait a frame to ensure target is focused prior to opening the menu so FocusScope
         // can record the correct element to restore focus to.
         requestAnimationFrame(() => {

--- a/packages/@react-aria/menu/src/useMenuTrigger.ts
+++ b/packages/@react-aria/menu/src/useMenuTrigger.ts
@@ -10,9 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import {AllHTMLAttributes} from 'react';
+import {AllHTMLAttributes, useRef} from 'react';
 import {MenuTriggerProps, MenuTriggerState} from '@react-types/menu';
-import {PressProps} from '@react-aria/interactions';
+import {PressProps, useFocusWithin} from '@react-aria/interactions';
 import {useId} from '@react-aria/utils';
 import {useOverlayTrigger} from '@react-aria/overlays';
 
@@ -37,9 +37,9 @@ export function useMenuTrigger(props: MenuTriggerProps, state: MenuTriggerState)
   });
 
   let onPress = () => {
-    if (!isDisabled) {
+    if (!isDisabled && !state.isOpen) {
       state.setFocusStrategy('first');
-      state.setOpen(!state.isOpen);
+      state.setOpen(true);
     }
   };
 
@@ -66,15 +66,28 @@ export function useMenuTrigger(props: MenuTriggerProps, state: MenuTriggerState)
     }
   };
 
+  let {focusWithinProps} = useFocusWithin({
+    onBlurWithin: () => {
+      state.setOpen(false);
+    }
+  });
+
   return {
     menuTriggerProps: {
       ...triggerAriaProps,
       id: menuTriggerId,
-      onPressStart: onPress,
+      onPressStart(e) {
+        // Wait a frame to ensure target is focused prior to opening the menu so FocusScope
+        // can record the correct element to restore focus to.
+        requestAnimationFrame(() => {
+          onPress();
+        });
+      },
       onKeyDown
     },
     menuProps: {
       ...overlayAriaProps,
+      ...focusWithinProps,
       'aria-labelledby': menuTriggerId
     }
   };

--- a/packages/@react-aria/menu/test/useMenuTrigger.test.js
+++ b/packages/@react-aria/menu/test/useMenuTrigger.test.js
@@ -21,6 +21,7 @@ describe('useMenuTrigger', function () {
 
   let renderMenuTriggerHook = (menuTriggerProps, menuTriggerState) => {
     let {result} = renderHook(() => useMenuTrigger(menuTriggerProps, menuTriggerState));
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
     return result.current;
   };
 

--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -38,7 +38,7 @@ describe('Breadcrumbs', function () {
     });
 
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
-
+    jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
   });
 
   afterEach(() => {

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -18,7 +18,8 @@ import {ListBoxOption} from './ListBoxOption';
 import {ListBoxSection} from './ListBoxSection';
 import {ListLayout, Node} from '@react-stately/collections';
 import {ListState} from '@react-stately/list';
-import React, {ReactElement, useMemo} from 'react';
+import {mergeProps} from '@react-aria/utils';
+import React, {HTMLAttributes, ReactElement, useMemo} from 'react';
 import {ReusableView} from '@react-stately/collections';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
 import {useCollator} from '@react-aria/i18n';
@@ -32,7 +33,8 @@ interface ListBoxBaseProps<T> extends DOMProps, StyleProps {
   focusStrategy?: FocusStrategy,
   wrapAround?: boolean,
   selectOnPressUp?: boolean,
-  focusOnPointerEnter?: boolean
+  focusOnPointerEnter?: boolean,
+  domProps?: HTMLAttributes<HTMLElement>
 }
 
 export function useListBoxLayout<T>(state: ListState<T>) {
@@ -51,9 +53,10 @@ export function useListBoxLayout<T>(state: ListState<T>) {
 }
 
 export function ListBoxBase<T>(props: ListBoxBaseProps<T>) {
-  let {layout, state, selectOnPressUp, focusOnPointerEnter} = props;
+  let {layout, state, selectOnPressUp, focusOnPointerEnter, domProps = {}} = props;
   let {listBoxProps} = useListBox({
     ...props,
+    ...domProps,
     keyboardDelegate: layout,
     isVirtualized: true
   }, state);
@@ -87,7 +90,7 @@ export function ListBoxBase<T>(props: ListBoxBaseProps<T>) {
     <CollectionView
       {...filterDOMProps(props)}
       {...styleProps}
-      {...listBoxProps}
+      {...mergeProps(listBoxProps, domProps)}
       focusedKey={state.selectionManager.focusedKey}
       sizeToFit="height"
       className={

--- a/packages/@react-spectrum/menu/src/Menu.tsx
+++ b/packages/@react-spectrum/menu/src/Menu.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, DOMEventPropNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {MenuContext} from './context';
 import {MenuItem} from './MenuItem';
 import {MenuSection} from './MenuSection';
@@ -36,7 +36,7 @@ export function Menu<T>(props: SpectrumMenuProps<T>) {
   return (
     <ul
       {...filterDOMProps(completeProps)}
-      {...menuProps}
+      {...mergeProps(menuProps, filterDOMProps(contextProps, DOMEventPropNames))}
       {...styleProps}
       ref={ref}
       className={

--- a/packages/@react-spectrum/menu/src/Menu.tsx
+++ b/packages/@react-spectrum/menu/src/Menu.tsx
@@ -36,6 +36,7 @@ export function Menu<T>(props: SpectrumMenuProps<T>) {
   return (
     <ul
       {...filterDOMProps(completeProps)}
+      // Allow DOM props to be passed from MenuTrigger via context only
       {...mergeProps(menuProps, filterDOMProps(contextProps, DOMEventPropNames))}
       {...styleProps}
       ref={ref}

--- a/packages/@react-spectrum/menu/src/context.ts
+++ b/packages/@react-spectrum/menu/src/context.ts
@@ -10,11 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import {DOMProps} from '@react-types/shared';
 import {FocusStrategy} from '@react-types/menu';
-import React, {useContext} from 'react';
+import React, {HTMLAttributes, useContext} from 'react';
 
-export interface MenuContextValue extends DOMProps {
+export interface MenuContextValue extends HTMLAttributes<HTMLElement> {
   onClose?: () => void,
   closeOnSelect?: boolean,
   focusStrategy?: FocusStrategy,

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -204,6 +204,32 @@ storiesOf('MenuTrigger', module)
     )
   )
   .add(
+    'menu closes on blur',
+    () => (
+      <>
+        <div style={{display: 'flex', width: 'auto', margin: '250px 0'}}>
+          <input placeholder="Shift tab here" />
+          <MenuTrigger onOpenChange={action('onOpenChange')}>
+            <ActionButton
+              onPress={action('press')}
+              onPressStart={action('pressstart')}
+              onPressEnd={action('pressend')}>
+                Menu Button
+            </ActionButton>
+            <Menu items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} disabledKeys={['Snake', 'Ross']}>
+              {item => (
+                <Section items={item.children} title={item.name}>
+                  {item => <Item childItems={item.children}>{item.name}</Item>}
+                </Section>
+              )}
+            </Menu>
+          </MenuTrigger>
+          <input placeholder="Tab here" />
+        </div>
+      </>
+    )
+  )
+  .add(
     'more than 2 children (split button)',
     () => (
       <div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -79,7 +79,7 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
   let listbox = (
     <FocusScope restoreFocus>
       <ListBoxBase
-        {...menuProps}
+        domProps={menuProps}
         autoFocus
         wrapAround
         selectOnPressUp

--- a/packages/@react-spectrum/utils/src/filterDOMProps.ts
+++ b/packages/@react-spectrum/utils/src/filterDOMProps.ts
@@ -54,6 +54,63 @@ export const TextInputDOMPropNames = {
   onInput: 1
 };
 
+// Based on DOMAttributes from react types
+export const DOMEventPropNames = {  
+  // Focus events
+  onFocus: 1,
+  onBlur: 1,
+
+  // Keyboard events
+  onKeyDown: 1,
+  onKeyPress: 1,
+  onKeyUp: 1,
+
+  // Mouse events
+  onAuxClick: 1,
+  onClick: 1,
+  onContextMenu: 1,
+  onDoubleClick: 1,
+  onDrag: 1,
+  onDragEnd: 1,
+  onDragEnter: 1,
+  onDragExit: 1,
+  onDragLeave: 1,
+  onDragOver: 1,
+  onDragStart: 1,
+  onDrop: 1,
+  onMouseDown: 1,
+  onMouseEnter: 1,
+  onMouseLeave: 1,
+  onMouseMove: 1,
+  onMouseOut: 1,
+  onMouseOver: 1,
+  onMouseUp: 1,
+
+  // Touch events
+  onTouchCancel: 1,
+  onTouchEnd: 1,
+  onTouchMove: 1,
+  onTouchStart: 1,
+
+  // Pointer events
+  onPointerDown: 1,
+  onPointerMove: 1,
+  onPointerUp: 1,
+  onPointerCancel: 1,
+  onPointerEnter: 1,
+  onPointerLeave: 1,
+  onPointerOver: 1,
+  onPointerOut: 1,
+  onGotPointerCapture: 1,
+  onLostPointerCapture: 1,
+
+  // UI events
+  onScroll: 1,
+
+  // Wheel events
+  onWheel: 1
+};
+
 /**
  * Checking for data-* props
  */


### PR DESCRIPTION
This adds support for automatically closing menus and moving focus to the element before or after the trigger when tabbing out. 

Closing the menu is handled using `useFocusWithin` to detect when focus moves outside.

Because overlays are rendered into a portal at the end of the body, letting the browser handle the Tab key as it normally would is insufficient as it would just tab to the next element in the document (or back to the body if nothing is after the portal). In order to support tabbing out of overlays and back to the element after/before the target, FocusScope handles the tab key and moves focus accordingly.