### PR TITLE
Make the modal examples look nice while we wait for other things

### DIFF
--- a/packages/@react-spectrum/overlays/package.json
+++ b/packages/@react-spectrum/overlays/package.json
@@ -37,7 +37,10 @@
     "react-transition-group": "^2.2.0"
   },
   "devDependencies": {
-    "@adobe/spectrum-css-temp": "^3.0.0-alpha.2"
+    "@adobe/spectrum-css-temp": "^3.0.0-alpha.2",
+    "@react-spectrum/divider": "^3.0.0-rc.1",
+    "@react-spectrum/view": "^3.0.0-alpha.1",
+    "@react-spectrum/typography": "^3.0.0-alpha.1"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/packages/@react-spectrum/overlays/stories/Modal.stories.tsx
+++ b/packages/@react-spectrum/overlays/stories/Modal.stories.tsx
@@ -11,7 +11,10 @@
  */
 
 import {ActionButton, Button} from '@react-spectrum/button';
+import {Content, Footer, Header} from '@react-spectrum/view';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
+import {Divider} from '@react-spectrum/divider';
+import {Heading, Text} from '@react-spectrum/typography';
 import {Modal} from '../';
 import React, {Fragment, useState} from 'react';
 import {storiesOf} from '@storybook/react';
@@ -36,8 +39,10 @@ function ModalExample() {
       <ActionButton onPress={() => setOpen(true)}>Open modal</ActionButton>
       <Modal isOpen={isOpen} onClose={() => setOpen(false)}>
         <Dialog>
-          <p>I am a dialog</p>
-          <Button variant="cta" onPress={() => setOpen(false)}>Close</Button>
+          <Header><Heading>Title</Heading></Header>
+          <Divider />
+          <Content><Text>I am a dialog</Text></Content>
+          <Footer><Button variant="cta" onPress={() => setOpen(false)}>Close</Button></Footer>
         </Dialog>
       </Modal>
     </Fragment>
@@ -59,13 +64,18 @@ function UnmountingTrigger() {
       <DialogTrigger type="popover" isOpen={isPopoverOpen} onOpenChange={setPopoverOpen}>
         <ActionButton>Open popover</ActionButton>
         <Dialog>
-          <ActionButton onPress={openModal}>Open modal</ActionButton>
+          <Header><Heading>Title</Heading></Header>
+          <Divider />
+          <Content><Text>I am a dialog</Text></Content>
+          <Footer><ActionButton onPress={openModal}>Open modal</ActionButton></Footer>
         </Dialog>
       </DialogTrigger>
       <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>
         <Dialog>
-          <p>I am a dialog</p>
-          <Button variant="cta" onPress={() => setModalOpen(false)}>Close</Button>
+          <Header><Heading>Title</Heading></Header>
+          <Divider />
+          <Content><Text>I am a dialog</Text></Content>
+          <Footer><Button variant="cta" onPress={() => setModalOpen(false)}>Close</Button></Footer>
         </Dialog>
       </Modal>
     </Fragment>


### PR DESCRIPTION
Closes <!-- Github issue # here -->

while fixing this, i noticed that in the unmounting example, keyboard focus isn't returned to the button after the modal closes
?path=/story/modal--unmounting-trigger

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
