### PR TITLE
Implement Picker menu width behavior

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -128,10 +128,25 @@ governing permissions and limitations under the License.
   min-width: var(--spectrum-dropdown-quiet-min-width);
 }
 
-.spectrum-Dropdown-popover {
-  max-width: var(--spectrum-dropdown-popover-max-width);
+.spectrum-Dropdown-popover--quiet {
+  width: var(--spectrum-dropdown-width);
+
+  /* Define this var so it can be read from JS */
+  --spectrum-dropdown-quiet-offset: calc(var(--spectrum-dropdown-quiet-popover-offset-x) + var(--spectrum-popover-border-size));
+  margin-left: calc(var(--spectrum-dropdown-quiet-offset) * -1);
 }
 
-.spectrum-Dropdown-popover--quiet {
-  margin-left: calc(calc(var(--spectrum-dropdown-quiet-popover-offset-x) + var(--spectrum-popover-border-size)) * -1);
+/* When used with a label or inside a Form, we need to override some things from .spectrum-Field
+ * so quiet dropdowns still collapse properly. */
+.spectrum-Field.spectrum-Dropdown-fieldWrapper--quiet {
+  width: auto;
+
+  .spectrum-Dropdown--quiet {
+    width: auto;
+    min-width: var(--spectrum-dropdown-quiet-min-width);
+
+    .spectrum-Dropdown-trigger {
+      width: auto;
+    }
+  }
 }

--- a/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/fieldlabel/index.css
@@ -71,7 +71,7 @@ governing permissions and limitations under the License.
   }
 
   /* The side label variant of Field is inline, and fills as much space as needed
-  * by default. If an explicit width is set, then the field flexes to fill available space. */
+   * by default. If an explicit width is set, then the field flexes to fill available space. */
   &.spectrum-Field--positionSide {
     display: inline-flex;
     align-items: flex-start;
@@ -99,16 +99,16 @@ governing permissions and limitations under the License.
     .spectrum-Field {
       display: table-row;
       width: 100%;
+    }
 
-      .spectrum-FieldLabel {
-        display: table-cell;
-      }
+    .spectrum-FieldLabel {
+      display: table-cell;
+    }
 
-      .spectrum-Field-field {
-        display: table-cell;
-        width: auto;
-        min-width: var(--spectrum-component-single-line-width);
-      }
+    .spectrum-Field-field {
+      display: table-cell;
+      width: auto;
+      min-width: var(--spectrum-component-single-line-width);
     }
   }
 
@@ -120,8 +120,8 @@ governing permissions and limitations under the License.
     min-width: var(--spectrum-component-single-line-width);
 
     /* Users may want to make multiple fields appear next to each other.
-    * We want to ensure that all items inside the form get the proper
-    * margin and widths applied, even if wrapped in extra divs for example. */
+     * We want to ensure that all items inside the form get the proper
+     * margin and widths applied, even if wrapped in extra divs for example. */
     > * {
       margin-top: var(--spectrum-fieldlabel-margin);
       width: 100%;

--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -47,7 +47,6 @@ governing permissions and limitations under the License.
   overflow: auto;
   user-select: none;
 
-  width: 200px;
   max-height: inherit; /* inherit from parent popover */
 
   & .spectrum-Menu-sectionHeading {

--- a/packages/@react-spectrum/form/stories/Form.stories.tsx
+++ b/packages/@react-spectrum/form/stories/Form.stories.tsx
@@ -11,6 +11,7 @@
  */
 
 import {Form} from '../';
+import {Item, Picker} from '@react-spectrum/picker';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
@@ -76,6 +77,10 @@ storiesOf('Form', module)
     () => render({isQuiet: true})
   )
   .add(
+    'isQuiet, labelPosition: side',
+    () => render({isQuiet: true, labelPosition: 'side'})
+  )
+  .add(
     'isEmphasized',
     () => render({isEmphasized: true})
   )
@@ -100,6 +105,14 @@ function render(props: any = {}) {
         <Radio value="cats">Cats</Radio>
         <Radio value="dragons">Dragons</Radio>
       </RadioGroup>
+      <Picker label="Favorite color">
+        <Item>Red</Item>
+        <Item>Orange</Item>
+        <Item>Yellow</Item>
+        <Item>Green</Item>
+        <Item>Blue</Item>
+        <Item>Purple</Item>
+      </Picker>
     </Form>
   );
 }

--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -96,7 +96,7 @@ storiesOf('ListBox', module)
     'Default ListBox',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={flatOptions} itemKey="name">
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={flatOptions} itemKey="name">
           {item => <Item>{item.name}</Item>}
         </ListBox>
       </Popover>
@@ -106,7 +106,7 @@ storiesOf('ListBox', module)
     'ListBox w/ sections',
     () => (
       <Popover isOpen hideArrow style={{maxHeight: 300}}>
-        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+        <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -120,7 +120,7 @@ storiesOf('ListBox', module)
     'ListBox w/ many sections',
     () => (
       <Popover isOpen hideArrow style={{maxHeight: 300}}>
-        <ListBox aria-labelledby="label" items={lotsOfSections} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+        <ListBox width={200} aria-labelledby="label" items={lotsOfSections} itemKey="name" onSelectionChange={action('onSelectionChange')}>
           {item => (
             <Section items={item.children} title={item.name}>
               {(item: any) => <Item>{item.name}</Item>}
@@ -134,7 +134,7 @@ storiesOf('ListBox', module)
     'Static',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
           <Item>One</Item>
           <Item>Two</Item>
           <Item>Three</Item>
@@ -146,7 +146,7 @@ storiesOf('ListBox', module)
     'Static with sections',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
           <Section title="Section 1">
             <Item>One</Item>
             <Item>Two</Item>
@@ -165,7 +165,7 @@ storiesOf('ListBox', module)
     'with default selected options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -179,7 +179,7 @@ storiesOf('ListBox', module)
     'static with default selected options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -213,7 +213,7 @@ storiesOf('ListBox', module)
     'with selected options (controlled)',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -227,7 +227,7 @@ storiesOf('ListBox', module)
     'static with selected options (controlled)',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -261,7 +261,7 @@ storiesOf('ListBox', module)
     'with disabled options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -275,7 +275,7 @@ storiesOf('ListBox', module)
     'static with disabled options',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} disabledKeys={['3', '5']}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} disabledKeys={['3', '5']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -309,7 +309,7 @@ storiesOf('ListBox', module)
     'Multiple selection',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
+        <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -323,7 +323,7 @@ storiesOf('ListBox', module)
     'Multiple selection, static',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['2', '5']} disabledKeys={['1', '3']}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['2', '5']} disabledKeys={['1', '3']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -354,7 +354,7 @@ storiesOf('ListBox', module)
     'No selection allowed',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="none">
+        <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="none">
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -368,7 +368,7 @@ storiesOf('ListBox', module)
     'No selection allowed, static',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectionMode="none">
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectionMode="none">
           <Section title="Section 1">
             <Item>One</Item>
             <Item>Two</Item>
@@ -387,7 +387,7 @@ storiesOf('ListBox', module)
     'ListBox with autoFocus=true',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus>
+        <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -401,7 +401,7 @@ storiesOf('ListBox', module)
     'ListBox with autoFocus=true and focusStrategy="last"',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus focusStrategy="last">
+        <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus focusStrategy="last">
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -415,7 +415,7 @@ storiesOf('ListBox', module)
     'ListBox with keyboard selection wrapping',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} wrapAround>
+        <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} wrapAround>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item>{item.name}</Item>}
@@ -429,7 +429,7 @@ storiesOf('ListBox', module)
     'with semantic elements (static)',
     () => (
       <Popover isOpen hideArrow>
-        <ListBox aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
+        <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')}>
           <Section title="Section 1">
             <Item textValue="Copy">
               <Copy size="S" />
@@ -470,7 +470,7 @@ storiesOf('ListBox', module)
     'with semantic elements (generative)',
     () => (
       <Popover isOpen hideArrow> 
-        <ListBox aria-labelledby="label"items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
+        <ListBox width={200} aria-labelledby="label"items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
           {item => (
             <Section items={item.children} title={item.name}>
               {item => customOption(item)}

--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -27,7 +27,7 @@ interface PopoverProps extends HTMLAttributes<HTMLElement> {
 }
 
 function Popover(props: PopoverProps, ref: RefObject<HTMLDivElement>) {
-  let {style, children, placement = 'bottom', arrowProps, isOpen, onClose, hideArrow, ...otherProps} = props;
+  let {style, children, placement = 'bottom', arrowProps, isOpen, onClose, hideArrow, className, ...otherProps} = props;
   let backupRef = useRef();
   let domRef = ref || backupRef;
   let {overlayProps} = useOverlay({ref: domRef, onClose, isOpen, isDismissable: true});
@@ -50,7 +50,8 @@ function Popover(props: PopoverProps, ref: RefObject<HTMLDivElement>) {
             overrideStyles,
             'spectrum-Popover',
             'react-spectrum-Popover'
-          )
+          ),
+          className
         )
       }
       role="presentation"

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -29,6 +29,7 @@
     "@react-aria/select": "^3.0.0-alpha.1",
     "@react-aria/utils": "^3.0.0-alpha.1",
     "@react-spectrum/button": "^3.0.0-rc.1",
+    "@react-spectrum/form": "^3.0.0-rc.1",
     "@react-spectrum/label": "^3.0.0-rc.1",
     "@react-spectrum/listbox": "^3.0.0-alpha.1",
     "@react-spectrum/overlays": "^3.0.0-alpha.1",

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -12,7 +12,7 @@
 
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
-import {classNames, filterDOMProps, SlotProvider, unwrapDOMRef, useDOMRef, useMediaQuery, useStyleProps} from '@react-spectrum/utils';
+import {classNames, dimensionValue, filterDOMProps, SlotProvider, unwrapDOMRef, useDOMRef, useMediaQuery, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef, DOMRefValue, FocusableRefValue, LabelPosition} from '@react-types/shared';
 import {FieldButton} from '@react-spectrum/button';
 import {FocusScope} from '@react-aria/focus';
@@ -22,10 +22,11 @@ import {ListBoxBase, useListBoxLayout} from '@react-spectrum/listbox';
 import {mergeProps} from '@react-aria/utils';
 import {Overlay, Popover, Tray} from '@react-spectrum/overlays';
 import {Placement} from '@react-types/overlays';
-import React, {ReactElement, useRef} from 'react';
+import React, {ReactElement, useLayoutEffect, useRef, useState} from 'react';
 import {SpectrumPickerProps} from '@react-types/select';
 import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
 import {Text} from '@react-spectrum/typography';
+import {useFormProps} from '@react-spectrum/form';
 import {useOverlayPosition} from '@react-aria/overlays';
 import {useProviderProps} from '@react-spectrum/provider';
 import {useSelect} from '@react-aria/select';
@@ -33,6 +34,7 @@ import {useSelectState} from '@react-stately/select';
 
 function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
   props = useProviderProps(props);
+  props = useFormProps(props);
   let {
     isDisabled,
     direction = 'bottom',
@@ -45,7 +47,8 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
     labelPosition = 'top' as LabelPosition,
     labelAlign,
     isRequired,
-    necessityIndicator
+    necessityIndicator,
+    menuWidth
   } = props;
 
   let {styleProps} = useStyleProps(props);
@@ -92,6 +95,15 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
     </FocusScope>
   );
 
+  // Measure the width of the button to inform the width of the menu (below).
+  let [buttonWidth, setButtonWidth] = useState(null);
+  useLayoutEffect(() => {
+    if (!isMobile) {
+      let width = triggerRef.current.UNSAFE_getDOMNode().offsetWidth;
+      setButtonWidth(width);
+    }
+  }, [isMobile, triggerRef, state.selectedKey]);
+
   let overlay;
   if (isMobile) {
     overlay = (
@@ -100,8 +112,24 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
       </Tray>
     );
   } else {
+    // If quiet, use the default width, otherwise match the width of the button. This can be overridden by the menuWidth prop.
+    // Always have a minimum width of the button width. When quiet, there is an extra offset to add.
+    let width = isQuiet ? null : buttonWidth;
+    let style = {
+      ...overlayProps.style,
+      width: menuWidth ? dimensionValue(menuWidth) : width,
+      minWidth: isQuiet ? `calc(${buttonWidth}px + calc(2 * var(--spectrum-dropdown-quiet-offset)))` : buttonWidth
+    };
+
     overlay = (
-      <Popover {...overlayProps} ref={popoverRef} placement={placement} hideArrow onClose={() => state.setOpen(false)}>
+      <Popover 
+        {...overlayProps}
+        style={style}
+        className={classNames(styles, 'spectrum-Dropdown-popover', {'spectrum-Dropdown-popover--quiet': isQuiet})}
+        ref={popoverRef}
+        placement={placement}
+        hideArrow
+        onClose={() => state.setOpen(false)}>
         {listbox}
       </Popover>
     );
@@ -123,8 +151,11 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
         classNames(
           styles,
           'spectrum-Dropdown',
-          {'is-invalid': validationState === 'invalid'},
-          styleProps.className
+          {
+            'is-invalid': validationState === 'invalid',
+            'is-disabled': isDisabled,
+            'spectrum-Dropdown--quiet': isQuiet
+          }
         )
       }>
       <FieldButton
@@ -169,6 +200,11 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
         'spectrum-Field--positionTop': labelPosition === 'top',
         'spectrum-Field--positionSide': labelPosition === 'side'
       },
+      classNames(
+        styles,
+        'spectrum-Field',
+        {'spectrum-Dropdown-fieldWrapper--quiet': isQuiet}
+      ),
       styleProps.className
     );
 

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -15,6 +15,7 @@ import AlignLeft from '@spectrum-icons/workflow/AlignLeft';
 import AlignRight from '@spectrum-icons/workflow/AlignRight';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
+import {Flex} from '@react-spectrum/layout';
 import {Item, Picker, Section} from '../';
 import Paste from '@spectrum-icons/workflow/Paste';
 import React from 'react';
@@ -106,16 +107,6 @@ storiesOf('Picker', module)
     )
   )
   .add(
-    'isQuiet',
-    () => (
-      <Picker isQuiet label="Test">
-        <Item>One</Item>
-        <Item>Two</Item>
-        <Item>Three</Item>
-      </Picker>
-    )
-  )
-  .add(
     'labelAlign: end',
     () => (
       <Picker label="Test" labelAlign="end">
@@ -176,6 +167,86 @@ storiesOf('Picker', module)
     )
   )
   .add(
+    'isQuiet',
+    () => (
+      <Picker isQuiet label="Test">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, isDisabled',
+    () => (
+      <Picker label="Test" isQuiet isDisabled>
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, labelAlign: end',
+    () => (
+      <Picker label="Test" isQuiet labelAlign="end">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, labelPosition: side',
+    () => (
+      <Picker label="Test" isQuiet labelPosition="side">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, isRequired',
+    () => (
+      <Picker label="Test" isQuiet isRequired>
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, isRequired, necessityIndicator: label',
+    () => (
+      <Picker label="Test" isQuiet isRequired necessityIndicator="label">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, optional, necessityIndicator: label',
+    () => (
+      <Picker label="Test" isQuiet necessityIndicator="label">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, validationState: invalid',
+    () => (
+      <Picker label="Test" isQuiet validationState="invalid">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
     'complex items',
     () => (
       <Picker label="Test">
@@ -208,6 +279,114 @@ storiesOf('Picker', module)
             <Text>Floof</Text>
           </Item>
         </Section>
+      </Picker>
+    )
+  )
+  .add(
+    'no visible label',
+    () => (
+      <Picker aria-label="Test">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, no visible label',
+    () => (
+      <Picker aria-label="Test" isQuiet>
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'isQuiet, align: end',
+    () => (
+      <Picker aria-label="Test" isQuiet align="end">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
+      </Picker>
+    )
+  )
+  .add(
+    'custom widths',
+    () => (
+      <Flex flexDirection="column">
+        <Picker label="Test" width="size-1200">
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+        <Picker label="Test" width="size-6000">
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+      </Flex>
+    )
+  )
+  .add(
+    'custom widths, labelPosition: side',
+    () => (
+      <Flex flexDirection="column">
+        <Picker label="Test" width="size-1200" labelPosition="side">
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+        <Picker label="Test" width="size-6000" labelPosition="side">
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+      </Flex>
+    )
+  )
+  .add(
+    'custom menu widths',
+    () => (
+      <Flex flexDirection="column">
+        <Picker label="Test" menuWidth="size-1000">
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+        <Picker label="Test" menuWidth="size-6000">
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+      </Flex>
+    )
+  )
+  .add(
+    'custom menu widths, isQuiet',
+    () => (
+      <Flex flexDirection="column">
+        <Picker label="Test" menuWidth="size-400" isQuiet>
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+        <Picker label="Test" menuWidth="size-6000" isQuiet>
+          <Item>One</Item>
+          <Item>Two</Item>
+          <Item>Three</Item>
+        </Picker>
+      </Flex>
+    )
+  )
+  .add(
+    'custom menu width, align: end',
+    () => (
+      <Picker label="Test" menuWidth="size-6000" align="end">
+        <Item>One</Item>
+        <Item>Two</Item>
+        <Item>Three</Item>
       </Picker>
     )
   );

--- a/packages/@react-types/shared/src/style.d.ts
+++ b/packages/@react-types/shared/src/style.d.ts
@@ -118,6 +118,8 @@ type AlignContentType = 'center'| 'start'| 'end'| 'flex-start' | 'flex-end' | 'n
 type AlignItemsType = 'normal'| 'stretch'| 'center'| 'start' | 'end' | 'flex-start' | 'flex-end' | 'baseline' | 'first baseline' | 'last baseline' | 'safe center' | 'unsafe center' | GlobalVals;
 
 export interface FlexStyleProps extends StyleProps {
+  flexDirection?: 'row' | 'column' | 'row-reverse' | 'column-reverse',
+  flexWrap?: 'wrap' | 'nowrap' | 'wrap-reverse',
   justifyContent?: JustifyContentType,
   justifyItems?: JustifyItemsType,
   alignContent?: AlignContentType,


### PR DESCRIPTION
This implements the menu width behavior for Picker. It is as follows:

* If standard, use the width of the button by default.
* If quiet, use `--spectrum-alias-single-line-width` as a default width.
* The width can be overridden by the `menuWidth` option.
* If standard, the minimum width is the width of the button.
* If quiet, the minimum width is the width of the button plus the offset.

Also adds a bunch of stories to test the behavior of Picker with different options and within a Form.