### PR TITLE
Change to selectionMode="none" by default for Menu, and onAction instead of onPress

### DIFF
--- a/packages/@react-aria/menu/src/useMenuItem.ts
+++ b/packages/@react-aria/menu/src/useMenuItem.ts
@@ -34,7 +34,7 @@ interface MenuItemProps {
   onClose?: () => void,
   closeOnSelect?: boolean,
   isVirtualized?: boolean,
-  onPress: (e: PressEvent) => void
+  onAction?: (key: Key) => void
 }
 
 export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuItemAria {
@@ -46,7 +46,7 @@ export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuI
     closeOnSelect,
     ref,
     isVirtualized,
-    onPress
+    onAction
   } = props;
 
   let role = 'menuitem';
@@ -91,9 +91,21 @@ export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuI
     }
   };
 
-  let onPressUp = (e) => {
-    if (e.pointerType !== 'keyboard' && closeOnSelect && onClose) {
-      onClose();
+  let onPressStart = (e: PressEvent) => {
+    if (e.pointerType === 'keyboard' && onAction) {
+      onAction(key);
+    }
+  };
+
+  let onPressUp = (e: PressEvent) => {
+    if (e.pointerType !== 'keyboard') {
+      if (onAction) {
+        onAction(key);
+      }
+
+      if (closeOnSelect && onClose) {
+        onClose();
+      }
     }
   };
 
@@ -104,7 +116,7 @@ export function useMenuItem<T>(props: MenuItemProps, state: MenuState<T>): MenuI
     selectOnPressUp: true
   });
 
-  let {pressProps} = usePress(mergeProps({onPressUp, onPress, onKeyDown, isDisabled}, itemProps));
+  let {pressProps} = usePress(mergeProps({onPressStart, onPressUp, onKeyDown, isDisabled}, itemProps));
   let {hoverProps} = useHover({
     isDisabled,
     onHover() {

--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -36,6 +36,7 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
     showRoot,
     isDisabled,
     maxVisibleItems = MAX_VISIBLE_ITEMS,
+    onAction,
     ...otherProps
   } = props;
 
@@ -88,15 +89,13 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
 
     let menuItem = (
       <BreadcrumbItem key="menu">
-        <MenuTrigger
-          isDisabled={isDisabled}>
+        <MenuTrigger isDisabled={isDisabled}>
           <ActionButton
             aria-label="…"
             isQuiet>
             <FolderBreadcrumb />
           </ActionButton>
-          <Menu
-            selectionMode="none" >
+          <Menu selectionMode="none" onAction={onAction}>
             {childArray}
           </Menu>
         </MenuTrigger>
@@ -115,23 +114,30 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
   let lastIndex = childArray.length - 1;
   let breadcrumbItems = childArray.map((child, index) => {
     let isCurrent = index === lastIndex;
-    let breadcrumbItemProps = {
-      isCurrent,
-      isHeading: isCurrent && isHeading,
-      headingAriaLevel,
-      isDisabled,
-      ...child.props
+    let key = child.props.uniqueKey || child.key;
+    let onPress = () => {
+      if (onAction) {
+        onAction(key);
+      }
     };
+
     return (
       <li
-        key={child.key}
+        key={key}
         className={
           classNames(
             styles,
             'spectrum-Breadcrumbs-item'
           )
         }>
-        <BreadcrumbItem {...breadcrumbItemProps} />
+        <BreadcrumbItem
+          isCurrent={isCurrent}
+          isHeading={isCurrent && isHeading}
+          headingAriaLevel={headingAriaLevel}
+          isDisabled={isDisabled}
+          onPress={onPress}>
+          {child.props.children}
+        </BreadcrumbItem>
       </li>
     );
   });

--- a/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
+++ b/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
@@ -37,36 +37,32 @@ storiesOf('Breadcrumbs', module)
     () => render({size: 'L'})
   )
   .add(
-    'onPress',
-    () => renderPress({})
-  )
-  .add(
     'maxVisibleItems: 4',
-    () => renderPress({})
+    () => renderMany({})
   )
   .add(
     'maxVisibleItems: 4, showRoot: true',
-    () => renderPress({showRoot: true})
+    () => renderMany({showRoot: true})
   )
   .add(
     'maxVisibleItems: auto',
-    () => renderPress({maxVisibleItems: 'auto'})
+    () => renderMany({maxVisibleItems: 'auto'})
   )
   .add(
     'collapsed, maxVisibleItems: auto',
     () => (
       <div style={{width: '100px'}}>
-        {renderPress({maxVisibleItems: 'auto'})}
+        {renderMany({maxVisibleItems: 'auto'})}
       </div>
     )
   )
   .add(
     'maxVisibleItems: auto, showRoot: true',
-    () => renderPress({maxVisibleItems: 'auto', showRoot: true})
+    () => renderMany({maxVisibleItems: 'auto', showRoot: true})
   )
   .add(
     'maxVisibleItems: auto, size: L',
-    () => renderPress({maxVisibleItems: 'auto', size: 'L'})
+    () => renderMany({maxVisibleItems: 'auto', size: 'L'})
   )
   .add(
     'isDisabled: true',
@@ -87,24 +83,24 @@ storiesOf('Breadcrumbs', module)
 
 function render(props = {}) {
   return (
-    <Breadcrumbs {...props}>
-      <Item>Folder 1</Item>
-      <Item>Folder 2</Item>
-      <Item>Folder 3</Item>
+    <Breadcrumbs {...props} onAction={action('onAction')}>
+      <Item uniqueKey="Folder 1">Folder 1</Item>
+      <Item uniqueKey="Folder 2">Folder 2</Item>
+      <Item uniqueKey="Folder 3">Folder 3</Item>
     </Breadcrumbs>
   );
 }
 
-function renderPress(props = {}) {
+function renderMany(props = {}) {
   return (
-    <Breadcrumbs {...props}>
-      <Item onPress={action('press Folder 1')}>Folder 1</Item>
-      <Item onPress={action('press Folder 2')}>Folder 2</Item>
-      <Item onPress={action('press Folder 3')}>Folder 3</Item>
-      <Item onPress={action('press Folder 4')}>Folder 4</Item>
-      <Item onPress={action('press Folder 5')}>Folder 5</Item>
-      <Item onPress={action('press Folder 6')}>Folder 6</Item>
-      <Item onPress={action('press Folder 7')}>Folder 7</Item>
+    <Breadcrumbs {...props} onAction={action('onAction')}>
+      <Item uniqueKey="Folder 1">Folder 1</Item>
+      <Item uniqueKey="Folder 2">Folder 2</Item>
+      <Item uniqueKey="Folder 3">Folder 3</Item>
+      <Item uniqueKey="Folder 4">Folder 4</Item>
+      <Item uniqueKey="Folder 5">Folder 5</Item>
+      <Item uniqueKey="Folder 6">Folder 6</Item>
+      <Item uniqueKey="Folder 7">Folder 7</Item>
     </Breadcrumbs>
   );
 }

--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -168,8 +168,8 @@ describe('Breadcrumbs', function () {
   it('Handles isDisabled', () => {
     let {getByText} = render(
       <Breadcrumbs isDisabled>
-        <Item data-testid="item-1">Folder 1</Item>
-        <Item data-testid="item-2">Folder 2</Item>
+        <Item>Folder 1</Item>
+        <Item>Folder 2</Item>
       </Breadcrumbs>
     );
 

--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -70,20 +70,20 @@ describe('Breadcrumbs', function () {
   });
 
   it('Handles multiple items', () => {
-    let {getByTestId} = render(
+    let {getByText} = render(
       <Breadcrumbs className="test-class">
-        <Item data-testid="item-1">Folder 1</Item>
-        <Item data-testid="item-2">Folder 2</Item>
-        <Item data-testid="item-3">Folder 3</Item>
+        <Item>Folder 1</Item>
+        <Item>Folder 2</Item>
+        <Item>Folder 3</Item>
       </Breadcrumbs>
     );
-    let item1 = getByTestId('item-1');
+    let item1 = getByText('Folder 1');
     expect(item1.tabIndex).toBe(0);
     expect(item1).not.toHaveAttribute('aria-current');
-    let item2 = getByTestId('item-2');
+    let item2 = getByText('Folder 2');
     expect(item2.tabIndex).toBe(0);
     expect(item2).not.toHaveAttribute('aria-current');
-    let item3 = getByTestId('item-3');
+    let item3 = getByText('Folder 3');
     expect(item3.tabIndex).toBe(-1);
     expect(item3).toHaveAttribute('aria-current', 'page');
   });
@@ -166,16 +166,16 @@ describe('Breadcrumbs', function () {
   });
 
   it('Handles isDisabled', () => {
-    let {getByTestId} = render(
+    let {getByText} = render(
       <Breadcrumbs isDisabled>
         <Item data-testid="item-1">Folder 1</Item>
         <Item data-testid="item-2">Folder 2</Item>
       </Breadcrumbs>
     );
 
-    let item1 = getByTestId('item-1');
+    let item1 = getByText('Folder 1');
     expect(item1).toHaveAttribute('aria-disabled', 'true');
-    let item2 = getByTestId('item-2');
+    let item2 = getByText('Folder 2');
     expect(item2).toHaveAttribute('aria-disabled', 'true');
   });
 
@@ -226,11 +226,11 @@ describe('Breadcrumbs', function () {
 
 
   it('Handles max visible items auto with dialog', () => {
-    let onPress = jest.fn();
+    let onAction = jest.fn();
     let {getAllByText, getByRole, getAllByRole} = render(
       <Provider theme={theme}>
-        <Breadcrumbs maxVisibleItems="auto" showRoot>
-          <Item onPress={() => onPress('Folder 1')}>Folder 1</Item>
+        <Breadcrumbs maxVisibleItems="auto" showRoot onAction={onAction}>
+          <Item uniqueKey="Folder 1">Folder 1</Item>
           <Item>Folder 2</Item>
           <Item>Folder 3</Item>
           <Item>Folder 4</Item>
@@ -253,11 +253,11 @@ describe('Breadcrumbs', function () {
     // breadcrumb root item
     expect(item1[0]).toHaveAttribute('role', 'link');
     triggerPress(item1[0]);
-    expect(onPress).toHaveBeenCalledWith('Folder 1');
+    expect(onAction).toHaveBeenCalledWith('Folder 1');
 
     // menu item
     expect(item1[1]).not.toHaveAttribute('role');
     triggerPress(item1[1]);
-    expect(onPress).toHaveBeenCalledWith('Folder 1');
+    expect(onAction).toHaveBeenCalledWith('Folder 1');
   });
 });

--- a/packages/@react-spectrum/menu/src/Menu.tsx
+++ b/packages/@react-spectrum/menu/src/Menu.tsx
@@ -25,7 +25,7 @@ export function Menu<T>(props: SpectrumMenuProps<T>) {
   let contextProps = useContext(MenuContext);
   let completeProps = {
     ...mergeProps(contextProps, props),
-    selectionMode: props.selectionMode || 'single'
+    selectionMode: props.selectionMode || 'none'
   };
 
   let ref = useRef();
@@ -52,7 +52,8 @@ export function Menu<T>(props: SpectrumMenuProps<T>) {
             <MenuSection 
               key={item.key}
               item={item}
-              state={state} />
+              state={state}
+              onAction={completeProps.onAction} />
           );
         }
 
@@ -60,7 +61,8 @@ export function Menu<T>(props: SpectrumMenuProps<T>) {
           <MenuItem
             key={item.key}
             item={item}
-            state={state} />
+            state={state}
+            onAction={completeProps.onAction} />
         );
 
         if (item.wrapper) {

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -15,7 +15,7 @@ import {classNames} from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
 import {Grid} from '@react-spectrum/layout';
 import {Node} from '@react-stately/collections';
-import React, {useRef} from 'react';
+import React, {Key, useRef} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
 import {Text} from '@react-spectrum/typography';
 import {TreeState} from '@react-stately/tree';
@@ -26,13 +26,15 @@ interface MenuItemProps<T> {
   item: Node<T>,
   state: TreeState<T>,
   isVirtualized?: boolean,
+  onAction?: (key: Key) => void
 }
 
 export function MenuItem<T>(props: MenuItemProps<T>) {
   let {
     item,
     state,
-    isVirtualized
+    isVirtualized,
+    onAction
   } = props;
 
   let {
@@ -44,8 +46,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
     rendered,
     isSelected,
     isDisabled,
-    key,
-    props: itemProps
+    key
   } = item;
 
   let ref = useRef<HTMLLIElement>();
@@ -58,7 +59,7 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
       closeOnSelect,
       ref,
       isVirtualized,
-      onPress: itemProps.onPress
+      onAction
     }, 
     state
   );

--- a/packages/@react-spectrum/menu/src/MenuSection.tsx
+++ b/packages/@react-spectrum/menu/src/MenuSection.tsx
@@ -13,7 +13,7 @@
 import {classNames} from '@react-spectrum/utils';
 import {MenuItem} from './MenuItem';
 import {Node} from '@react-stately/collections';
-import React, {Fragment} from 'react';
+import React, {Fragment, Key} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
 import {TreeState} from '@react-stately/tree';
 import {useMenuSection} from '@react-aria/menu';
@@ -21,11 +21,12 @@ import {useSeparator} from '@react-aria/separator';
 
 interface MenuSectionProps<T> {
   item: Node<T>,
-  state: TreeState<T>
+  state: TreeState<T>,
+  onAction?: (key: Key) => void
 }
 
 export function MenuSection<T>(props: MenuSectionProps<T>) {
-  let {item, state} = props;
+  let {item, state, onAction} = props;
   let {itemProps, headingProps, groupProps} = useMenuSection();
   let {separatorProps} = useSeparator({
     elementType: 'li'
@@ -67,7 +68,8 @@ export function MenuSection<T>(props: MenuSectionProps<T>) {
               <MenuItem
                 key={node.key}
                 item={node}
-                state={state} />
+                state={state}
+                onAction={onAction} />
             );
 
             if (node.wrapper) {

--- a/packages/@react-spectrum/menu/stories/Menu.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/Menu.stories.tsx
@@ -88,7 +88,7 @@ storiesOf('Menu', module)
     'Default Menu',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} items={flatMenu} itemKey="name">
+        <Menu items={flatMenu} itemKey="name" onAction={action('onAction')}>
           {item => <Item>{item.name}</Item>}
         </Menu>
       </Popover>
@@ -98,10 +98,10 @@ storiesOf('Menu', module)
     'Menu w/ sections',
     () => (
       <Popover isOpen hideArrow>
-        <Menu items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+        <Menu items={withSection} itemKey="name" onAction={action('onAction')}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </Menu>
@@ -112,7 +112,7 @@ storiesOf('Menu', module)
     'Static',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')}>
+        <Menu onAction={action('onAction')}>
           <Item>One</Item>
           <Item>Two</Item>
           <Item>Three</Item>
@@ -124,7 +124,7 @@ storiesOf('Menu', module)
     'Static with sections',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')}>
+        <Menu onAction={action('onAction')}>
           <Section title="Section 1">
             <Item>One</Item>
             <Item>Two</Item>
@@ -143,7 +143,7 @@ storiesOf('Menu', module)
     'Static with dialog trigger',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} selectionMode="none">
+        <Menu>
           <Section title="Actions">
             <DialogTrigger>
               <Item>Edit...</Item>
@@ -169,10 +169,24 @@ storiesOf('Menu', module)
     )
   )
   .add(
+    'with single selection',
+    () => (
+      <Popover isOpen hideArrow>
+        <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name">
+          {item => (
+            <Section items={item.children} title={item.name}>
+              {item => <Item childItems={item.children}>{item.name}</Item>}
+            </Section>
+          )}
+        </Menu>
+      </Popover>
+    )
+  )
+  .add(
     'with default selected menu items',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
+        <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item childItems={item.children}>{item.name}</Item>}
@@ -186,7 +200,7 @@ storiesOf('Menu', module)
     'static with default selected menu items',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
+        <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -220,7 +234,7 @@ storiesOf('Menu', module)
     'with selected menu items (controlled)',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
+        <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => <Item childItems={item.children}>{item.name}</Item>}
@@ -234,7 +248,7 @@ storiesOf('Menu', module)
     'static with selected menu items (controlled)',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
+        <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -268,10 +282,10 @@ storiesOf('Menu', module)
     'with disabled menu items',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']}>
+        <Menu items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']} onAction={action('onAction')}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </Menu>
@@ -282,7 +296,7 @@ storiesOf('Menu', module)
     'static with disabled menu items',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} disabledKeys={['3', '5']}>
+        <Menu disabledKeys={['3', '5']} onAction={action('onAction')}>
           <Section title="Section 1">
             <Item uniqueKey="1">
               One
@@ -358,46 +372,13 @@ storiesOf('Menu', module)
     )
   )
   .add(
-    'No selection allowed menu',
-    () => (
-      <Popover isOpen hideArrow>
-        <Menu items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="none">
-          {item => (
-            <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
-            </Section>
-          )}
-        </Menu>
-      </Popover>
-    )
-  )
-  .add(
-    'No selection allowed menu, static',
-    () => (
-      <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} selectionMode="none">
-          <Section title="Section 1">
-            <Item>One</Item>
-            <Item>Two</Item>
-            <Item>Three</Item>
-          </Section>
-          <Section title="Section 2">
-            <Item>Four</Item>
-            <Item>Five</Item>
-            <Item>Six</Item>
-          </Section>
-        </Menu>
-      </Popover>
-    )
-  )
-  .add(
     'Menu with autoFocus=true',
     () => (
       <Popover isOpen hideArrow>
-        <Menu items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus>
+        <Menu items={withSection} itemKey="name" autoFocus onAction={action('onAction')}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </Menu>
@@ -408,10 +389,10 @@ storiesOf('Menu', module)
     'Menu with autoFocus=true and focusStrategy="last"',
     () => (
       <Popover isOpen hideArrow>
-        <Menu items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus focusStrategy="last">
+        <Menu items={withSection} itemKey="name" autoFocus focusStrategy="last" onAction={action('onAction')}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </Menu>
@@ -422,10 +403,10 @@ storiesOf('Menu', module)
     'Menu with keyboard selection wrapping',
     () => (
       <Popover isOpen hideArrow>
-        <Menu items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} wrapAround>
+        <Menu items={withSection} itemKey="name" wrapAround onAction={action('onAction')}>
           {item => (
             <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+              {item => <Item>{item.name}</Item>}
             </Section>
           )}
         </Menu>
@@ -436,7 +417,7 @@ storiesOf('Menu', module)
     'with semantic elements (static)',
     () => (
       <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')}>
+        <Menu onAction={action('onAction')}>
           <Section title="Section 1">
             <Item textValue="Copy">
               <Copy size="S" />
@@ -482,34 +463,12 @@ storiesOf('Menu', module)
     'with semantic elements (generative)',
     () => (
       <Popover isOpen hideArrow> 
-        <Menu items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
+        <Menu items={hardModeProgrammatic} itemKey="name" onAction={action('onAction')}>
           {item => (
             <Section items={item.children} title={item.name}>
               {item => customMenuItem(item)}
             </Section>
           )}
-        </Menu>
-      </Popover>
-    )
-  )
-  .add(
-    'with onPress',
-    () => (
-      <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')} items={flatMenu} itemKey="name">
-          {item => <Item onPress={action('onPress')}>{item.name}</Item>}
-        </Menu>
-      </Popover>
-    )
-  )
-  .add(
-    'static with onPress',
-    () => (
-      <Popover isOpen hideArrow>
-        <Menu onSelectionChange={action('onSelectionChange')}>
-          <Item onPress={action('onPress One')}>One</Item>
-          <Item onPress={action('onPress Two')}>Two</Item>
-          <Item onPress={action('onPress Three')}>Three</Item>
         </Menu>
       </Popover>
     )

--- a/packages/@react-spectrum/menu/test/Menu.test.js
+++ b/packages/@react-spectrum/menu/test/Menu.test.js
@@ -42,30 +42,31 @@ let withSection = [
   ]}
 ];
 
-function renderComponent(Component, contextProps = {}, props) {
+function renderComponent(Component, contextProps = {}, props = {}) {
   if (Component === V2Menu) {
+    let role = props.onSelect ? 'menuitemradio' : 'menuitem';
     return render(
       <V2Menu id={menuId} {...props}>
         <V2MenuHeading>
           Heading 1
         </V2MenuHeading>
-        <V2MenuItem role="menuitemradio" value="foo">
+        <V2MenuItem role={role} value="foo">
           Foo
         </V2MenuItem>
-        <V2MenuItem role="menuitemradio" value="bar">
+        <V2MenuItem role={role} value="bar">
           Bar
         </V2MenuItem>
-        <V2MenuItem role="menuitemradio" value="baz" disabled>
+        <V2MenuItem role={role} value="baz" disabled>
           Baz
         </V2MenuItem>
         <V2MenuDivider />
         <V2MenuHeading>
           Heading 2
         </V2MenuHeading>
-        <V2MenuItem role="menuitemradio" value="blah">
+        <V2MenuItem role={role} value="blah">
           Blah
         </V2MenuItem>
-        <V2MenuItem role="menuitemradio" value="bleh">
+        <V2MenuItem role={role} value="bleh">
           Bleh
         </V2MenuItem>
       </V2Menu>
@@ -133,12 +134,11 @@ describe('Menu', function () {
     let dividers = within(menu).getAllByRole('separator');
     expect(dividers.length).toBe(1);
 
-    let items = within(menu).getAllByRole('menuitemradio');
+    let items = within(menu).getAllByRole('menuitem');
     expect(items.length).toBe(5);
     for (let item of items) {
       if (Component === Menu) {
         expect(item).toHaveAttribute('tabindex');
-        expect(item).toHaveAttribute('aria-checked');
         expect(item).toHaveAttribute('aria-disabled');
       }
     }
@@ -163,7 +163,7 @@ describe('Menu', function () {
   `('$Name allows user to change menu item focus via up/down arrow keys', function ({Component, props}) {
     let tree = renderComponent(Component, {}, props);
     let menu = tree.getByRole('menu');
-    let menuItems = within(menu).getAllByRole('menuitemradio');
+    let menuItems = within(menu).getAllByRole('menuitem');
     let selectedItem = menuItems[0];
     expect(selectedItem).toBe(document.activeElement);
     fireEvent.keyDown(selectedItem, {key: 'ArrowDown', code: 40, charCode: 40});
@@ -180,7 +180,7 @@ describe('Menu', function () {
   `('$Name wraps focus from first to last/last to first item if up/down arrow is pressed if wrapAround is true', function ({Component, props}) {
     let tree = renderComponent(Component, {}, props);
     let menu = tree.getByRole('menu');
-    let menuItems = within(menu).getAllByRole('menuitemradio');
+    let menuItems = within(menu).getAllByRole('menuitem');
     let firstItem = menuItems[0];
     expect(firstItem).toBe(document.activeElement);
     fireEvent.keyDown(firstItem, {key: 'ArrowUp', code: 38, charCode: 38});
@@ -193,7 +193,7 @@ describe('Menu', function () {
   describe('supports single selection', function () {
     it.each`
       Name        | Component | props
-      ${'Menu'}   | ${Menu}   | ${{onSelectionChange, defaultSelectedKeys: ['Blah'], autoFocus: true}}
+      ${'Menu'}   | ${Menu}   | ${{selectionMode: 'single', onSelectionChange, defaultSelectedKeys: ['Blah'], autoFocus: true}}
     `('$Name supports defaultSelectedKeys (uncontrolled)', function ({Component, props}) {
       // Check that correct menu item is selected by default
       let tree = renderComponent(Component, {}, props);
@@ -228,7 +228,7 @@ describe('Menu', function () {
 
     it.each`
     Name        | Component | props
-      ${'Menu'}   | ${Menu}   | ${{onSelectionChange, selectedKeys: ['Blah'], autoFocus: true}}
+      ${'Menu'}   | ${Menu}   | ${{selectionMode: 'single', onSelectionChange, selectedKeys: ['Blah'], autoFocus: true}}
     `('$Name supports selectedKeys (controlled)', function ({Component, props}) {
       // Check that correct menu item is selected by default
       let tree = renderComponent(Component, {}, props);
@@ -262,7 +262,7 @@ describe('Menu', function () {
 
     it.each`
       Name        | Component | props
-      ${'Menu'}   | ${Menu}   | ${{onSelectionChange}}
+      ${'Menu'}   | ${Menu}   | ${{selectionMode: 'single', onSelectionChange}}
       ${'V2Menu'} | ${V2Menu} | ${{onSelect}}
     `('$Name supports using space key to change item selection', function ({Component, props}) {
       let tree = renderComponent(Component, {}, props);
@@ -295,7 +295,7 @@ describe('Menu', function () {
 
     it.each`
       Name        | Component | props
-      ${'Menu'}   | ${Menu}   | ${{onSelectionChange}}
+      ${'Menu'}   | ${Menu}   | ${{selectionMode: 'single', onSelectionChange}}
       ${'V2Menu'} | ${V2Menu} | ${{onSelect}}
     `('$Name supports using click to change item selection', function ({Component, props}) {
       let tree = renderComponent(Component, {}, props);
@@ -327,7 +327,7 @@ describe('Menu', function () {
     
     it.each`
       Name        | Component | props
-      ${'Menu'}   | ${Menu}   | ${{onSelectionChange, disabledKeys: ['Baz']}}
+      ${'Menu'}   | ${Menu}   | ${{selectionMode: 'single', onSelectionChange, disabledKeys: ['Baz']}}
       ${'V2Menu'} | ${V2Menu} | ${{onSelect}}
     `('$Name supports disabled items', function ({Component, props}) {
       let tree = renderComponent(Component, {}, props);
@@ -573,7 +573,7 @@ describe('Menu', function () {
     `('$Name supports focusing items by typing letters in rapid succession', function ({Component, props}) {
       let tree = renderComponent(Component, {}, props);
       let menu = tree.getByRole('menu');
-      let menuItems = within(menu).getAllByRole('menuitemradio');
+      let menuItems = within(menu).getAllByRole('menuitem');
       expect(document.activeElement).toBe(menuItems[0]);
 
       fireEvent.keyDown(menu, {key: 'B'});
@@ -592,7 +592,7 @@ describe('Menu', function () {
     `('$Name resets the search text after a timeout', function ({Component, props}) {
       let tree = renderComponent(Component, {}, props);
       let menu = tree.getByRole('menu');
-      let menuItems = within(menu).getAllByRole('menuitemradio');
+      let menuItems = within(menu).getAllByRole('menuitem');
       expect(document.activeElement).toBe(menuItems[0]);
 
       fireEvent.keyDown(menu, {key: 'B'});
@@ -610,7 +610,7 @@ describe('Menu', function () {
     `('$Name wraps around when no items past the current one match', function ({Component, props}) {
       let tree = renderComponent(Component, {}, props);
       let menu = tree.getByRole('menu');
-      let menuItems = within(menu).getAllByRole('menuitemradio');
+      let menuItems = within(menu).getAllByRole('menuitem');
       expect(document.activeElement).toBe(menuItems[0]);
 
       fireEvent.keyDown(menu, {key: 'B'});
@@ -649,16 +649,16 @@ describe('Menu', function () {
     expect(dialog).toBeVisible();
   });
 
-  describe('supports onPress', function () {
-    it('Menu with static list supports onPress', function () {
-      let onPress = jest.fn();
+  describe('supports onAction', function () {
+    it('Menu with static list supports onAction', function () {
+      let onAction = jest.fn();
       let onSelectionChange = jest.fn();
       let tree = render(
         <Provider theme={theme}>
-          <Menu onSelectionChange={onSelectionChange}>
-            <Item onPress={() => onPress('One')}>One</Item>
-            <Item onPress={() => onPress('Two')}>Two</Item>
-            <Item onPress={() => onPress('Three')}>Three</Item>
+          <Menu onSelectionChange={onSelectionChange} onAction={onAction}>
+            <Item uniqueKey="One">One</Item>
+            <Item uniqueKey="Two">Two</Item>
+            <Item uniqueKey="Three">Three</Item>
           </Menu>
         </Provider>
       );
@@ -672,22 +672,22 @@ describe('Menu', function () {
       ];
 
       triggerPress(item1);
-      expect(onPress).toHaveBeenCalledWith('One');
-      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledWith('One');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
 
 
       triggerPress(item2);
-      expect(onPress).toHaveBeenCalledWith('Two');
-      expect(onSelectionChange).toHaveBeenCalledTimes(2);
+      expect(onAction).toHaveBeenCalledWith('Two');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
 
 
       triggerPress(item3);
-      expect(onPress).toHaveBeenCalledWith('Three');
-      expect(onSelectionChange).toHaveBeenCalledTimes(3);
+      expect(onAction).toHaveBeenCalledWith('Three');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
     });
 
-    it('Menu with generative list supports onPress', function () {
-      let onPress = jest.fn();
+    it('Menu with generative list supports onAction', function () {
+      let onAction = jest.fn();
       let onSelectionChange = jest.fn();
       let flatItems = [
         {name: 'One'},
@@ -696,8 +696,8 @@ describe('Menu', function () {
       ];
       let tree = render(
         <Provider theme={theme}>
-          <Menu onSelectionChange={onSelectionChange} items={flatItems} itemKey="name">
-            {item => <Item onPress={() => onPress(item.name)}>{item.name}</Item>}
+          <Menu onSelectionChange={onSelectionChange} items={flatItems} itemKey="name" onAction={onAction}>
+            {item => <Item>{item.name}</Item>}
           </Menu>
         </Provider>
       );
@@ -713,18 +713,18 @@ describe('Menu', function () {
       ];
 
       triggerPress(item1);
-      expect(onPress).toHaveBeenCalledWith('One');
-      expect(onSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledWith('One');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
 
 
       triggerPress(item2);
-      expect(onPress).toHaveBeenCalledWith('Two');
-      expect(onSelectionChange).toHaveBeenCalledTimes(2);
+      expect(onAction).toHaveBeenCalledWith('Two');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
 
 
       triggerPress(item3);
-      expect(onPress).toHaveBeenCalledWith('Three');
-      expect(onSelectionChange).toHaveBeenCalledTimes(3);
+      expect(onAction).toHaveBeenCalledWith('Three');
+      expect(onSelectionChange).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -732,7 +732,7 @@ describe('Menu', function () {
     let tree = render(
       <Provider theme={theme}>
         <Menu id={menuId} selectionMode="none">
-          <Item>
+          <Item textValue="Label">
             <Bell />
             <Text>Label</Text>
             <Text slot="description">Description</Text>

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -261,7 +261,7 @@ describe('MenuTrigger', function () {
       jest.runAllTimers();
       let menu = tree.getByRole('menu');
       expect(menu).toBeTruthy();
-      let menuItems = within(menu).getAllByRole('menuitemradio');
+      let menuItems = within(menu).getAllByRole('menuitem');
       let selectedItem = menuItems[1];
       expect(selectedItem).toBe(document.activeElement);
       triggerPress(button);
@@ -272,7 +272,7 @@ describe('MenuTrigger', function () {
       // Opening menu via down arrow still autofocuses the selected item
       fireEvent.keyDown(button, {key: 'ArrowDown', code: 40, charCode: 40});
       menu = tree.getByRole('menu');
-      menuItems = within(menu).getAllByRole('menuitemradio');
+      menuItems = within(menu).getAllByRole('menuitem');
       selectedItem = menuItems[1];
       expect(selectedItem).toBe(document.activeElement);
       triggerPress(button);
@@ -282,7 +282,7 @@ describe('MenuTrigger', function () {
       // Opening menu via up arrow still autofocuses the selected item
       fireEvent.keyDown(button, {key: 'ArrowUp', code: 38, charCode: 38});
       menu = tree.getByRole('menu');
-      menuItems = within(menu).getAllByRole('menuitemradio');
+      menuItems = within(menu).getAllByRole('menuitem');
       selectedItem = menuItems[1];
       expect(selectedItem).toBe(document.activeElement);
     });
@@ -295,7 +295,7 @@ describe('MenuTrigger', function () {
       let button = tree.getByRole('button');
       fireEvent.keyDown(button, {key: 'ArrowUp', code: 38, charCode: 38});
       let menu = tree.getByRole('menu');
-      let menuItems = within(menu).getAllByRole('menuitemradio');
+      let menuItems = within(menu).getAllByRole('menuitem');
       let selectedItem = menuItems[menuItems.length - 1];
       expect(selectedItem).toBe(document.activeElement);
     });
@@ -308,7 +308,7 @@ describe('MenuTrigger', function () {
       let button = tree.getByRole('button');
       fireEvent.keyDown(button, {key: 'ArrowDown', code: 40, charCode: 40});
       let menu = tree.getByRole('menu');
-      let menuItems = within(menu).getAllByRole('menuitemradio');
+      let menuItems = within(menu).getAllByRole('menuitem');
       let selectedItem = menuItems[0];
       expect(selectedItem).toBe(document.activeElement);
     });
@@ -401,7 +401,7 @@ describe('MenuTrigger', function () {
       ${'MenuTrigger'} | ${MenuTrigger} | ${{onOpenChange, closeOnSelect: false}}
       ${'V2Dropdown'}  | ${V2Dropdown}  | ${{onOpen, onClose, onSelect, closeOnSelect: false}}
     `('$Name doesn\'t close on menu item selection if closeOnSelect=false', function ({Component, props}) {
-      let tree = renderComponent(Component, props, {onSelectionChange});
+      let tree = renderComponent(Component, props, {selectionMode: 'single', onSelectionChange});
       expect(onOpenChange).toBeCalledTimes(0);
       let button = tree.getByRole('button');
       triggerPress(button);
@@ -444,7 +444,7 @@ describe('MenuTrigger', function () {
       Name             | Component      | props
       ${'MenuTrigger'} | ${MenuTrigger} | ${{onOpenChange, closeOnSelect: false}}
     `('$Name closes menu on item selection via ENTER press even if closeOnSelect=false', function ({Component, props}) {
-      let tree = renderComponent(Component, props, {onSelectionChange});
+      let tree = renderComponent(Component, props, {selectionMode: 'single', onSelectionChange});
       expect(onOpenChange).toBeCalledTimes(0);
       let button = tree.getByRole('button');
       triggerPress(button);

--- a/packages/@react-types/breadcrumbs/src/index.d.ts
+++ b/packages/@react-types/breadcrumbs/src/index.d.ts
@@ -12,7 +12,7 @@
 
 import {DOMProps, PressEvents, StyleProps} from '@react-types/shared';
 import {ItemProps} from '@react-types/shared';
-import {ReactElement, ReactNode} from 'react';
+import {Key, ReactElement, ReactNode} from 'react';
 
 export interface BreadcrumbItemProps extends PressEvents {
   isCurrent?: boolean,
@@ -25,7 +25,8 @@ export interface BreadcrumbItemProps extends PressEvents {
 
 export interface BreadcrumbsProps<T> {
   children: ReactElement<ItemProps<T>> | ReactElement<ItemProps<T>>[],
-  maxVisibleItems?: 'auto' | number
+  maxVisibleItems?: 'auto' | number,
+  onAction?: (key: Key) => void
 }
 
 export interface SpectrumBreadcrumbsProps<T> extends BreadcrumbsProps<T>, DOMProps, StyleProps {

--- a/packages/@react-types/menu/src/index.d.ts
+++ b/packages/@react-types/menu/src/index.d.ts
@@ -11,8 +11,8 @@
  */
 
 import {CollectionBase, DOMProps, Expandable, MultipleSelection, StyleProps} from '@react-types/shared';
+import {Key, ReactElement, RefObject} from 'react';
 import {Node} from '@react-stately/collections';
-import {ReactElement, RefObject} from 'react';
 
 export type FocusStrategy = 'first' | 'last';
 
@@ -44,7 +44,8 @@ export interface SpectrumMenuTriggerProps extends MenuTriggerProps {
 export interface MenuProps<T> extends CollectionBase<T>, Expandable, MultipleSelection {
   autoFocus?: boolean,
   focusStrategy?: FocusStrategy,
-  wrapAround?: boolean
+  wrapAround?: boolean,
+  onAction?: (key: Key) => void
 }
 
 export interface SpectrumMenuProps<T> extends MenuProps<T>, DOMProps, StyleProps {

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -11,7 +11,6 @@
  */
 
 import {Key, ReactElement, ReactNode} from 'react';
-import {PressEvent} from '@react-types/shared';
 
 export interface ItemProps<T> {
   title?: ReactNode, // label?? contents?
@@ -19,8 +18,7 @@ export interface ItemProps<T> {
   hasChildItems?: boolean,
   children: ReactNode, // CellRenderer??
   textValue?: string,
-  uniqueKey?: Key,
-  onPress?: (e: PressEvent) => void
+  uniqueKey?: Key
 }
 
 export type ItemElement<T> = ReactElement<ItemProps<T>>;


### PR DESCRIPTION
This switches to `selectionMode="none` by default for Menu since it's more likely to be used for performing actions than selection. In addition, after debating further with @dannify, we decided to switch to `onAction` instead of `onPress` for menu items and breadcrumbs, and move the prop to the top-level component rather than on `<Item>`. This was for a few reasons:

1. Menu items are activated on key down, and pointer up, so are inconsistent with `onPress` in other places. A higher level action event seems more appropriate.
2. We have moved most other actions to the top level for collections components. It's useful to receive the key of the item that was activated.
3. Less props on `<Item>`, which is shared between all collections components.