### PR TITLE
Dialogs mobile fullscreen

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -85,16 +85,16 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog .spectrum-Dialog-grid {
   display: grid;
-  grid-template-columns: var(--spectrum-dialog-padding) auto var(--spectrum-dialog-padding);
+  grid-template-columns: var(--spectrum-dialog-padding) 1fr auto var(--spectrum-dialog-padding);
   grid-template-rows: auto var(--spectrum-dialog-padding) auto auto 1fr auto var(--spectrum-dialog-padding);
   grid-template-areas:
-    "hero hero    hero"
-    ".    .       closeButton"
-    ".    header  ."
-    ".    divider ."
-    ".    content ."
-    ".    footer  ."
-    ".    .       .";
+    "hero hero    hero        hero"
+    ".    .       .           closeButton"
+    ".    header  header      ."
+    ".    divider divider     ."
+    ".    content content     ."
+    ".    footer  buttonGroup ."
+    ".    .       .           .";
   width: 100%;
 }
 
@@ -153,7 +153,6 @@ governing permissions and limitations under the License.
 
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
 
   outline: none; /* Hide focus outline */
 
@@ -162,6 +161,12 @@ governing permissions and limitations under the License.
   > .spectrum-Button + .spectrum-Button {
     margin-bottom: 0;
   }
+}
+
+.spectrum-Dialog-buttonGroup {
+  grid-area: buttonGroup;
+  /* this padding isn't built into the grid because it disappears with this buttonGroup */
+  padding-block-start: var(--spectrum-global-dimension-static-size-500);
 }
 
 .spectrum-Dialog--dismissable {
@@ -215,14 +220,14 @@ governing permissions and limitations under the License.
 
   &.spectrum-Dialog .spectrum-Dialog-grid {
     display: grid;
-    grid-template-columns: var(--spectrum-dialog-padding) 1fr auto var(--spectrum-dialog-padding);
+    grid-template-columns: var(--spectrum-dialog-padding) 1fr auto auto var(--spectrum-dialog-padding);
     grid-template-rows: calc(var(--spectrum-dialog-padding) + var(--spectrum-dialog-fullscreen-padding-top)) auto auto 1fr var(--spectrum-dialog-padding);
     grid-template-areas:
-      ".    .       .       ."
-      ".    header  footer  ."
-      ".    divider divider ."
-      ".    content content ."
-      ".    .       .       .";
+      ".    .       .       .            ."
+      ".    header  header  buttonGroup  ."
+      ".    divider divider divider      ."
+      ".    content content content      ."
+      ".    .       .       .            .";
   }
 
   .spectrum-Dialog-heading {
@@ -234,8 +239,13 @@ governing permissions and limitations under the License.
     max-height: none;
   }
 
-  .spectrum-Dialog-footer {
+  .spectrum-Dialog-footer,
+  .spectrum-Dialog-buttonGroup {
     padding-block-start: 0px;
+  }
+
+  .spectrum-Dialog-footer {
+    display: none;
   }
 }
 
@@ -245,18 +255,18 @@ governing permissions and limitations under the License.
 
     &.spectrum-Dialog .spectrum-Dialog-grid {
        display: grid;
-       grid-template-columns: var(--spectrum-dialog-padding) 1fr auto var(--spectrum-dialog-padding);
+       grid-template-columns: var(--spectrum-dialog-padding) 1fr auto auto var(--spectrum-dialog-padding);
        grid-template-rows: calc(var(--spectrum-dialog-padding) + var(--spectrum-dialog-fullscreen-padding-top)) auto auto 1fr auto var(--spectrum-dialog-padding);
        grid-template-areas:
-         ".    .       .       ."
-         ".    header  header  ."
-         ".    divider divider ."
-         ".    content content ."
-         ".    .       footer  ."
-         ".    .       .       .";
+         ".    .       .            ."
+         ".    header  header       ."
+         ".    divider divider      ."
+         ".    content content      ."
+         ".    .       buttonGroup  ."
+         ".    .       .            .";
     }
 
-    .spectrum-Dialog-footer {
+    .spectrum-Dialog-buttonGroup {
       padding-block-start: var(--spectrum-global-dimension-static-size-500);
     }
   }

--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -149,7 +149,7 @@ governing permissions and limitations under the License.
 .spectrum-Dialog-footer {
   grid-area: footer;
   /* this padding isn't built into the grid because it disappears with this footer */
-  padding-top: var(--spectrum-global-dimension-static-size-500);
+  padding-block-start: var(--spectrum-global-dimension-static-size-500);
 
   display: flex;
   flex-wrap: wrap;
@@ -199,7 +199,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog--fullscreen {
   width: calc(100vw - calc(2 * var(--spectrum-dialog-fullscreen-margin)));
-  height: calc(100vw - calc(2 * var(--spectrum-dialog-fullscreen-margin)));
+  height: calc(100vh - calc(2 * var(--spectrum-dialog-fullscreen-margin)));
 }
 .spectrum-Dialog--fullscreenTakeover {
   width: 100vw;
@@ -235,6 +235,29 @@ governing permissions and limitations under the License.
   }
 
   .spectrum-Dialog-footer {
-    padding-top: 0px;
+    padding-block-start: 0px;
+  }
+}
+
+@media screen and (max-width: 700px) {
+  .spectrum-Dialog--fullscreen,
+  .spectrum-Dialog--fullscreenTakeover {
+
+    &.spectrum-Dialog .spectrum-Dialog-grid {
+       display: grid;
+       grid-template-columns: var(--spectrum-dialog-padding) 1fr auto var(--spectrum-dialog-padding);
+       grid-template-rows: calc(var(--spectrum-dialog-padding) + var(--spectrum-dialog-fullscreen-padding-top)) auto auto 1fr auto var(--spectrum-dialog-padding);
+       grid-template-areas:
+         ".    .       .       ."
+         ".    header  header  ."
+         ".    divider divider ."
+         ".    content content ."
+         ".    .       footer  ."
+         ".    .       .       .";
+    }
+
+    .spectrum-Dialog-footer {
+      padding-block-start: var(--spectrum-global-dimension-static-size-500);
+    }
   }
 }

--- a/packages/@react-spectrum/button/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/button/src/ButtonGroup.tsx
@@ -24,13 +24,13 @@ function ButtonGroup(props, ref) {
   let {styleProps} = useStyleProps(otherProps);
 
   return (
-      <div
-        {...filterDOMProps(otherProps)}
-        {...styleProps}
-        ref={ref}
-        className={styleProps.className}>
-        {children}
-      </div>
+    <div
+      {...filterDOMProps(otherProps)}
+      {...styleProps}
+      ref={ref}
+      className={styleProps.className}>
+      {children}
+    </div>
   );
 }
 

--- a/packages/@react-spectrum/button/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/button/src/ButtonGroup.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import React from 'react';
+import {useProviderProps} from '@react-spectrum/provider';
+
+function ButtonGroup(props, ref) {
+  props = useProviderProps(props);
+  props = useSlotProps(props, 'buttonGroup');
+  let {
+    children,
+    ...otherProps
+  } = props;
+  let {styleProps} = useStyleProps(otherProps);
+
+  return (
+      <div
+        {...filterDOMProps(otherProps)}
+        {...styleProps}
+        ref={ref}
+        className={styleProps.className}>
+        {children}
+      </div>
+  );
+}
+
+/**
+ * Buttons allow users to perform an action or to navigate to another page.
+ * They have multiple styles for various needs, and are ideal for calling attention to
+ * where a user needs to do something in order to move forward in a flow.
+ */
+let _ButtonGroup = React.forwardRef(ButtonGroup);
+export {_ButtonGroup as ButtonGroup};

--- a/packages/@react-spectrum/button/src/index.ts
+++ b/packages/@react-spectrum/button/src/index.ts
@@ -15,3 +15,4 @@ export * from './ActionButton';
 export * from './FieldButton';
 export * from './LogicButton';
 export * from './ClearButton';
+export * from './ButtonGroup';

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -11,10 +11,10 @@
  */
 
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
-import {Button} from '@react-spectrum/button';
+import {Button, ButtonGroup} from '@react-spectrum/button';
 import {chain} from '@react-aria/utils';
 import {classNames, useSlotProps, useStyleProps} from '@react-spectrum/utils';
-import {Content, Footer, Header} from '@react-spectrum/view';
+import {Content, Header} from '@react-spectrum/view';
 import {Dialog} from './Dialog';
 import {DialogContext, DialogContextValue} from './context';
 import {Divider} from '@react-spectrum/divider';
@@ -59,11 +59,11 @@ export function AlertDialog(props: SpectrumAlertDialogProps) {
       <Header><Heading>{title}</Heading>{(variant === 'error' || variant === 'warning') && <AlertMedium slot="typeIcon" aria-label="alert" />}</Header>
       <Divider />
       <Content>{children}</Content>
-      <Footer>
+      <ButtonGroup>
         {secondaryLabel && <Button variant="secondary" onPress={() => chain(onClose(), onConfirm('secondary'))} autoFocus={autoFocusButton === 'secondary'}>{secondaryLabel}</Button>}
         {cancelLabel && <Button variant="secondary" onPress={() => chain(onClose(), onCancel())} autoFocus={autoFocusButton === 'cancel'}>{cancelLabel}</Button>}
         <Button variant={confirmVariant} onPress={() => chain(onClose(), onConfirm('primary'))} isDisabled={isConfirmDisabled} autoFocus={autoFocusButton === 'primary'}>{primaryLabel}</Button>
-      </Footer>
+      </ButtonGroup>
     </Dialog>
   );
 }

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -57,8 +57,8 @@ export function Dialog(props: SpectrumDialogProps) {
     return (
       <ModalDialog {...allProps} size={size}>
         {children}
-        {isDismissable && 
-          <ActionButton 
+        {isDismissable &&
+          <ActionButton
             slot="closeButton"
             isQuiet
             aria-label="dismiss"
@@ -98,7 +98,8 @@ function BaseDialog({children, slots, size, role, ...otherProps}: SpectrumBaseDi
       divider: {UNSAFE_className: styles['spectrum-Dialog-divider'], size: 'M'},
       content: {UNSAFE_className: styles['spectrum-Dialog-content']},
       footer: {UNSAFE_className: styles['spectrum-Dialog-footer']},
-      closeButton: {UNSAFE_className: styles['spectrum-Dialog-closeButton']}
+      closeButton: {UNSAFE_className: styles['spectrum-Dialog-closeButton']},
+      buttonGroup: {UNSAFE_className: styles['spectrum-Dialog-buttonGroup']}
     };
   }
 

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ActionButton, Button} from '@react-spectrum/button';
+import {ActionButton, Button, ButtonGroup} from '@react-spectrum/button';
 import {AlertDialog, Dialog, DialogTrigger} from '../';
 import {Checkbox} from '@react-spectrum/checkbox';
 import {Content, Footer, Header} from '@react-spectrum/view';
@@ -49,6 +49,10 @@ storiesOf('Dialog', module)
   .add(
     'with hero, isDimissable',
     () => renderHero({isDismissable: true})
+  )
+  .add(
+    'with footer, isDimissable',
+    () => renderFooter({})
   )
   .add(
     'small',
@@ -209,10 +213,10 @@ function render({width = 'auto', isDismissable = undefined, ...props}) {
             <Divider />
             <Content>{singleParagraph()}</Content>
             {!isDismissable &&
-              <Footer>
+              <ButtonGroup>
                 <Button variant="secondary" onPress={close}>Cancel</Button>
                 <Button variant="cta" onPress={close}>Confirm</Button>
-              </Footer>}
+              </ButtonGroup>}
           </Dialog>
         )}
       </DialogTrigger>
@@ -232,12 +236,35 @@ function renderHero({width = 'auto', isDismissable = undefined, ...props}) {
             <Divider />
             <Content>{singleParagraph()}</Content>
             {!isDismissable &&
-              <Footer>
+              <ButtonGroup>
                 <Button variant="secondary" onPress={close}>Cancel</Button>
                 <Button variant="cta" onPress={close} autoFocus>Confirm</Button>
-              </Footer>}
+              </ButtonGroup>}
           </Dialog>
           )}
+      </DialogTrigger>
+    </div>
+  );
+}
+
+function renderFooter({width = 'auto', isDismissable = undefined, ...props}) {
+  return (
+    <div style={{display: 'flex', width, margin: '100px 0'}}>
+      <DialogTrigger isDismissable={isDismissable} defaultOpen>
+        <ActionButton>Trigger</ActionButton>
+        {(close) => (
+          <Dialog {...props}>
+            <Header><Heading>The Heading</Heading></Header>
+            <Divider />
+            <Content>{singleParagraph()}</Content>
+            <Footer><Checkbox>I accept</Checkbox></Footer>
+            {!isDismissable &&
+            <ButtonGroup>
+              <Button variant="secondary" onPress={close}>Cancel</Button>
+              <Button variant="cta" onPress={close}>Confirm</Button>
+            </ButtonGroup>}
+          </Dialog>
+        )}
       </DialogTrigger>
     </div>
   );
@@ -281,10 +308,10 @@ function renderWithForm({width = 'auto', ...props}) {
                 </RadioGroup>
               </Form>
             </Content>
-            <Footer>
+            <ButtonGroup>
               <Button variant="secondary" onPress={close}>Cancel</Button>
               <Button variant="cta" onPress={close}>Confirm</Button>
-            </Footer>
+            </ButtonGroup>
           </Dialog>
         )}
       </DialogTrigger>
@@ -312,10 +339,10 @@ function renderLongContent({width = 'auto', ...props}) {
             <Header><Heading>The Heading</Heading></Header>
             <Divider />
             <Content>{fiveParagraphs()}</Content>
-            <Footer>
+            <ButtonGroup>
               <Button variant="secondary" onPress={close}>Cancel</Button>
               <Button variant="cta" onPress={close} autoFocus>Confirm</Button>
-            </Footer>
+            </ButtonGroup>
           </Dialog>
         )}
       </DialogTrigger>
@@ -333,11 +360,11 @@ function renderWithThreeButtons({width = 'auto', ...props}) {
             <Header><Heading>The Heading</Heading></Header>
             <Divider />
             <Content>{singleParagraph()}</Content>
-            <Footer>
+            <ButtonGroup>
               <Button variant="secondary" onPress={close}>Secondary</Button>
               <Button variant="primary" onPress={close}>Primary</Button>
               <Button variant="cta" onPress={close} autoFocus>CTA</Button>
-            </Footer>
+            </ButtonGroup>
           </Dialog>
         )}
       </DialogTrigger>
@@ -361,10 +388,10 @@ function renderWithDividerInContent({width = 'auto', ...props}) {
                 <Text flexGrow={1} flexBasis={0}>Column number two. Eleifend quam adipiscing vitae proin sagittis nisl. Diam donec adipiscing tristique risus.</Text>
               </Flex>
             </Content>
-            <Footer>
+            <ButtonGroup>
               <Button variant="primary" onPress={close}>Primary</Button>
               <Button variant="cta" onPress={close} autoFocus>CTA</Button>
-            </Footer>
+            </ButtonGroup>
           </Dialog>
         )}
       </DialogTrigger>

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -11,10 +11,10 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ActionButton, Button} from '@react-spectrum/button';
+import {ActionButton, Button, ButtonGroup} from '@react-spectrum/button';
 import {AlertDialog, Dialog, DialogTrigger} from '../';
 import {chain} from '@react-aria/utils';
-import {Content, Footer, Header} from '@react-spectrum/view';
+import {Content, Header} from '@react-spectrum/view';
 import {Divider} from '@react-spectrum/divider';
 import {Heading, Text} from '@react-spectrum/typography';
 import isChromatic from 'storybook-chromatic/isChromatic';
@@ -236,10 +236,10 @@ function render({width = 'auto', ...props}) {
             <Divider />
             <Content><Text>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin sit amet tristique risus. In sit amet suscipit lorem. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. In condimentum imperdiet metus non condimentum. Duis eu velit et quam accumsan tempus at id velit. Duis elementum elementum purus, id tempus mauris posuere a. Nunc vestibulum sapien pellentesque lectus commodo ornare.</Text></Content>
             {!props.isDismissable &&
-              <Footer>
+              <ButtonGroup>
                 <Button variant="secondary" onPress={chain(close, action('cancel'))}>Cancel</Button>
                 <Button variant="cta" onPress={chain(close, action('confirm'))}>Confirm</Button>
-              </Footer>}
+              </ButtonGroup>}
           </Dialog>
         )}
       </DialogTrigger>

--- a/packages/@react-spectrum/overlays/stories/Modal.stories.tsx
+++ b/packages/@react-spectrum/overlays/stories/Modal.stories.tsx
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import {ActionButton, Button} from '@react-spectrum/button';
-import {Content, Footer, Header} from '@react-spectrum/view';
+import {ActionButton, Button, ButtonGroup} from '@react-spectrum/button';
+import {Content, Header} from '@react-spectrum/view';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
 import {Divider} from '@react-spectrum/divider';
 import {Heading, Text} from '@react-spectrum/typography';
@@ -42,7 +42,7 @@ function ModalExample() {
           <Header><Heading>Title</Heading></Header>
           <Divider />
           <Content><Text>I am a dialog</Text></Content>
-          <Footer><Button variant="cta" onPress={() => setOpen(false)}>Close</Button></Footer>
+          <ButtonGroup><Button variant="cta" onPress={() => setOpen(false)}>Close</Button></ButtonGroup>
         </Dialog>
       </Modal>
     </Fragment>
@@ -67,7 +67,7 @@ function UnmountingTrigger() {
           <Header><Heading>Title</Heading></Header>
           <Divider />
           <Content><Text>I am a dialog</Text></Content>
-          <Footer><ActionButton onPress={openModal}>Open modal</ActionButton></Footer>
+          <ButtonGroup><ActionButton onPress={openModal}>Open modal</ActionButton></ButtonGroup>
         </Dialog>
       </DialogTrigger>
       <Modal isOpen={isModalOpen} onClose={() => setModalOpen(false)}>
@@ -75,7 +75,7 @@ function UnmountingTrigger() {
           <Header><Heading>Title</Heading></Header>
           <Divider />
           <Content><Text>I am a dialog</Text></Content>
-          <Footer><Button variant="cta" onPress={() => setModalOpen(false)}>Close</Button></Footer>
+          <ButtonGroup><Button variant="cta" onPress={() => setModalOpen(false)}>Close</Button></ButtonGroup>
         </Dialog>
       </Modal>
     </Fragment>

--- a/rfcs/2019-v3-slots.md
+++ b/rfcs/2019-v3-slots.md
@@ -8,10 +8,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License. -->
 
 - Start Date: 2019-10-31
-- RFC PR: (leave this empty, to be filled in later)
+- RFC PR: https://github.com/adobe-private/react-spectrum-v3/pull/149 and https://github.com/adobe-private/react-spectrum-v3/pull/263
 - Authors: Rob Snow
 
-# React Spectrum v3 Slots Architecture (NAME TBD)
+# React Spectrum v3 Slots Architecture
 
 ## Summary
 
@@ -128,7 +128,8 @@ export const Card = (props) => {
       avatar: {UNSAFE_className: classNames(styles, 'avatar')},
       title: {UNSAFE_className: classNames(styles, 'title')},
       footer: {UNSAFE_className: classNames(styles, 'footer')},
-      divider: {UNSAFE_className: classNames(styles, 'divider')}
+      divider: {UNSAFE_className: classNames(styles, 'divider')},
+      buttonGroup: {UNSAFE_className: classNames(styles, 'buttonGroup')}
     }};
   let {slots} = {...defaults, ...props};
 
@@ -142,7 +143,7 @@ export const Card = (props) => {
           <Button>More</Button>
         </Flex>
         <Description slot="description">Description</Description>
-        <Footer slot="footer">Final remarks</Footer>
+        <ButtonGroup slot="footer">Final remarks</ButtonGroup>
       </Grid>
     </div>
   );
@@ -158,7 +159,8 @@ export const Card = (props) => {
       avatar: {UNSAFE_className: classNames(styles, 'avatar')},
       title: {UNSAFE_className: classNames(styles, 'title')},
       footer: {UNSAFE_className: classNames(styles, 'footer')},
-      divider: {UNSAFE_className: classNames(styles, 'divider')}
+      divider: {UNSAFE_className: classNames(styles, 'divider')},
+      buttonGroup: {UNSAFE_className: classNames(styles, 'buttonGroup')}
     }};
   let {slots} = {...defaults, ...props};
 


### PR DESCRIPTION
Move buttons to the bottom for fullscreen mobile
Give the title the full width of the top
Move button group out of footer and into its own placeholder component
Do not move title out because collapse rules mean that it couldn't take the full width for any dialogs where a button group was provided. I'll try to demo here:

```
". .       .           ."
". title   header      ."
". content content     ."
". footer  buttonGroup ."
". .       .           ."
```
this is simplified, but if there is no header supplied and there is a buttonGroup supplied, then the title cannot expand in the header area. It's better to leave that as one area because all dialogs, the title is right next to the header, and flex can be used in there so that things expand/collapse as needed

Closes https://jira.corp.adobe.com/browse/RSP-1619

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
