### PR TITLE
Improve ARIA labeling for Picker

### DIFF
--- a/packages/@react-aria/select/src/useSelect.ts
+++ b/packages/@react-aria/select/src/useSelect.ts
@@ -12,7 +12,7 @@
 
 import {HTMLAttributes, RefObject} from 'react';
 import {KeyboardDelegate} from '@react-types/shared';
-import {mergeProps} from '@react-aria/utils';
+import {mergeProps, useId} from '@react-aria/utils';
 import {PressProps} from '@react-aria/interactions';
 import {SelectState} from '@react-stately/select';
 import {useLabel} from '@react-aria/label';
@@ -28,6 +28,7 @@ interface SelectProps {
 interface SelectAria {
   labelProps: HTMLAttributes<HTMLElement>,
   triggerProps: HTMLAttributes<HTMLElement> & PressProps,
+  valueProps: HTMLAttributes<HTMLElement>,
   menuProps: HTMLAttributes<HTMLElement>
 }
 
@@ -61,13 +62,27 @@ export function useSelect<T>(props: SelectProps, state: SelectState<T>): SelectA
   });
 
   let triggerProps = mergeProps(mergeProps(menuTriggerProps, fieldProps), typeSelectProps);
-  triggerProps['aria-labelledby'] = `${triggerProps['aria-labelledby']} ${triggerProps.id}`;
-
-  menuProps['aria-labelledby'] = fieldProps['aria-labelledby'];
+  let valueId = useId();
 
   return {
     labelProps,
-    triggerProps,
-    menuProps
+    triggerProps: {
+      ...triggerProps,
+      'aria-labelledby': [
+        triggerProps['aria-labelledby'],
+        triggerProps['aria-label'] ? triggerProps.id : null,
+        valueId
+      ].filter(Boolean).join(' ')
+    },
+    valueProps: {
+      id: valueId
+    },
+    menuProps: {
+      ...menuProps,
+      'aria-labelledby': [
+        fieldProps['aria-labelledby'],
+        triggerProps['aria-label'] ? triggerProps.id : null
+      ].filter(Boolean).join(' ')
+    }
   };
 }

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -63,7 +63,7 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
   // so that the layout information can be cached even while the listbox is not mounted.
   // We also use the layout as the keyboard delegate for type to select.
   let layout = useListBoxLayout(state);
-  let {labelProps, triggerProps, menuProps} = useSelect({
+  let {labelProps, triggerProps, valueProps, menuProps} = useSelect({
     ...props,
     triggerRef: unwrapDOMRef(triggerRef),
     keyboardDelegate: layout
@@ -170,11 +170,14 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
         <SlotProvider
           slots={{
             icon: {UNSAFE_className: classNames(styles, 'spectrum-Icon'), size: 'S'},
-            text: {UNSAFE_className: classNames(
-            styles,
-            'spectrum-Dropdown-label',
-            {'is-placeholder': !selectedItem}
-          )},
+            text: {
+              ...valueProps,
+              UNSAFE_className: classNames(
+                styles,
+                'spectrum-Dropdown-label',
+                {'is-placeholder': !selectedItem}
+              )
+            },
             description: {
               isHidden: true
             }


### PR DESCRIPTION
This adds an id to the text slot in picker and uses `aria-labelledby` to point to that rather than to the button itself. This enables `aria-label` to work correctly when the picker isn't labelled by a visible label. In that case, the button is labelled by itself and the value.