### PR TITLE
Disable text selection on long press on iOS

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -20,6 +20,7 @@ governing permissions and limitations under the License.
 .spectrum-Dropdown {
   position: relative;
   display: inline-block;
+  user-select: none;
 
   /* Truncate if menu options make us too wide */
   max-width: 100%;

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -30,7 +30,8 @@ interface PressState {
   ignoreClickAfterPress: boolean,
   activePointerId: any,
   target: HTMLElement | null,
-  isOverTarget: boolean
+  isOverTarget: boolean,
+  userSelect?: string
 }
 
 interface EventBase {
@@ -233,6 +234,27 @@ export function usePress(props: PressHookProps): PressResult {
       }
     };
 
+    // Safari on iOS starts selecting text on long press. The only way to avoid this, it seems,
+    // is to add user-select: none to the entire page. Adding it to the pressable element prevents
+    // that element from being selected, but nearby elements may still receive selection. We add
+    // user-select: none on touch start, and remove it again on touch end to prevent this.
+    let disableTextSelection = () => {
+      state.userSelect = document.documentElement.style.webkitUserSelect;
+      document.documentElement.style.webkitUserSelect = 'none';
+    };
+
+    let restoreTextSelection = () => {
+      // There appears to be a delay on iOS where selection still might occur 
+      // after pointer up, so wait a bit before removing user-select.
+      setTimeout(() => {
+        // Avoid race conditions
+        if (!state.isPressed && document.documentElement.style.webkitUserSelect === 'none') {
+          document.documentElement.style.webkitUserSelect = state.userSelect || '';
+          state.userSelect = null;
+        }
+      }, 300);
+    };
+
     if (typeof PointerEvent !== 'undefined') {
       pressProps.onPointerDown = (e) => {
         // Only handle left clicks
@@ -246,6 +268,7 @@ export function usePress(props: PressHookProps): PressResult {
           state.isOverTarget = true;
           state.activePointerId = e.pointerId;
           state.target = e.currentTarget;
+          disableTextSelection();
           triggerPressStart(e, e.pointerType);
 
           document.addEventListener('pointermove', onPointerMove, false);
@@ -300,6 +323,7 @@ export function usePress(props: PressHookProps): PressResult {
           state.isOverTarget = false;
           state.activePointerId = null;
           unbindEvents();
+          restoreTextSelection();
         }
       };
 
@@ -312,6 +336,7 @@ export function usePress(props: PressHookProps): PressResult {
           state.isOverTarget = false;
           state.activePointerId = null;
           unbindEvents();
+          restoreTextSelection();
         }
       };
     } else {
@@ -381,6 +406,8 @@ export function usePress(props: PressHookProps): PressResult {
         state.ignoreEmulatedMouseEvents = true;
         state.isOverTarget = true;
         state.isPressed = true;
+
+        disableTextSelection();
         triggerPressStart(e, 'touch');
       };
 
@@ -414,6 +441,7 @@ export function usePress(props: PressHookProps): PressResult {
         state.activePointerId = null;
         state.isOverTarget = false;
         state.ignoreEmulatedMouseEvents = true;
+        restoreTextSelection();
       };
 
       pressProps.onTouchCancel = (e) => {
@@ -425,6 +453,7 @@ export function usePress(props: PressHookProps): PressResult {
           state.isPressed = false;
           state.activePointerId = null;
           state.isOverTarget = false;
+          restoreTextSelection();
         }
       };
     }


### PR DESCRIPTION
Safari on iOS starts selecting text on long press. This is undesirable for components that use `usePress`, e.g. Picker. Adding `user-select: none` to the pressable element prevents that element from being selected, but nearby elements may still receive selection when long pressing on it. The only way to avoid this, it seems, is to add `user-select: none` to the entire document instead. We add it on touch start, and remove it again on touch end to prevent selection from occurring.