### PR TITLE
Fire screen reader clicks with a 'virtual' pointerType instead of 'keyboard'

### DIFF
--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -206,9 +206,9 @@ export function usePress(props: PressHookProps): PressResult {
           // If triggered from a screen reader or by using element.click(),
           // trigger as if it were a keyboard click.
           if (!state.ignoreClickAfterPress && !state.ignoreEmulatedMouseEvents && isVirtualClick(e.nativeEvent)) {
-            triggerPressStart(e, 'keyboard');
-            triggerPressUp(e, 'keyboard');
-            triggerPressEnd(e, 'keyboard');
+            triggerPressStart(e, 'virtual');
+            triggerPressUp(e, 'virtual');
+            triggerPressEnd(e, 'virtual');
           }
 
           state.ignoreEmulatedMouseEvents = false;

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -1029,7 +1029,7 @@ describe('usePress', function () {
         {
           type: 'pressstart',
           target: el,
-          pointerType: 'keyboard',
+          pointerType: 'virtual',
           ctrlKey: false,
           metaKey: false,
           shiftKey: false
@@ -1041,7 +1041,7 @@ describe('usePress', function () {
         {
           type: 'pressup',
           target: el,
-          pointerType: 'keyboard',
+          pointerType: 'virtual',
           ctrlKey: false,
           metaKey: false,
           shiftKey: false
@@ -1049,7 +1049,7 @@ describe('usePress', function () {
         {
           type: 'pressend',
           target: el,
-          pointerType: 'keyboard',
+          pointerType: 'virtual',
           ctrlKey: false,
           metaKey: false,
           shiftKey: false
@@ -1061,7 +1061,7 @@ describe('usePress', function () {
         {
           type: 'press',
           target: el,
-          pointerType: 'keyboard',
+          pointerType: 'virtual',
           ctrlKey: false,
           metaKey: false,
           shiftKey: false
@@ -1383,6 +1383,67 @@ describe('usePress', function () {
       fireEvent.keyUp(document.body, {key: ' '});
 
       expect(events).toEqual([]);
+    });
+  });
+
+  describe('virtual click events', function () {
+    it('should fire press events events for virtual click events from screen readers', function () {
+      let events = [];
+      let addEvent = (e) => events.push(e);
+      let {getByText} = render(
+        <Example
+          onPressStart={addEvent}
+          onPressEnd={addEvent}
+          onPressChange={pressed => addEvent({type: 'presschange', pressed})}
+          onPress={addEvent}
+          onPressUp={addEvent} />
+      );
+
+      let el = getByText('test');
+      fireEvent.click(el);
+
+      expect(events).toEqual([
+        {
+          type: 'pressstart',
+          target: el,
+          pointerType: 'virtual',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
+          type: 'presschange',
+          pressed: true
+        },
+        {
+          type: 'pressup',
+          target: el,
+          pointerType: 'virtual',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
+          type: 'pressend',
+          target: el,
+          pointerType: 'virtual',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        },
+        {
+          type: 'presschange',
+          pressed: false
+        },
+        {
+          type: 'press',
+          target: el,
+          pointerType: 'virtual',
+          ctrlKey: false,
+          metaKey: false,
+          shiftKey: false
+        }
+      ]);
     });
   });
 });

--- a/packages/@react-types/shared/src/events.d.ts
+++ b/packages/@react-types/shared/src/events.d.ts
@@ -27,7 +27,7 @@ export type BaseEvent<T extends SyntheticEvent> = T & {
 export type KeyboardEvent = BaseEvent<ReactKeyboardEvent<any>>;
 export type FocusEvent = BaseEvent<ReactFocusEvent<any>>;
 
-export type PointerType = 'mouse' | 'pen' | 'touch' | 'keyboard';
+export type PointerType = 'mouse' | 'pen' | 'touch' | 'keyboard' | 'virtual';
 
 export interface PressEvent {
   type: 'pressstart' | 'pressend' | 'pressup' | 'press',


### PR DESCRIPTION
This fixes clicking on menu items with a screen reader, which fires only an `onClick` event rather than keyboard or mouse events. It's solved by firing events with a `'virtual'` pointerType rather than a fake `'keyboard'` event, which let's us handle the event differently than for keyboard events.