### PR TITLE
Speed up build of docs with more resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ jobs:
   storybook:
     docker:
       - image: circleci/node:12.10
+      resource_class: large
 
     working_directory: ~/react-spectrum-v3
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ jobs:
   docs:
     docker:
       - image: circleci/node:12.10
+    resource_class: large
 
     working_directory: ~/react-spectrum-v3
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
   storybook:
     docker:
       - image: circleci/node:12.10
-      resource_class: large
+    resource_class: large
 
     working_directory: ~/react-spectrum-v3
     steps:


### PR DESCRIPTION
default resource_class is medium, try bumping to large to see if our docs build faster (ever)


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
