### PR TITLE
RSP-1639: AlertDialog prop updates for buttons

### DIFF
--- a/packages/@react-spectrum/dialog/docs/AlertDialog.mdx
+++ b/packages/@react-spectrum/dialog/docs/AlertDialog.mdx
@@ -35,7 +35,7 @@ import {AlertDialog, DialogTrigger} from '@react-spectrum/dialog';
 ```tsx example
 <DialogTrigger>
   <ActionButton>Save</ActionButton>
-  <AlertDialog title="Low Disk Space" variant="warning" primaryLabel="Confirm">
+  <AlertDialog title="Low Disk Space" variant="warning" primaryActionLabel="Confirm">
     You are running low on disk space. Delete unnecessary files to free up space.
   </AlertDialog>
 </DialogTrigger>
@@ -45,13 +45,13 @@ import {AlertDialog, DialogTrigger} from '@react-spectrum/dialog';
 
 Unlike Dialog, the layout in AlertDialog is very deliberate. The body of an AlertDialog can be provided by passing 
 children to the component. The AlertDialog also supports having up to three buttons in its footer: a primary button,
-a secondary button, and a cancel button. Each button can be rendered by providing a string to the `primaryLabel`, `secondaryLabel`,
+a secondary button, and a cancel button. Each button can be rendered by providing a string to the `primaryActionLabel`, `secondaryActionLabel`,
 and `cancelLabel` respectively. Be sure to localize any strings provided to the AlertDialog and to the button labels as well. 
 
 ```tsx example
 <DialogTrigger>
   <ActionButton>Exit</ActionButton>
-  <AlertDialog variant="information" title="Register profile" primaryLabel="Register" secondaryLabel="Remind me later" cancelLabel="Cancel">
+  <AlertDialog variant="information" title="Register profile" primaryActionLabel="Register" secondaryActionLabel="Remind me later" cancelLabel="Cancel">
     You have not saved your profile information for this account. Would you like to register now?
   </AlertDialog>
 </DialogTrigger>
@@ -64,7 +64,7 @@ If any of the buttons in the ActionDialog's footer should be focused on render, 
 ```tsx example
 <DialogTrigger>
   <ActionButton>Save</ActionButton>
-  <AlertDialog variant="confirmation" title="Save file" primaryLabel="Save" cancelLabel="Cancel" autoFocusButton="primary">
+  <AlertDialog variant="confirmation" title="Save file" primaryActionLabel="Save" cancelLabel="Cancel" autoFocusButton="primary">
     A file with the same name already exists. Overwrite?
   </AlertDialog>
 </DialogTrigger>
@@ -77,15 +77,14 @@ so that the ActionDialog is properly internationalized.
 
 ## Events
 
-AlertDialog accepts an `onConfirm` and `onCancel` prop, triggered when the AlertDialog's confirm or cancel buttons are clicked respectively. 
-To distinguish between whether the primary button or the secondary button was clicked, the `onConfirm` handler is called with a "primary" or "secondary"
-argument. 
+AlertDialog accepts an `onPrimaryAction`, `onSecondaryAction` and `onCancel` prop, triggered when the AlertDialog's confirm or cancel buttons are clicked respectively.
 
-The example below uses `onConfirm` and `onCancel` to tell the user which button was clicked to close the AlertDialog.
+The example below uses `onPrimaryAction`, `onSecondaryAction` and `onCancel` to tell the user which button was clicked to close the AlertDialog.
 
 ```tsx example
 function Example() {
-  let alertConfirm = (button) => alert(`${button} button clicked.`);
+  let onPrimaryAction = () => alert('Primary button clicked.');
+  let onSecondaryAction = () => alert('Secondary button clicked.');
   let alertCancel = () => alert('Cancel button clicked.');
 
   return (
@@ -93,14 +92,15 @@ function Example() {
       <ActionButton>
         Publish
       </ActionButton>
-      <AlertDialog 
+      <AlertDialog
         variant="confirmation" 
         title="Confirm Publish" 
-        primaryLabel="Publish" 
-        secondaryLabel="Save as draft" 
+        primaryActionLabel="Publish" 
+        secondaryActionLabel="Save as draft" 
         cancelLabel="Cancel"
         onCancel={alertCancel}
-        onConfirm={alertConfirm}>
+        onPrimaryAction={onPrimaryAction}
+        onSecondaryAction={onSecondaryAction}>
         Are you sure you want to publish this document?
       </AlertDialog>
     </DialogTrigger>
@@ -120,35 +120,35 @@ function Example() {
 ```tsx example
 <DialogTrigger marginEnd="20px">
   <ActionButton>Exit</ActionButton>
-  <AlertDialog variant="confirmation" title="Exit instance?" primaryLabel="Confirm" cancelLabel="Cancel">
+  <AlertDialog variant="confirmation" title="Exit instance?" primaryActionLabel="Confirm" cancelLabel="Cancel">
     Exit dungeon instance and return to main hub?
   </AlertDialog>
 </DialogTrigger>
 
 <DialogTrigger marginEnd="20px">
   <ActionButton>New file</ActionButton>
-  <AlertDialog variant="information" title="Connect your account" primaryLabel="Continue" cancelLabel="Cancel">
+  <AlertDialog variant="information" title="Connect your account" primaryActionLabel="Continue" cancelLabel="Cancel">
     Please connect an existing account to sync any new files.
   </AlertDialog>
 </DialogTrigger>
 
 <DialogTrigger marginEnd="20px">
   <ActionButton>Delete</ActionButton>
-  <AlertDialog variant="destructive" title="Delete file" primaryLabel="Delete" cancelLabel="Cancel">
+  <AlertDialog variant="destructive" title="Delete file" primaryActionLabel="Delete" cancelLabel="Cancel">
     This will permanently delete the selected file. Continue?
   </AlertDialog>
 </DialogTrigger>
 
 <DialogTrigger marginEnd="20px">
   <ActionButton>Login</ActionButton>
-  <AlertDialog variant="error" title="Unable to connect" primaryLabel="Retry" cancelLabel="Cancel">
+  <AlertDialog variant="error" title="Unable to connect" primaryActionLabel="Retry" cancelLabel="Cancel">
     Something went wrong while connecting to the server. Please try again in a couple minutes.
   </AlertDialog>
 </DialogTrigger>
 
 <DialogTrigger>
   <ActionButton>Enter</ActionButton>
-  <AlertDialog variant="warning" title="Raid instance" primaryLabel="Confirm" cancelLabel="Cancel">
+  <AlertDialog variant="warning" title="Raid instance" primaryActionLabel="Confirm" cancelLabel="Cancel">
     The following encounter meant for parties of 4 or more. Enter anyways?
   </AlertDialog>
 </DialogTrigger>
@@ -161,7 +161,7 @@ Disables the primary button.
 ```tsx example
 <DialogTrigger>
   <ActionButton>Upgrade</ActionButton>
-  <AlertDialog isPrimaryActionDisabled variant="confirmation" title="Upgrade subscription" primaryLabel="Upgrade" cancelLabel="Cancel">
+  <AlertDialog isPrimaryActionDisabled variant="confirmation" title="Upgrade subscription" primaryActionLabel="Upgrade" cancelLabel="Cancel">
     Upgrade subscription for an additional $14.99 a month?
   </AlertDialog>
 </DialogTrigger>
@@ -174,7 +174,7 @@ Disables the secondary button.
 ```tsx example
 <DialogTrigger>
   <ActionButton>Upgrade</ActionButton>
-  <AlertDialog isSecondaryActionDisabled variant="confirmation" title="Upgrade subscription" primaryLabel="Upgrade" secondaryLabel="Apply Coupon" cancelLabel="Cancel">
+  <AlertDialog isSecondaryActionDisabled variant="confirmation" title="Upgrade subscription" primaryActionLabel="Upgrade" secondaryActionLabel="Apply Coupon" cancelLabel="Cancel">
     Upgrade subscription for an additional $14.99 a month?
   </AlertDialog>
 </DialogTrigger>

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -39,15 +39,16 @@ export function AlertDialog(props: SpectrumAlertDialogProps) {
   let {
     variant,
     children,
-    secondaryLabel,
+    primaryActionLabel,
+    secondaryActionLabel,
     cancelLabel,
-    primaryLabel,
     autoFocusButton,
     title,
     isPrimaryActionDisabled,
     isSecondaryActionDisabled,
     onCancel = () => {},
-    onConfirm = () => {},
+    onPrimaryAction = () => {},
+    onSecondaryAction = () => {},
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps);
@@ -63,15 +64,50 @@ export function AlertDialog(props: SpectrumAlertDialogProps) {
   }
 
   return (
-    <Dialog {...styleProps} UNSAFE_className={classNames(styles, {[`spectrum-Dialog--${variant}`]: variant}, styleProps.className)} size="M" role="alertdialog">
+    <Dialog
+      {...styleProps}
+      UNSAFE_className={classNames(styles, {[`spectrum-Dialog--${variant}`]: variant}, styleProps.className)}
+      size="M"
+      role="alertdialog">
       <Heading>{title}</Heading>
-      <Header><Flex justifyContent="flex-end" width="100%">{(variant === 'error' || variant === 'warning') && <AlertMedium slot="typeIcon" aria-label={formatMessage('alert')} />}</Flex></Header>
+      <Header>
+        <Flex
+          justifyContent="flex-end"
+          width="100%">
+          {(variant === 'error' || variant === 'warning') &&
+            <AlertMedium
+              slot="typeIcon"
+              aria-label={formatMessage('alert')} />
+          }
+        </Flex>
+      </Header>
       <Divider />
       <Content>{children}</Content>
       <ButtonGroup>
-        {secondaryLabel && <Button variant="secondary" onPress={() => chain(onClose(), onConfirm('secondary'))} isDisabled={isSecondaryActionDisabled} autoFocus={autoFocusButton === 'secondary'}>{secondaryLabel}</Button>}
-        {cancelLabel && <Button variant="secondary" onPress={() => chain(onClose(), onCancel())} autoFocus={autoFocusButton === 'cancel'}>{cancelLabel}</Button>}
-        <Button variant={confirmVariant} onPress={() => chain(onClose(), onConfirm('primary'))} isDisabled={isPrimaryActionDisabled} autoFocus={autoFocusButton === 'primary'}>{primaryLabel}</Button>
+        {secondaryActionLabel &&
+          <Button
+            variant="secondary"
+            onPress={() => chain(onClose(), onSecondaryAction())}
+            isDisabled={isSecondaryActionDisabled}
+            autoFocus={autoFocusButton === 'secondary'}>
+            {secondaryActionLabel}
+          </Button>
+        }
+        {cancelLabel &&
+          <Button
+            variant="secondary"
+            onPress={() => chain(onClose(), onCancel())}
+            autoFocus={autoFocusButton === 'cancel'}>
+            {cancelLabel}
+          </Button>
+        }
+        <Button
+          variant={confirmVariant}
+          onPress={() => chain(onClose(), onPrimaryAction())}
+          isDisabled={isPrimaryActionDisabled}
+          autoFocus={autoFocusButton === 'primary'}>
+          {primaryActionLabel}
+        </Button>
       </ButtonGroup>
     </Dialog>
   );

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -93,9 +93,10 @@ storiesOf('Dialog/Alert', module)
       variant: 'destructive',
       title: 'Warning Destructive',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      onConfirm: action('confirm'),
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel')
     })
   )
@@ -105,9 +106,10 @@ storiesOf('Dialog/Alert', module)
       variant: 'confirmation',
       title: 'Confirmation Required',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      onConfirm: action('confirm'),
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel')
     })
   )
@@ -117,9 +119,10 @@ storiesOf('Dialog/Alert', module)
       variant: 'information',
       title: 'Informative Alert',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      onConfirm: action('confirm'),
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel')
     })
   )
@@ -129,9 +132,10 @@ storiesOf('Dialog/Alert', module)
       variant: 'error',
       title: 'Error: Danger Will Robinson',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      onConfirm: action('confirm'),
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel')
     })
   )
@@ -141,9 +145,10 @@ storiesOf('Dialog/Alert', module)
       variant: 'warning',
       title: 'This is a warning',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      onConfirm: action('confirm'),
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel')
     })
   )
@@ -153,9 +158,10 @@ storiesOf('Dialog/Alert', module)
       variant: 'error',
       title: 'Error: Danger Will Robinson',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      onConfirm: action('confirm'),
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel'),
       isPrimaryActionDisabled: true
     })
@@ -166,10 +172,11 @@ storiesOf('Dialog/Alert', module)
       variant: 'error',
       title: 'Error: Danger Will Robinson',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      secondaryLabel: 'Secondary button',
-      onConfirm: action('confirm'),
+      secondaryActionLabel: 'Secondary button',
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel'),
       autoFocusButton: 'primary'
     })
@@ -180,10 +187,11 @@ storiesOf('Dialog/Alert', module)
       variant: 'error',
       title: 'Error: Danger Will Robinson',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
-      secondaryLabel: 'Secondary button',
+      primaryActionLabel: 'Accept',
+      secondaryActionLabel: 'Secondary button',
       cancelLabel: 'Cancel',
-      onConfirm: action('confirm'),
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel'),
       isSecondaryActionDisabled: true
     })
@@ -194,10 +202,11 @@ storiesOf('Dialog/Alert', module)
       variant: 'error',
       title: 'Error: Danger Will Robinson',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      secondaryLabel: 'Secondary button',
-      onConfirm: action('confirm'),
+      secondaryActionLabel: 'Secondary button',
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel'),
       autoFocusButton: 'secondary'
     })
@@ -208,10 +217,11 @@ storiesOf('Dialog/Alert', module)
       variant: 'error',
       title: 'Error: Danger Will Robinson',
       children: singleParagraph(),
-      primaryLabel: 'Accept',
+      primaryActionLabel: 'Accept',
       cancelLabel: 'Cancel',
-      secondaryLabel: 'Secondary button',
-      onConfirm: action('confirm'),
+      secondaryActionLabel: 'Secondary button',
+      onPrimaryAction: action('primary'),
+      onSecondaryAction: action('secondary'),
       onCancel: action('cancel'),
       autoFocusButton: 'cancel'
     })
@@ -293,7 +303,7 @@ function renderAlert({width = 'auto', ...props}: SpectrumAlertDialogProps) {
     <div style={{display: 'flex', width, margin: '100px 0'}}>
       <DialogTrigger defaultOpen>
         <ActionButton>Trigger</ActionButton>
-        <AlertDialog {...props} onConfirm={props.onConfirm} onCancel={props.onCancel} />
+        <AlertDialog {...props} onPrimaryAction={action('primary')} onSecondaryAction={action('secondary')} onCancel={props.onCancel} />
       </DialogTrigger>
     </div>
   );

--- a/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/DialogTrigger.stories.tsx
@@ -271,7 +271,7 @@ function renderAlert({width = 'auto', ...props}) {
       <DialogTrigger {...props} onOpenChange={action('open change')} defaultOpen={isChromatic()}>
         <ActionButton>Trigger</ActionButton>
         {(close) => (
-          <AlertDialog title="Alert! Danger!" variant="error" primaryLabel="Accept" secondaryLabel="Whoa" cancelLabel="Cancel" onCancel={chain(close, action('cancel'))} onConfirm={chain(close, action('confirm'))}>
+          <AlertDialog title="Alert! Danger!" variant="error" primaryActionLabel="Accept" secondaryActionLabel="Whoa" cancelLabel="Cancel" onCancel={chain(close, action('cancel'))} onPrimaryAction={chain(close, action('primary'))} onSecondaryAction={chain(close, action('secondary'))}>
             <Text>Fine! No, absolutely fine. It's not like I don't have, you know, ten thousand other test subjects begging me to help them escape. You know, it's not like this place is about to EXPLODE.</Text>
           </AlertDialog>
         )}

--- a/packages/@react-spectrum/dialog/test/AlertDialog.test.js
+++ b/packages/@react-spectrum/dialog/test/AlertDialog.test.js
@@ -19,10 +19,10 @@ import {triggerPress} from '@react-spectrum/test-utils';
 describe('AlertDialog', function () {
   afterEach(cleanup);
 
-  it('renders alert dialog with onConfirm', function () {
-    let onConfirmSpy = jest.fn();
+  it('renders alert dialog with onPrimaryAction', function () {
+    let onPrimaryAction = jest.fn();
     let {getByRole} = render(
-      <AlertDialog variant="confirmation" title="the title" primaryLabel="confirm" onConfirm={onConfirmSpy}>
+      <AlertDialog variant="confirmation" title="the title" primaryActionLabel="confirm" onPrimaryAction={onPrimaryAction}>
         Content body
       </AlertDialog>
     );
@@ -32,15 +32,15 @@ describe('AlertDialog', function () {
 
     let button = getByRole('button');
     triggerPress(button);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(1);
-    expect(onConfirmSpy).toHaveBeenCalledWith('primary');
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
+    expect(onPrimaryAction).toHaveBeenCalledWith();
   });
 
-  it('renders 2 button alert dialog with onConfirm / onCancel', function () {
+  it('renders 2 button alert dialog with onPrimaryAction / onCancel', function () {
     let onCancelSpy = jest.fn();
-    let onConfirmSpy = jest.fn();
+    let onPrimaryAction = jest.fn();
     let {getByRole, getByText} = render(
-      <AlertDialog variant="confirmation" title="the title" primaryLabel="confirm" cancelLabel="cancel" onConfirm={onConfirmSpy} onCancel={onCancelSpy}>
+      <AlertDialog variant="confirmation" title="the title" primaryActionLabel="confirm" cancelLabel="cancel" onPrimaryAction={onPrimaryAction} onCancel={onCancelSpy}>
         Content body
       </AlertDialog>
     );
@@ -50,22 +50,23 @@ describe('AlertDialog', function () {
 
     let cancelButton = getByText('cancel');
     triggerPress(cancelButton);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(0);
+    expect(onPrimaryAction).toHaveBeenCalledTimes(0);
     expect(onCancelSpy).toHaveBeenCalledTimes(1);
     expect(onCancelSpy).toHaveBeenCalledWith();
 
     let confirmButton = getByText('confirm');
     triggerPress(confirmButton);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(1);
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
     expect(onCancelSpy).toHaveBeenCalledTimes(1);
-    expect(onConfirmSpy).toHaveBeenCalledWith('primary');
+    expect(onPrimaryAction).toHaveBeenCalledWith();
   });
 
-  it('renders a 3 button alert dialog with onConfirm / onCancel', function () {
+  it('renders a 3 button alert dialog with onPrimaryAction / onCancel', function () {
     let onCancelSpy = jest.fn();
-    let onConfirmSpy = jest.fn();
+    let onPrimaryAction = jest.fn();
+    let onSecondaryAction = jest.fn();
     let {getByRole, getByText} = render(
-      <AlertDialog variant="confirmation" title="the title" primaryLabel="confirm" cancelLabel="cancel" secondaryLabel="secondary" onConfirm={onConfirmSpy} onCancel={onCancelSpy}>
+      <AlertDialog variant="confirmation" title="the title" primaryActionLabel="confirm" cancelLabel="cancel" secondaryActionLabel="secondary" onPrimaryAction={onPrimaryAction} onSecondaryAction={onSecondaryAction} onCancel={onCancelSpy}>
         Content body
       </AlertDialog>
     );
@@ -77,25 +78,25 @@ describe('AlertDialog', function () {
     let secondaryButton = getByText('secondary');
     let cancelButton = getByText('cancel');
     triggerPress(secondaryButton);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(1);
-    expect(onConfirmSpy).toHaveBeenLastCalledWith('secondary');
+    expect(onSecondaryAction).toHaveBeenCalledTimes(1);
+    expect(onSecondaryAction).toHaveBeenLastCalledWith();
     expect(onCancelSpy).toHaveBeenCalledTimes(0);
 
     triggerPress(confirmButton);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(2);
-    expect(onConfirmSpy).toHaveBeenLastCalledWith('primary');
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
+    expect(onPrimaryAction).toHaveBeenLastCalledWith();
     expect(onCancelSpy).toHaveBeenCalledTimes(0);
 
     triggerPress(cancelButton);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(2);
+    expect(onPrimaryAction).toHaveBeenCalledTimes(1);
     expect(onCancelSpy).toHaveBeenCalledTimes(1);
     expect(onCancelSpy).toHaveBeenLastCalledWith();
   });
 
   it('disable its confirm button', function () {
-    let onConfirmSpy = jest.fn();
+    let onPrimaryAction = jest.fn();
     let {getByRole, getByText} = render(
-      <AlertDialog variant="confirmation" isPrimaryActionDisabled title="the title" primaryLabel="confirm" onConfirm={onConfirmSpy}>
+      <AlertDialog variant="confirmation" isPrimaryActionDisabled title="the title" primaryActionLabel="confirm" onPrimaryAction={onPrimaryAction}>
         Content body
       </AlertDialog>
     );
@@ -105,12 +106,12 @@ describe('AlertDialog', function () {
 
     let button = getByText('confirm');
     triggerPress(button);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(0);
+    expect(onPrimaryAction).toHaveBeenCalledTimes(0);
   });
 
   it('autofocus its confirm button', function () {
     let {getByText} = render(
-      <AlertDialog variant="confirmation" title="the title" primaryLabel="confirm" autoFocusButton="primary">
+      <AlertDialog variant="confirmation" title="the title" primaryActionLabel="confirm" autoFocusButton="primary">
         Content body
       </AlertDialog>
     );
@@ -121,7 +122,7 @@ describe('AlertDialog', function () {
 
   it('autofocus its cancel button', function () {
     let {getByText} = render(
-      <AlertDialog variant="confirmation" title="the title" primaryLabel="confirm" cancelLabel="cancel" autoFocusButton="cancel" >
+      <AlertDialog variant="confirmation" title="the title" primaryActionLabel="confirm" cancelLabel="cancel" autoFocusButton="cancel" >
         Content body
       </AlertDialog>
     );
@@ -131,9 +132,9 @@ describe('AlertDialog', function () {
   });
 
   it('disable its secondary button', function () {
-    let onConfirmSpy = jest.fn();
+    let onPrimaryAction = jest.fn();
     let {getByRole, getByText} = render(
-      <AlertDialog variant="confirmation" isSecondaryActionDisabled title="the title" primaryLabel="confirm" secondaryLabel="secondary" onConfirm={onConfirmSpy}>
+      <AlertDialog variant="confirmation" isSecondaryActionDisabled title="the title" primaryActionLabel="confirm" secondaryActionLabel="secondary" onPrimaryAction={onPrimaryAction}>
         Content body
       </AlertDialog>
     );
@@ -143,12 +144,12 @@ describe('AlertDialog', function () {
 
     let button = getByText('secondary');
     triggerPress(button);
-    expect(onConfirmSpy).toHaveBeenCalledTimes(0);
+    expect(onPrimaryAction).toHaveBeenCalledTimes(0);
   });
 
   it('autofocus its secondary button', function () {
     let {getByText} = render(
-      <AlertDialog variant="confirmation" title="the title" primaryLabel="confirm" secondaryLabel="secondary" autoFocusButton="secondary">
+      <AlertDialog variant="confirmation" title="the title" primaryActionLabel="confirm" secondaryActionLabel="secondary" autoFocusButton="secondary">
         Content body
       </AlertDialog>
     );

--- a/packages/@react-spectrum/menu/stories/Menu.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/Menu.stories.tsx
@@ -159,7 +159,7 @@ storiesOf('Menu', module)
             </DialogTrigger>
             <DialogTrigger>
               <Item>Delete...</Item>
-              <AlertDialog title="Delete" variant="destructive" primaryLabel="Delete" cancelLabel="Cancel">
+              <AlertDialog title="Delete" variant="destructive" primaryActionLabel="Delete" cancelLabel="Cancel">
                 Are you sure?
               </AlertDialog>
             </DialogTrigger>

--- a/packages/@react-types/dialog/src/index.d.ts
+++ b/packages/@react-types/dialog/src/index.d.ts
@@ -54,17 +54,19 @@ export interface SpectrumAlertDialogProps extends DOMProps, StyleProps {
   /** The label to display within the cancel button. */
   cancelLabel?: string,
   /** The label to display within the confirm button. */
-  primaryLabel: string,
+  primaryActionLabel: string,
   /** The label to display within the secondary button. */
-  secondaryLabel?: string,
+  secondaryActionLabel?: string,
   /** Whether the primary button is disabled. */
   isPrimaryActionDisabled?: boolean,
   /** Whether the secondary button is disabled. */
   isSecondaryActionDisabled?: boolean,
   /** Handler that is called when the cancel button is pressed. */
   onCancel?: () => void,
-  /** Handler that is called when the confirm button is pressed. */
-  onConfirm?: (button: 'primary' | 'secondary') => void,
+  /** Handler that is called when the primary button is pressed. */
+  onPrimaryAction?: () => void,
+  /** Handler that is called when the secondary button is pressed. */
+  onSecondaryAction?: () => void,
   /** Button to focus by default upon render. */
   autoFocusButton?: 'cancel' | 'primary' | 'secondary',
   // allowsKeyboardConfirmation?: boolean, // triggers primary action


### PR DESCRIPTION
New prop names for button labels
`primaryActionLabel`
`secondaryActionLabel`

Make two separate event handlers to replace `onConfirm`:

`onPrimaryAction`
`onSecondaryAction`

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
