### PR TITLE
adding aria and role to storybook stories

### DIFF
--- a/packages/@react-spectrum/illustrated-message/stories/IllustratedMessage.stories.tsx
+++ b/packages/@react-spectrum/illustrated-message/stories/IllustratedMessage.stories.tsx
@@ -16,9 +16,9 @@ import {IllustratedMessage} from '../';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 
-function noResultsImg() {
+function noResultsImg(props) {
   return (
-    <svg width="150" height="103" viewBox="0 0 150 103">
+    <svg width="150" height="103" viewBox="0 0 150 103" {...props}>
       <path d="M133.7,8.5h-118c-1.9,0-3.5,1.6-3.5,3.5v27c0,0.8,0.7,1.5,1.5,1.5s1.5-0.7,1.5-1.5V23.5h119V92c0,0.3-0.2,0.5-0.5,0.5h-118c-0.3,0-0.5-0.2-0.5-0.5V69c0-0.8-0.7-1.5-1.5-1.5s-1.5,0.7-1.5,1.5v23c0,1.9,1.6,3.5,3.5,3.5h118c1.9,0,3.5-1.6,3.5-3.5V12C137.2,10.1,135.6,8.5,133.7,8.5z M15.2,21.5V12c0-0.3,0.2-0.5,0.5-0.5h118c0.3,0,0.5,0.2,0.5,0.5v9.5H15.2z M32.6,16.5c0,0.6-0.4,1-1,1h-10c-0.6,0-1-0.4-1-1s0.4-1,1-1h10C32.2,15.5,32.6,15.9,32.6,16.5z M13.6,56.1l-8.6,8.5C4.8,65,4.4,65.1,4,65.1c-0.4,0-0.8-0.1-1.1-0.4c-0.6-0.6-0.6-1.5,0-2.1l8.6-8.5l-8.6-8.5c-0.6-0.6-0.6-1.5,0-2.1c0.6-0.6,1.5-0.6,2.1,0l8.6,8.5l8.6-8.5c0.6-0.6,1.5-0.6,2.1,0c0.6,0.6,0.6,1.5,0,2.1L15.8,54l8.6,8.5c0.6,0.6,0.6,1.5,0,2.1c-0.3,0.3-0.7,0.4-1.1,0.4c-0.4,0-0.8-0.1-1.1-0.4L13.6,56.1z" />
     </svg>
   );
@@ -27,11 +27,11 @@ function noResultsImg() {
 storiesOf('IllustratedMessage', module)
   .add(
     'default',
-    () => render({illustration: noResultsImg()})
+    () => render({illustration: noResultsImg({role: 'img', 'aria-label': 'No Results'})})
   )
   .add(
     'heading, description',
-    () => render({heading: 'No Results', description: 'Try another search', illustration: noResultsImg()})
+    () => render({heading: 'No Results', description: 'Try another search', illustration: noResultsImg({'aria-hidden': 'true', role: 'presentation'})})
   );
 
 function render(props: any = {}) {

--- a/packages/@react-types/illustrated-message/src/index.d.ts
+++ b/packages/@react-types/illustrated-message/src/index.d.ts
@@ -15,7 +15,6 @@ import {ReactElement} from 'react';
 import {Slots} from '@react-types/layout';
 
 export interface SpectrumIllustratedMessageProps extends DOMProps, StyleProps {
-  ariaLevel?: number,
   children: [ReactElement],
   slots?: Slots
 }


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1653
and follow up to https://github.com/adobe-private/react-spectrum-v3/pull/311 and https://jira.corp.adobe.com/browse/RSP-1585

## 📝 Test Instructions:

Inspect both illustrated message stories for their aria and role attributes

## 🧢 Your Team:

RSP
