### PR TITLE
Fixing Popover tips more

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/popover/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/popover/index.css
@@ -47,6 +47,7 @@ governing permissions and limitations under the License.
   border-radius: var(--spectrum-popover-border-radius);
 
   outline: none; /* Hide focus outline */
+  box-sizing: border-box;
 
   &.is-open {
     @inherit: %spectrum-overlay--open;
@@ -57,8 +58,11 @@ governing permissions and limitations under the License.
   position: absolute;
   --spectrum-popover-tip-size: var(--spectrum-popover-tip-width);
   --spectrum-popover-tip-borderWidth: var(--spectrum-popover-border-size);
+  /* https://stackoverflow.com/questions/44170229/how-to-prevent-half-pixel-svg-shift-on-high-pixel-ratio-devices-retina */
+  transform: translate(0, 0);
+  -webkit-transform: translate(0, 0);
 
-  path {
+  .spectrum-Popover-tip-triangle {
     stroke-linecap: square;
     stroke-linejoin: miter;
     stroke-width: var(--spectrum-popover-border-size);
@@ -93,6 +97,7 @@ governing permissions and limitations under the License.
   }
   .spectrum-Popover-tip {
     right: 100%;
+    transform: scaleX(-1);
   }
 }
 
@@ -114,7 +119,8 @@ governing permissions and limitations under the License.
     @inherit: %spectrum-overlay--bottom--open;
   }
   .spectrum-Popover-tip {
-    bottom: calc(100% - var(--spectrum-global-dimension-size-65));
+    bottom: 100%;
+    transform: scaleY(-1);
   }
 }
 
@@ -127,7 +133,7 @@ governing permissions and limitations under the License.
     @inherit: %spectrum-overlay--top--open;
   }
   .spectrum-Popover-tip {
-    top: calc(100% - var(--spectrum-global-dimension-size-50));
+    top: 100%;
   }
 }
 

--- a/packages/@adobe/spectrum-css-temp/components/popover/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/popover/index.css
@@ -59,7 +59,6 @@ governing permissions and limitations under the License.
   --spectrum-popover-tip-size: var(--spectrum-popover-tip-width);
   --spectrum-popover-tip-borderWidth: var(--spectrum-popover-border-size);
   /* https://stackoverflow.com/questions/44170229/how-to-prevent-half-pixel-svg-shift-on-high-pixel-ratio-devices-retina */
-  transform: translate(0, 0);
   -webkit-transform: translate(0, 0);
 
   .spectrum-Popover-tip-triangle {
@@ -106,7 +105,7 @@ governing permissions and limitations under the License.
 .spectrum-Popover--right {
   .spectrum-Popover-tip {
     top: 50%;
-    margin-top: -12px;
+    margin-top: calc(var(--spectrum-global-dimension-size-150) * -1);
   }
 }
 
@@ -142,6 +141,6 @@ governing permissions and limitations under the License.
 .spectrum-Popover--top {
   .spectrum-Popover-tip {
     left: 50%;
-    margin-left: -12px;
+    margin-left: calc(var(--spectrum-global-dimension-size-150) * -1);
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/popover/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/popover/skin.css
@@ -17,17 +17,25 @@ governing permissions and limitations under the License.
     box-shadow offset/blur is hardcoded here as it cannot be adjusted when scale changes,
     and we'd rather it be able to change when color stops change
     use filter instead so it includes the triangle
-  */
-  filter: drop-shadow(var(--spectrum-popover-shadow-color) 0 1px 4px);
 
-  .spectrum-Dialog-header,
-  .spectrum-Dialog-footer,
-  .spectrum-Dialog-wrapper {
-    background-color: transparent;
-  }
+    we can't use box-shadow anymore because it renders along the rectangle that encloses the triangle instead
+    of along the triangle's diagonal borders.
+    we may be able to use box-shadow for the popover + drop-shadow just for the tip, each direction would need it's own
+    and it may still have the problem where the tip's shadow would cover the popover border just a little and make it look sloppy again
+  */
+  filter: drop-shadow(0 1px 4px var(--spectrum-popover-shadow-color));
+  /* explicitly adding this webkit prefix may fix the bug where the drop-shadow remains dirty */
+  /* https://stackoverflow.com/questions/56478925/safari-drop-shadow-filter-remains-visible-even-with-hidden-element */
+  -webkit-filter: drop-shadow(0 1px 4px var(--spectrum-popover-shadow-color));
+  will-change: filter;
+  /* this helps mark the "dirty" area, it shouldn't affect anything unless it's sticking out from the popover. (tooltips?)
+     this is an assumption that may not be a good idea
+     it has to be 30px outside to compensate for the tip size at large + the drop-shadow coming off of it
+  */
+  clip-path: inset(-30px -30px);
 
   .spectrum-Popover-tip {
-    path {
+    .spectrum-Popover-tip-triangle {
       fill: var(--spectrum-popover-background-color);
       stroke: var(--spectrum-popover-border-color);
     }

--- a/packages/@react-aria/overlays/src/calculatePosition.ts
+++ b/packages/@react-aria/overlays/src/calculatePosition.ts
@@ -219,7 +219,7 @@ function getMaxHeight(
   margins: Position,
   padding: number
 ) {
-  return position.top != null 
+  return position.top != null
     ? Math.max(0, boundaryDimensions.height + boundaryDimensions.top + boundaryDimensions.scroll.top + containerOffsetWithBoundary.top - position.top - margins.top - margins.bottom - padding)
     : Math.max(0, childOffset.top - boundaryDimensions.top - boundaryDimensions.scroll.top - containerOffsetWithBoundary.top - margins.top - margins.bottom - padding);
 }

--- a/packages/@react-aria/overlays/src/calculatePosition.ts
+++ b/packages/@react-aria/overlays/src/calculatePosition.ts
@@ -202,10 +202,11 @@ function computePosition(
     position[crossAxis] = Math.max(positionForPositiveSideOverflow, childOffset[crossAxis] - overlaySize[crossSize] + childOffset[crossSize]);
   }
 
+  // Floor these so the position isn't placed on a partial pixel, only whole pixels. Shouldn't matter if it was floored or ceiled, so chose one.
   if (placement === axis) {
-    position[FLIPPED_DIRECTION[axis]] = boundaryDimensions[size] - childOffset[axis] - offset;
+    position[FLIPPED_DIRECTION[axis]] = Math.floor(boundaryDimensions[size] - childOffset[axis] - offset);
   } else {
-    position[axis] = childOffset[axis] + childOffset[size] + offset;
+    position[axis] = Math.floor(childOffset[axis] + childOffset[size] + offset);
   }
 
   return position;

--- a/packages/@react-spectrum/overlays/src/Popover.tsx
+++ b/packages/@react-spectrum/overlays/src/Popover.tsx
@@ -133,11 +133,12 @@ function Arrow(props) {
   ];
   let arrowProps = props.arrowProps;
 
+  /* use ceil because the svg needs to always accomodate the path inside it */
   return (
     <svg
       xmlns="http://www.w3.org/svg/2000"
-      width={landscape ? secondary : primary}
-      height={landscape ? primary : secondary}
+      width={Math.ceil(landscape ? secondary : primary)}
+      height={Math.ceil(landscape ? primary : secondary)}
       style={props.style}
       className={classNames(styles, 'spectrum-Popover-tip')}
       ref={ref}
@@ -160,4 +161,6 @@ export {_Popover as Popover};
  * This didn't work because again the issue was inside the svg
  * - I didn't try drawing the svg backwards
  * This could still be tried
+ * - I tried changing the calculation of the popover placement AND the svg height/width so that they were all rounded
+ * This seems to have done the trick
  */


### PR DESCRIPTION
Trying to fix popover tips for Safari and hoping it works for windows. Also fixed them for RTL.

I've added a lot of code comments to explain what i've tried and come up with


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
