### PR TITLE
RSP-1638 Disallowing select all (cmd/ctrl+a) for ActionGroup component

### DIFF
--- a/packages/@react-aria/actiongroup/src/useActionGroup.ts
+++ b/packages/@react-aria/actiongroup/src/useActionGroup.ts
@@ -50,7 +50,8 @@ export function useActionGroup<T>(props: ActionGroupProps<T>, state: ActionGroup
 
   let {collectionProps} = useSelectableCollection({
     selectionManager: state.selectionManager,
-    keyboardDelegate
+    keyboardDelegate,
+    disallowSelectAll: true
   });
 
   let [isFocusWithin, setFocusWithin] = useState(false);

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -36,7 +36,8 @@ interface SelectableCollectionOptions {
   keyboardDelegate: KeyboardDelegate,
   autoFocus?: boolean | FocusStrategy,
   shouldFocusWrap?: boolean,
-  disallowEmptySelection?: boolean
+  disallowEmptySelection?: boolean,
+  disallowSelectAll?: boolean
 }
 
 interface SelectableCollectionAria {
@@ -49,7 +50,8 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
     keyboardDelegate: delegate,
     autoFocus = false,
     shouldFocusWrap = false,
-    disallowEmptySelection = false
+    disallowEmptySelection = false,
+    disallowSelectAll = false
   } = options;
 
   let onKeyDown = (e: KeyboardEvent) => {
@@ -155,7 +157,7 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
         }
         break;
       case 'a':
-        if (isCtrlKeyPressed(e) && manager.selectionMode === 'multiple') {
+        if (isCtrlKeyPressed(e) && manager.selectionMode === 'multiple' && disallowSelectAll !== true) {
           e.preventDefault();
           manager.selectAll();
         }
@@ -196,7 +198,7 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
       // By default, select first item for focus target
       let focusedKey = delegate.getFirstKey();
       let selectedKeys = manager.selectedKeys;
-    
+
       // Set the last item as the new focus target if autoFocus is 'last' (i.e. ArrowUp opening the menu)
       if (autoFocus === 'last') {
         focusedKey = delegate.getLastKey();

--- a/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
+++ b/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
@@ -28,7 +28,7 @@ let theme = {
 
 // Describes the tabIndex values of button 1 (column 1), 2, and 3 as focus is moved forward or back.
 // e.g. button2Focused describes button 2 having tabindex=0 while all other buttons have -1
-let expectedButtonIndicies = {
+let expectedButtonIndices = {
   button1Focused: ['0', '-1', '-1'],
   button2Focused: ['-1', '0', '-1'],
   button3Focused: ['-1', '-1', '0']
@@ -38,7 +38,7 @@ let expectedButtonIndicies = {
 class BtnBehavior {
   constructor() {
     this.index = 0;
-    this.buttons = expectedButtonIndicies;
+    this.buttons = expectedButtonIndices;
     this.forward = this.forward.bind(this);
     this.backward = this.backward.bind(this);
   }
@@ -220,7 +220,7 @@ describe('ActionGroup', function () {
     buttonGroup.focus();
     fireEvent.keyDown(document.activeElement, {key: 'Tab'});
 
-    verifyResult(buttons, expectedButtonIndicies.button1Focused);
+    verifyResult(buttons, expectedButtonIndices.button1Focused);
 
     orders.forEach(({action, result}, index) => {
       action(document.activeElement);
@@ -252,7 +252,20 @@ describe('ActionGroup', function () {
     expect(button2).toHaveAttribute('aria-checked', 'true');
   });
 
-  it('ActionGroup suports shift + arrow keys to extend selection', function () {
+  it('ActionGroup should not allow selecting all items with cmd + a', function () {
+    let {getAllByRole} = renderComponent({selectionMode: 'multiple'});
+
+    let [button1, button2] = getAllByRole('checkbox');
+    triggerPress(button1);
+    expect(button1).toHaveAttribute('aria-checked', 'true');
+    expect(button2).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.keyDown(button1, {key: 'a', ctrlKey: true});
+    expect(button1).toHaveAttribute('aria-checked', 'true');
+    expect(button2).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('ActionGroup supports shift + arrow keys to extend selection', function () {
     let {getAllByRole} = renderComponent({selectionMode: 'multiple'});
 
     let [button1, button2] = getAllByRole('checkbox');


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
