### PR TITLE
Slots audit

### DIFF
--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -13,7 +13,7 @@
 import {ActionButton} from '@react-spectrum/button';
 import {ActionGroupState, useActionGroupState} from '@react-stately/actiongroup';
 import buttonStyles from '@adobe/spectrum-css-temp/components/button/vars.css';
-import {classNames, filterDOMProps, useDOMRef, useSlotProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef} from '@react-spectrum/utils';
 import {DOMProps, DOMRef, SelectionMode, StyleProps} from '@react-types/shared';
 import {mergeProps} from '@react-aria/utils';
 import {Node} from '@react-stately/collections';
@@ -25,7 +25,6 @@ import {useActionGroup} from '@react-aria/actiongroup';
 import {useSelectableItem} from '@react-aria/selection';
 
 function ActionGroup<T>(props: SpectrumActionGroupProps<T>, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     isEmphasized,
     isConnected, // no quiet option available in this mode

--- a/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
+++ b/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
@@ -16,8 +16,8 @@ import {Item} from '@react-stately/collections';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import scaleMedium from '@adobe/spectrum-css-temp/vars/spectrum-medium-unique.css';
-import {testSlotsAPI, triggerPress} from '@react-spectrum/test-utils';
 import themeLight from '@adobe/spectrum-css-temp/vars/spectrum-light-unique.css';
+import {triggerPress} from '@react-spectrum/test-utils';
 import V2Button from '@react/react-spectrum/Button';
 import V2ButtonGroup from '@react/react-spectrum/ButtonGroup';
 
@@ -122,10 +122,6 @@ describe('ActionGroup', function () {
   afterEach(() => {
     btnBehavior.reset();
     cleanup();
-  });
-
-  it('uses slots api', () => {
-    testSlotsAPI(ActionGroup);
   });
 
   it.each`

--- a/packages/@react-spectrum/alert/src/Alert.tsx
+++ b/packages/@react-spectrum/alert/src/Alert.tsx
@@ -11,7 +11,7 @@
  */
 
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import HelpMedium from '@spectrum-icons/ui/HelpMedium';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
 import intlMessages from '../intl';
@@ -30,7 +30,6 @@ let ICONS = {
 };
 
 export function Alert(props: SpectrumAlertProps) {
-  props = useSlotProps(props);
   let {
     title,
     children,

--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -12,7 +12,7 @@
 
 import {ActionButton} from '@react-spectrum/button';
 import {BreadcrumbItem} from './BreadcrumbItem';
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import FolderBreadcrumb from '@spectrum-icons/ui/FolderBreadcrumb';
 import {Menu, MenuTrigger} from '@react-spectrum/menu';
@@ -27,7 +27,6 @@ const MAX_VISIBLE_ITEMS = 4;
 
 function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     size = 'M',
     children,

--- a/packages/@react-spectrum/button/src/ActionButton.tsx
+++ b/packages/@react-spectrum/button/src/ActionButton.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import CornerTriangle from '@spectrum-icons/ui/CornerTriangle';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
@@ -23,8 +23,6 @@ import {useProviderProps} from '@react-spectrum/provider';
 
 function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef) {
   props = useProviderProps(props);
-  
-  props = useSlotProps(props);
   let {
     elementType: ElementType = 'button',
     isQuiet,

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import React from 'react';
@@ -27,7 +27,6 @@ let VARIANT_MAPPING = {
 
 function Button(props: SpectrumButtonProps, ref: FocusableRef) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     elementType: ElementType = 'button',
     children,

--- a/packages/@react-spectrum/button/src/ClearButton.tsx
+++ b/packages/@react-spectrum/button/src/ClearButton.tsx
@@ -11,7 +11,7 @@
  */
 
 import {ButtonProps} from '@react-types/button';
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import CrossSmall from '@spectrum-icons/ui/CrossSmall';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
@@ -25,7 +25,6 @@ interface ClearButtonProps extends ButtonProps {
 }
 
 function ClearButton(props: ClearButtonProps, ref: FocusableRef<HTMLButtonElement>) {
-  props = useSlotProps(props);
   let {
     children = <CrossSmall />,
     focusClassName,

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -11,7 +11,7 @@
  */
 
 import {ButtonProps} from '@react-types/button';
-import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import {mergeProps} from '@react-aria/utils';
@@ -27,7 +27,6 @@ interface FieldButtonProps extends ButtonProps {
 
 // @private
 function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
-  props = useSlotProps(props);
   let {
     elementType: ElementType = 'button',
     isQuiet,

--- a/packages/@react-spectrum/button/src/LogicButton.tsx
+++ b/packages/@react-spectrum/button/src/LogicButton.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import React from 'react';
@@ -21,7 +21,6 @@ import {useProviderProps} from '@react-spectrum/provider';
 
 function LogicButton(props: SpectrumLogicButtonProps, ref: FocusableRef) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     elementType: ElementType = 'button',
     variant,

--- a/packages/@react-spectrum/button/test/ActionButton.test.js
+++ b/packages/@react-spectrum/button/test/ActionButton.test.js
@@ -13,7 +13,7 @@
 import {ActionButton} from '../';
 import {cleanup, render} from '@testing-library/react';
 import React from 'react';
-import {testSlotsAPI, triggerPress} from '@react-spectrum/test-utils';
+import {triggerPress} from '@react-spectrum/test-utils';
 import V2Button from '@react/react-spectrum/Button';
 
 describe('ActionButton', function () {
@@ -22,10 +22,6 @@ describe('ActionButton', function () {
   afterEach(() => {
     cleanup();
     onPressSpy.mockClear();
-  });
-
-  it('uses slots api', () => {
-    testSlotsAPI(ActionButton);
   });
 
   it.each`

--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -13,7 +13,7 @@
 import {ActionButton, Button, ClearButton, LogicButton} from '../';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
-import {testSlotsAPI, triggerPress} from '@react-spectrum/test-utils';
+import {triggerPress} from '@react-spectrum/test-utils';
 import V2Button from '@react/react-spectrum/Button';
 
 /**
@@ -28,10 +28,6 @@ describe('Button', function () {
   afterEach(() => {
     cleanup();
     onPressSpy.mockClear();
-  });
-
-  it('uses slots api', () => {
-    testSlotsAPI(Button);
   });
 
   it.each`

--- a/packages/@react-spectrum/button/test/ClearButton.test.js
+++ b/packages/@react-spectrum/button/test/ClearButton.test.js
@@ -13,7 +13,7 @@
 import {cleanup, render} from '@testing-library/react';
 import {ClearButton} from '../';
 import React from 'react';
-import {testSlotsAPI, triggerPress} from '@react-spectrum/test-utils';
+import {triggerPress} from '@react-spectrum/test-utils';
 import V2Button from '@react/react-spectrum/Button';
 
 // NOTE: ClearButton doesn't use Button.tsx as a base and thus differs from v2 ClearButton in a couple ways
@@ -25,10 +25,6 @@ describe('ClearButton', function () {
   afterEach(() => {
     cleanup();
     onPressSpy.mockClear();
-  });
-
-  it('uses slots api', () => {
-    testSlotsAPI(ClearButton);
   });
 
   it.each`

--- a/packages/@react-spectrum/calendar/src/CalendarBase.tsx
+++ b/packages/@react-spectrum/calendar/src/CalendarBase.tsx
@@ -18,7 +18,7 @@ import {CalendarTableBody} from './CalendarTableBody';
 import {CalendarTableHeader} from './CalendarTableHeader';
 import ChevronLeft from '@spectrum-icons/ui/ChevronLeftLarge';
 import ChevronRight from '@spectrum-icons/ui/ChevronRightLarge';
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {DOMProps, StyleProps} from '@react-types/shared';
 import React from 'react';
 import styles from '@adobe/spectrum-css-temp/components/calendar/vars.css';
@@ -33,7 +33,6 @@ interface CalendarBaseProps extends CalendarPropsBase, DOMProps, StyleProps {
 
 export function CalendarBase(props: CalendarBaseProps) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     state,
     aria,

--- a/packages/@react-spectrum/checkbox/src/Checkbox.tsx
+++ b/packages/@react-spectrum/checkbox/src/Checkbox.tsx
@@ -11,7 +11,7 @@
  */
 
 import CheckmarkSmall from '@spectrum-icons/ui/CheckmarkSmall';
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import DashSmall from '@spectrum-icons/ui/DashSmall';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
@@ -24,7 +24,6 @@ import {useToggleState} from '@react-stately/toggle';
 
 function Checkbox(props: SpectrumCheckboxProps, ref: FocusableRef<HTMLLabelElement>) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     isIndeterminate = false,
     isEmphasized = false,

--- a/packages/@react-spectrum/datepicker/src/DatePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePicker.tsx
@@ -12,7 +12,7 @@
 
 import {Calendar} from '@react-spectrum/calendar';
 import CalendarIcon from '@spectrum-icons/workflow/Calendar';
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
@@ -29,7 +29,6 @@ import {useProviderProps} from '@react-spectrum/provider';
 
 export function DatePicker(props: SpectrumDatePickerProps) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     autoFocus,
     formatOptions,

--- a/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
+++ b/packages/@react-spectrum/datepicker/src/DatePickerField.tsx
@@ -12,7 +12,7 @@
 
 import Alert from '@spectrum-icons/ui/AlertMedium';
 import Checkmark from '@spectrum-icons/ui/CheckmarkMedium';
-import {classNames, useSlotProps} from '@react-spectrum/utils';
+import {classNames} from '@react-spectrum/utils';
 import {DatePickerSegment} from './DatePickerSegment';
 import datepickerStyles from './index.css';
 import {filterDOMProps, useStyleProps} from '@react-spectrum/utils';
@@ -25,7 +25,6 @@ import {useDateField} from '@react-aria/datepicker';
 import {useDatePickerFieldState} from '@react-stately/datepicker';
 
 export function DatePickerField(props: SpectrumDatePickerProps) {
-  props = useSlotProps(props);
   let state = useDatePickerFieldState(props);
   let {
     isDisabled,

--- a/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
+++ b/packages/@react-spectrum/datepicker/src/DateRangePicker.tsx
@@ -11,7 +11,7 @@
  */
 
 import CalendarIcon from '@spectrum-icons/workflow/Calendar';
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {DatePickerField} from './DatePickerField';
 import datepickerStyles from './index.css';
 import {Dialog, DialogTrigger} from '@react-spectrum/dialog';
@@ -28,7 +28,6 @@ import {useProviderProps} from '@react-spectrum/provider';
 
 export function DateRangePicker(props: SpectrumDateRangePickerProps) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     isQuiet,
     isDisabled,

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -13,7 +13,7 @@
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import {Button, ButtonGroup} from '@react-spectrum/button';
 import {chain} from '@react-aria/utils';
-import {classNames, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, useStyleProps} from '@react-spectrum/utils';
 import {Content} from '@react-spectrum/view';
 import {Dialog} from './Dialog';
 import {DialogContext, DialogContextValue} from './context';
@@ -28,8 +28,10 @@ import {SpectrumButtonProps} from '@react-types/button';
 import styles from '@adobe/spectrum-css-temp/components/dialog/vars.css';
 import {useMessageFormatter} from '@react-aria/i18n';
 
+/**
+ * AlertDialogs are a specific type of Dialog. They display important information that users need to acknowledge.
+ */
 function AlertDialog(props: SpectrumAlertDialogProps, ref: DOMRef) {
-  props = useSlotProps(props);
   let {
     onClose = () => {}
   } = useContext(DialogContext) || {} as DialogContextValue;

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -11,7 +11,7 @@
  */
 
 import {ActionButton} from '@react-spectrum/button';
-import {classNames, filterDOMProps, unwrapDOMRef, useDOMRef, useHasChild, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, unwrapDOMRef, useDOMRef, useHasChild, useStyleProps} from '@react-spectrum/utils';
 import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DialogContext, DialogContextValue} from './context';
 import {DOMRef} from '@react-types/shared';
@@ -64,7 +64,6 @@ function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
   let hasFooter = useHasChild(`.${styles['spectrum-Dialog-footer']}`, unwrapDOMRef(gridRef));
 
   let slots = {
-    container: {UNSAFE_className: styles['spectrum-Dialog-grid']},
     hero: {UNSAFE_className: styles['spectrum-Dialog-hero']},
     header: {UNSAFE_className: styles['spectrum-Dialog-header']},
     heading: {UNSAFE_className: classNames(styles, 'spectrum-Dialog-heading', {'spectrum-Dialog-heading--noHeader': !hasHeader}), ...titleProps},
@@ -98,8 +97,10 @@ function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
           styleProps.className
         )}
         ref={domRef}>
-        <Grid slots={slots} ref={gridRef}>
-          {children}
+        <Grid ref={gridRef} UNSAFE_className={styles['spectrum-Dialog-grid']}>
+          <SlotProvider slots={slots}>
+            {children}
+          </SlotProvider>
           {isDismissable &&
             <ActionButton
               UNSAFE_className={styles['spectrum-Dialog-closeButton']}

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -11,7 +11,7 @@
  */
 
 import {ActionButton} from '@react-spectrum/button';
-import {classNames, filterDOMProps, unwrapDOMRef, useDOMRef, useHasChild, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, unwrapDOMRef, useDOMRef, useHasChild, useStyleProps} from '@react-spectrum/utils';
 import CrossLarge from '@spectrum-icons/ui/CrossLarge';
 import {DialogContext, DialogContextValue} from './context';
 import {DOMRef} from '@react-types/shared';
@@ -35,7 +35,6 @@ let sizeMap = {
 };
 
 function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
-  props = useSlotProps(props);
   let {
     type = 'popover',
     ...contextProps
@@ -73,7 +72,6 @@ function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
     divider: {UNSAFE_className: styles['spectrum-Dialog-divider'], size: 'M'},
     content: {UNSAFE_className: styles['spectrum-Dialog-content']},
     footer: {UNSAFE_className: styles['spectrum-Dialog-footer']},
-    closeButton: {UNSAFE_className: styles['spectrum-Dialog-closeButton']},
     buttonGroup: {UNSAFE_className: classNames(styles, 'spectrum-Dialog-buttonGroup', {'spectrum-Dialog-buttonGroup--noFooter': !hasFooter})}
   };
 
@@ -104,7 +102,7 @@ function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
           {children}
           {isDismissable &&
             <ActionButton
-              slot="closeButton"
+              UNSAFE_className={styles['spectrum-Dialog-closeButton']}
               isQuiet
               aria-label={formatMessage('dismiss')}
               onPress={onDismiss}>

--- a/packages/@react-spectrum/form/src/Form.tsx
+++ b/packages/@react-spectrum/form/src/Form.tsx
@@ -11,7 +11,7 @@
  */
 
 import {Alignment, DOMRef, LabelPosition, SpectrumLabelableProps} from '@react-types/shared';
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {Provider, useProviderProps} from '@react-spectrum/provider';
 import React, {useContext} from 'react';
 import {SpectrumFormProps} from '@react-types/form';
@@ -25,7 +25,6 @@ export function useFormProps<T extends SpectrumLabelableProps>(props: T): T {
 
 function Form(props: SpectrumFormProps, ref: DOMRef<HTMLFormElement>) {
   props = useProviderProps(props);
-  props = useSlotProps(props, 'form');
   let {
     children,
     labelPosition = 'top' as LabelPosition,

--- a/packages/@react-spectrum/icon/src/Icon.tsx
+++ b/packages/@react-spectrum/icon/src/Icon.tsx
@@ -40,7 +40,8 @@ interface IconProps extends DOMProps, StyleProps {
    */
   color?: string,
   /**
-   * TODO
+   * A slot to place the icon in.
+   * @default "icon"
    */
   slot?: string,
   /**

--- a/packages/@react-spectrum/icon/src/UIIcon.tsx
+++ b/packages/@react-spectrum/icon/src/UIIcon.tsx
@@ -23,7 +23,7 @@ interface IconProps extends DOMProps, StyleProps {
 }
 
 export function UIIcon(props: IconProps) {
-  props = useSlotProps(props, 'uiIcon');
+  props = useSlotProps(props, 'icon');
   let {
     alt,
     children,

--- a/packages/@react-spectrum/illustrated-message/src/IllustratedMessage.tsx
+++ b/packages/@react-spectrum/illustrated-message/src/IllustratedMessage.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import {Flex} from '@react-spectrum/layout';
 import React, {forwardRef} from 'react';
@@ -19,7 +19,6 @@ import styles from '@adobe/spectrum-css-temp/components/illustratedmessage/vars.
 import typographyStyles from '@adobe/spectrum-css-temp/components/typography/vars.css';
 
 function IllustratedMessage(props: SpectrumIllustratedMessageProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     children,
     slots,

--- a/packages/@react-spectrum/illustrated-message/src/IllustratedMessage.tsx
+++ b/packages/@react-spectrum/illustrated-message/src/IllustratedMessage.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, SlotProvider, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import {Flex} from '@react-spectrum/layout';
 import React, {forwardRef} from 'react';
@@ -53,9 +53,10 @@ function IllustratedMessage(props: SpectrumIllustratedMessageProps, ref: DOMRef<
         'spectrum-IllustratedMessage',
         styleProps.className
       )}
-      slots={slots}
       ref={ref}>
-      {children}
+      <SlotProvider slots={slots}>
+        {children}
+      </SlotProvider>
     </Flex>
   );
 }

--- a/packages/@react-spectrum/label/src/Label.tsx
+++ b/packages/@react-spectrum/label/src/Label.tsx
@@ -11,7 +11,7 @@
  */
 
 import Asterisk from '@spectrum-icons/ui/Asterisk';
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
@@ -23,7 +23,6 @@ import {useProviderProps} from '@react-spectrum/provider';
 
 function Label(props: SpectrumLabelProps, ref: DOMRef<HTMLLabelElement>) {
   props = useProviderProps(props);
-  props = useSlotProps(props, 'label');
   let {
     children,
     labelPosition = 'top',

--- a/packages/@react-spectrum/layout/src/Flex.tsx
+++ b/packages/@react-spectrum/layout/src/Flex.tsx
@@ -11,14 +11,13 @@
  */
 
 import {DOMRef} from '@react-types/shared';
-import {filterDOMProps, flexStyleProps, SlotProvider, useDOMRef, useStyleProps} from '@react-spectrum/utils';
+import {filterDOMProps, flexStyleProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {FlexProps} from '@react-types/layout';
 import React, {forwardRef} from 'react';
 
 function Flex(props: FlexProps, ref: DOMRef<HTMLDivElement>) {
   let {
     children,
-    slots,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps, flexStyleProps);
@@ -27,9 +26,7 @@ function Flex(props: FlexProps, ref: DOMRef<HTMLDivElement>) {
 
   return (
     <div {...filterDOMProps(otherProps)} {...styleProps} ref={domRef}>
-      <SlotProvider slots={slots}>
-        {children}
-      </SlotProvider>
+      {children}
     </div>
   );
 }

--- a/packages/@react-spectrum/layout/src/Flex.tsx
+++ b/packages/@react-spectrum/layout/src/Flex.tsx
@@ -11,12 +11,11 @@
  */
 
 import {DOMRef} from '@react-types/shared';
-import {filterDOMProps, flexStyleProps, SlotProvider, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {filterDOMProps, flexStyleProps, SlotProvider, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {FlexProps} from '@react-types/layout';
 import React, {forwardRef} from 'react';
 
 function Flex(props: FlexProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     children,
     slots,

--- a/packages/@react-spectrum/layout/src/Grid.tsx
+++ b/packages/@react-spectrum/layout/src/Grid.tsx
@@ -10,12 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
-import classNames from 'classnames';
 import {DOMRef} from '@react-types/shared';
 import {
   filterDOMProps,
   gridStyleProps,
-  SlotProvider,
   useDOMRef,
   useStyleProps
 } from '@react-spectrum/utils';
@@ -25,7 +23,6 @@ import React, {forwardRef} from 'react';
 function Grid(props: GridProps, ref: DOMRef<HTMLDivElement>) {
   let {
     children,
-    slots,
     ...otherProps
   } = props;
   let {styleProps} = useStyleProps(otherProps, gridStyleProps);
@@ -33,10 +30,8 @@ function Grid(props: GridProps, ref: DOMRef<HTMLDivElement>) {
   let domRef = useDOMRef(ref);
 
   return (
-    <div {...filterDOMProps(otherProps)} {...styleProps} ref={domRef} className={classNames(styleProps.className, slots && slots.container && slots.container.UNSAFE_className)}>
-      <SlotProvider slots={slots}>
-        {children}
-      </SlotProvider>
+    <div {...filterDOMProps(otherProps)} {...styleProps} ref={domRef}>
+      {children}
     </div>
   );
 }

--- a/packages/@react-spectrum/layout/src/Grid.tsx
+++ b/packages/@react-spectrum/layout/src/Grid.tsx
@@ -17,14 +17,12 @@ import {
   gridStyleProps,
   SlotProvider,
   useDOMRef,
-  useSlotProps,
   useStyleProps
 } from '@react-spectrum/utils';
 import {GridProps} from '@react-types/layout';
 import React, {forwardRef} from 'react';
 
 function Grid(props: GridProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     children,
     slots,

--- a/packages/@react-spectrum/layout/stories/Grid.stories.tsx
+++ b/packages/@react-spectrum/layout/stories/Grid.stories.tsx
@@ -11,10 +11,10 @@
  */
 
 import {ActionButton} from '@react-spectrum/button';
-import {Content, Header} from '@react-spectrum/view';
 import {cssModuleToSlots} from '@react-spectrum/utils';
 import {Divider} from '@react-spectrum/divider';
 import {Flex, Grid} from '@react-spectrum/layout';
+import {Footer, View} from '@react-spectrum/view';
 import {GridProps} from '@react-types/layout';
 import {Heading} from '@react-spectrum/typography';
 import {Image} from '@react-spectrum/image';
@@ -33,19 +33,19 @@ storiesOf('Layout', module)
     })
   );
 
-function render(props:GridProps) {
+function render(props: GridProps) {
   return (
     <Grid {...props} UNSAFE_className={styles['spectrum-Card']}>
       <Image slot="preview" objectFit="cover" src="https://scontent-sjc3-1.cdninstagram.com/vp/061c1b0fa69e3f36c24710f8d5603655/5E500437/t51.2885-15/sh0.08/e35/s640x640/72625830_117633199385660_495143751973844448_n.jpg?_nc_ht=scontent-sjc3-1.cdninstagram.com&_nc_cat=108" alt="" />
       <Image slot="avatar" src="https://a5.behance.net/a9758425f0eaa6f4064d20ba73dfb7946a48f067/img/profile/no-image-138.png?cb=264615658" alt="" />
-      <Header slot="title">
+      <View slot="title">
         <Flex justifyContent="space-between" alignItems="center">
           <Heading>Thor Odinson</Heading>
           <ActionButton isQuiet><More /></ActionButton>
         </Flex>
-      </Header>
+      </View>
       <Divider size="S" />
-      <Content slot="footer">Got lost in the Lost Coast, trying to find home up there. Heimdall, if you see this post, send the Bifrost!</Content>
+      <Footer>Got lost in the Lost Coast, trying to find home up there. Heimdall, if you see this post, send the Bifrost!</Footer>
     </Grid>
   );
 }

--- a/packages/@react-spectrum/layout/stories/Grid.stories.tsx
+++ b/packages/@react-spectrum/layout/stories/Grid.stories.tsx
@@ -11,7 +11,7 @@
  */
 
 import {ActionButton} from '@react-spectrum/button';
-import {cssModuleToSlots} from '@react-spectrum/utils';
+import {cssModuleToSlots, SlotProvider} from '@react-spectrum/utils';
 import {Divider} from '@react-spectrum/divider';
 import {Flex, Grid} from '@react-spectrum/layout';
 import {Footer, View} from '@react-spectrum/view';
@@ -28,7 +28,6 @@ storiesOf('Layout', module)
   .add(
     'Grid: card',
     () => render({
-      slots: cssModuleToSlots(styles),
       children: null
     })
   );
@@ -36,16 +35,18 @@ storiesOf('Layout', module)
 function render(props: GridProps) {
   return (
     <Grid {...props} UNSAFE_className={styles['spectrum-Card']}>
-      <Image slot="preview" objectFit="cover" src="https://scontent-sjc3-1.cdninstagram.com/vp/061c1b0fa69e3f36c24710f8d5603655/5E500437/t51.2885-15/sh0.08/e35/s640x640/72625830_117633199385660_495143751973844448_n.jpg?_nc_ht=scontent-sjc3-1.cdninstagram.com&_nc_cat=108" alt="" />
-      <Image slot="avatar" src="https://a5.behance.net/a9758425f0eaa6f4064d20ba73dfb7946a48f067/img/profile/no-image-138.png?cb=264615658" alt="" />
-      <View slot="title">
-        <Flex justifyContent="space-between" alignItems="center">
-          <Heading>Thor Odinson</Heading>
-          <ActionButton isQuiet><More /></ActionButton>
-        </Flex>
-      </View>
-      <Divider size="S" />
-      <Footer>Got lost in the Lost Coast, trying to find home up there. Heimdall, if you see this post, send the Bifrost!</Footer>
+      <SlotProvider slots={cssModuleToSlots(styles)}>
+        <Image slot="preview" objectFit="cover" src="https://scontent-sjc3-1.cdninstagram.com/vp/061c1b0fa69e3f36c24710f8d5603655/5E500437/t51.2885-15/sh0.08/e35/s640x640/72625830_117633199385660_495143751973844448_n.jpg?_nc_ht=scontent-sjc3-1.cdninstagram.com&_nc_cat=108" alt="" />
+        <Image slot="avatar" src="https://a5.behance.net/a9758425f0eaa6f4064d20ba73dfb7946a48f067/img/profile/no-image-138.png?cb=264615658" alt="" />
+        <View slot="title">
+          <Flex justifyContent="space-between" alignItems="center">
+            <Heading>Thor Odinson</Heading>
+            <ActionButton isQuiet><More /></ActionButton>
+          </Flex>
+        </View>
+        <Divider size="S" />
+        <Footer>Got lost in the Lost Coast, trying to find home up there. Heimdall, if you see this post, send the Bifrost!</Footer>
+      </SlotProvider>
     </Grid>
   );
 }

--- a/packages/@react-spectrum/layout/stories/styles.css
+++ b/packages/@react-spectrum/layout/stories/styles.css
@@ -22,7 +22,7 @@
   margin: 0;
 }
 
-.container {
+.spectrum-Card {
   display: grid;
   grid-template-columns: 14px 48px 1fr 1fr 14px;
   grid-template-rows: minmax(auto, 168px) 32px 16px auto auto auto;

--- a/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxOption.tsx
@@ -11,7 +11,7 @@
  */
 
 import CheckmarkMedium from '@spectrum-icons/ui/CheckmarkMedium';
-import {classNames} from '@react-spectrum/utils';
+import {classNames, SlotProvider} from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
 import {Grid} from '@react-spectrum/layout';
 import {ListState} from '@react-stately/list';
@@ -84,23 +84,25 @@ export function ListBoxOption<T>(props: OptionProps<T>) {
               styles,
               'spectrum-Menu-itemGrid'
             )
-          }
-          slots={{
-            text: {UNSAFE_className: styles['spectrum-Menu-itemLabel'], ...labelProps},
-            icon: {UNSAFE_className: styles['spectrum-Menu-icon']},
-            description: {UNSAFE_className: styles['spectrum-Menu-description'], ...descriptionProps}
-          }}>
-          {contents}
-          {isSelected && 
-            <CheckmarkMedium
-              slot="checkmark"
-              UNSAFE_className={
-                classNames(
-                  styles, 
-                  'spectrum-Menu-checkmark'
-                )
-              } />
-          }
+          }>
+          <SlotProvider
+            slots={{
+              text: {UNSAFE_className: styles['spectrum-Menu-itemLabel'], ...labelProps},
+              icon: {UNSAFE_className: styles['spectrum-Menu-icon']},
+              description: {UNSAFE_className: styles['spectrum-Menu-description'], ...descriptionProps}
+            }}>
+            {contents}
+            {isSelected && 
+              <CheckmarkMedium
+                slot="checkmark"
+                UNSAFE_className={
+                      classNames(
+                        styles, 
+                        'spectrum-Menu-checkmark'
+                      )
+                    } />
+                }
+          </SlotProvider>
         </Grid>
       </div>
     </FocusRing>

--- a/packages/@react-spectrum/menu/src/MenuItem.tsx
+++ b/packages/@react-spectrum/menu/src/MenuItem.tsx
@@ -11,7 +11,7 @@
  */
 
 import CheckmarkMedium from '@spectrum-icons/ui/CheckmarkMedium';
-import {classNames} from '@react-spectrum/utils';
+import {classNames, SlotProvider} from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
 import {Grid} from '@react-spectrum/layout';
 import {Node} from '@react-stately/collections';
@@ -90,25 +90,27 @@ export function MenuItem<T>(props: MenuItemProps<T>) {
               styles,
               'spectrum-Menu-itemGrid'
             )
-          }
-          slots={{
-            text: {UNSAFE_className: styles['spectrum-Menu-itemLabel'], ...labelProps},
-            end: {UNSAFE_className: styles['spectrum-Menu-end'], ...descriptionProps},
-            icon: {UNSAFE_className: styles['spectrum-Menu-icon']},
-            description: {UNSAFE_className: styles['spectrum-Menu-description'], ...descriptionProps},
-            keyboard: {UNSAFE_className: styles['spectrum-Menu-keyboard'], ...keyboardShortcutProps}
-          }}>
-          {contents}
-          {isSelected && 
-            <CheckmarkMedium 
-              slot="checkmark" 
-              UNSAFE_className={
-                classNames(
-                  styles, 
-                  'spectrum-Menu-checkmark'
-                )
-              } />
-          }
+          }>
+          <SlotProvider
+            slots={{
+              text: {UNSAFE_className: styles['spectrum-Menu-itemLabel'], ...labelProps},
+              end: {UNSAFE_className: styles['spectrum-Menu-end'], ...descriptionProps},
+              icon: {UNSAFE_className: styles['spectrum-Menu-icon']},
+              description: {UNSAFE_className: styles['spectrum-Menu-description'], ...descriptionProps},
+              keyboard: {UNSAFE_className: styles['spectrum-Menu-keyboard'], ...keyboardShortcutProps}
+            }}>
+            {contents}
+            {isSelected && 
+              <CheckmarkMedium 
+                slot="checkmark" 
+                UNSAFE_className={
+                      classNames(
+                        styles, 
+                        'spectrum-Menu-checkmark'
+                      )
+                    } />
+                }
+          </SlotProvider>
         </Grid>
       </li>
     </FocusRing>

--- a/packages/@react-spectrum/progress/src/ProgressBarBase.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressBarBase.tsx
@@ -11,7 +11,7 @@
  */
 
 import {clamp} from '@react-aria/utils';
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import {ProgressBarProps} from '@react-types/progress';
 import React, {CSSProperties, HTMLAttributes} from 'react';
@@ -26,7 +26,6 @@ interface ProgressBarBaseProps extends SpectrumProgressBarBaseProps, ProgressBar
 
 // Base ProgressBar component shared with Meter.
 function ProgressBarBase(props: ProgressBarBaseProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     value = 0,
     minValue = 0,

--- a/packages/@react-spectrum/progress/src/ProgressCircle.tsx
+++ b/packages/@react-spectrum/progress/src/ProgressCircle.tsx
@@ -11,7 +11,7 @@
  */
 
 import {clamp} from '@react-aria/utils';
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import React, {CSSProperties} from 'react';
 import {SpectrumProgressCircleProps} from '@react-types/progress';
@@ -19,7 +19,6 @@ import styles from '@adobe/spectrum-css-temp/components/circleloader/vars.css';
 import {useProgressBar} from '@react-aria/progress';
 
 function ProgressCircle(props: SpectrumProgressCircleProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     value = 0,
     minValue = 0,

--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -17,7 +17,6 @@ import {
   filterDOMProps,
   shouldKeepSpectrumClassNames,
   useDOMRef,
-  useSlotProps,
   useStyleProps
 } from '@react-spectrum/utils';
 import {Provider as I18nProvider, useLocale} from '@react-aria/i18n';
@@ -116,7 +115,6 @@ let _Provider = React.forwardRef(Provider);
 export {_Provider as Provider};
 
 const ProviderWrapper = React.forwardRef(function ProviderWrapper(props: ProviderProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     children,
     ...otherProps

--- a/packages/@react-spectrum/radio/src/Radio.tsx
+++ b/packages/@react-spectrum/radio/src/Radio.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import React, {forwardRef, useRef} from 'react';
@@ -23,7 +23,6 @@ function Radio(props: SpectrumRadioProps, ref: FocusableRef<HTMLLabelElement>) {
   if (!props.children && !props['aria-label']) {
     console.warn('If no children are provided, an aria-label must be specified');
   }
-  props = useSlotProps(props);
 
   let {
     isDisabled,

--- a/packages/@react-spectrum/radio/src/RadioGroup.tsx
+++ b/packages/@react-spectrum/radio/src/RadioGroup.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef, LabelPosition} from '@react-types/shared';
 import {Label} from '@react-spectrum/label';
 import labelStyles from '@adobe/spectrum-css-temp/components/fieldlabel/vars.css';
@@ -41,7 +41,6 @@ export function useRadioProvider(): RadioGroupContext {
 function RadioGroup(props: SpectrumRadioGroupProps, ref: DOMRef<HTMLDivElement>) {
   props = useProviderProps(props);
   props = useFormProps(props);
-  props = useSlotProps(props);
   let {
     isEmphasized,
     isRequired,

--- a/packages/@react-spectrum/statuslight/src/StatusLight.tsx
+++ b/packages/@react-spectrum/statuslight/src/StatusLight.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import React, {forwardRef} from 'react';
 import {SpectrumStatusLightProps} from '@react-types/statuslight';
@@ -18,7 +18,6 @@ import styles from '@adobe/spectrum-css-temp/components/statuslight/vars.css';
 import {useProviderProps} from '@react-spectrum/provider';
 
 function StatusLight(props: SpectrumStatusLightProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     variant,
     children,

--- a/packages/@react-spectrum/switch/src/Switch.tsx
+++ b/packages/@react-spectrum/switch/src/Switch.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import React, {forwardRef, useRef} from 'react';
@@ -22,7 +22,6 @@ import {useToggleState} from '@react-stately/toggle';
 
 function Switch(props: SpectrumSwitchProps, ref: FocusableRef<HTMLLabelElement>) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let {
     isEmphasized = false,
     isDisabled = false,

--- a/packages/@react-spectrum/tabs/src/Tab.tsx
+++ b/packages/@react-spectrum/tabs/src/Tab.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {DOMProps, StyleProps} from '@react-types/shared';
 import React, {ReactNode} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/tabs/vars.css';
@@ -27,7 +27,6 @@ interface TabProps extends DOMProps, StyleProps {
 }
 
 export function Tab(props: TabProps) {
-  props = useSlotProps(props);
   // v3 come up with rule for how to handle props and dom props issue
   // v3 Always use classNames even when only one class because of modules and "turnonclassname" option
   // TODO: Add in icon in the render when cloneIcon/icon v3 becomes available. Make it so icon or label must be defined.

--- a/packages/@react-spectrum/tabs/src/TabList.tsx
+++ b/packages/@react-spectrum/tabs/src/TabList.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {DOMProps, Orientation, StyleProps} from '@react-types/shared';
 import React, {ReactElement, ReactNode, useEffect, useRef, useState} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/tabs/vars.css';
@@ -45,7 +45,6 @@ interface TabListProps extends DOMProps, StyleProps {
 // TODO: Implement functionality related to overflowMode
 export function TabList(props: TabListProps) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let state = useTabListState(props);
   let [tabsArray, setTabsArray] = useState([]);
   let {tabListProps} = useTabList(props);

--- a/packages/@react-spectrum/tabs/src/Tabs.tsx
+++ b/packages/@react-spectrum/tabs/src/Tabs.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {DOMProps, Orientation, StyleProps} from '@react-types/shared';
 import React, {ReactElement, ReactNode} from 'react';
 import styles from '../style/index.css';
@@ -45,7 +45,6 @@ interface TabsProps extends DOMProps, StyleProps {
 
 export function Tabs(props: TabsProps) {
   props = useProviderProps(props);
-  props = useSlotProps(props);
   let state = useTabListState(props);
   let {
     orientation = 'horizontal' as Orientation,

--- a/packages/@react-spectrum/tag/src/Tag.tsx
+++ b/packages/@react-spectrum/tag/src/Tag.tsx
@@ -11,7 +11,7 @@
  */
 
 import Alert from '@spectrum-icons/workflow/Alert';
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {ClearButton} from '@react-spectrum/button';
 import {FocusRing} from '@react-aria/focus';
 import React from 'react';
@@ -21,7 +21,6 @@ import {useTag} from '@react-aria/tag';
 import {useTagGroupProvider} from './TagGroup';
 
 export const Tag = ((props: SpectrumTagProps) => {
-  props = useSlotProps(props);
   const {
     isDisabled,
     isRemovable,

--- a/packages/@react-spectrum/tag/src/TagGroup.tsx
+++ b/packages/@react-spectrum/tag/src/TagGroup.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import React, {useContext} from 'react';
 import {Removable} from '@react-types/shared';
 import {SpectrumTagGroupProps} from '@react-types/tag';
@@ -35,7 +35,6 @@ export function useTagGroupProvider(): TagGroupContext {
 
 export const TagGroup = ((props: SpectrumTagGroupProps) => {
   props = useProviderProps(props);
-  props = useSlotProps(props);
 
   let {
     isReadOnly,

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -17,7 +17,6 @@ import {
   createFocusableRef,
   filterDOMProps,
   TextInputDOMPropNames,
-  useSlotProps,
   useStyleProps
 } from '@react-spectrum/utils';
 import {FocusRing} from '@react-aria/focus';
@@ -41,7 +40,6 @@ interface TextFieldBaseProps extends SpectrumTextFieldProps {
 function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
   props = useProviderProps(props);
   props = useFormProps(props);
-  props = useSlotProps(props);
   let {
     label,
     labelPosition = 'top' as LabelPosition,

--- a/packages/@react-spectrum/toast/src/Toast.tsx
+++ b/packages/@react-spectrum/toast/src/Toast.tsx
@@ -12,7 +12,7 @@
 
 import AlertMedium from '@spectrum-icons/ui/AlertMedium';
 import {Button, ClearButton} from '@react-spectrum/button';
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import CrossMedium from '@spectrum-icons/ui/CrossMedium';
 import {DOMRef} from '@react-types/shared';
 import InfoMedium from '@spectrum-icons/ui/InfoMedium';
@@ -32,7 +32,6 @@ export const ICONS = {
 };
 
 function Toast(props: SpectrumToastProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     actionLabel,
     children,

--- a/packages/@react-spectrum/tooltip/src/Tooltip.tsx
+++ b/packages/@react-spectrum/tooltip/src/Tooltip.tsx
@@ -10,14 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import React, {RefObject, useRef} from 'react';
 import {SpectrumTooltipProps} from '@react-types/tooltip';
 import styles from '@adobe/spectrum-css-temp/components/tooltip/vars.css';
 import {useTooltip} from '@react-aria/tooltip';
 
 export const Tooltip = React.forwardRef((props: SpectrumTooltipProps, ref: RefObject<HTMLDivElement>) => {
-  props = useSlotProps(props);
   ref = ref || useRef();
   let {
     variant = 'neutral',

--- a/packages/@react-spectrum/utils/src/Slots.tsx
+++ b/packages/@react-spectrum/utils/src/Slots.tsx
@@ -13,10 +13,14 @@
 import {mergeProps} from '@react-aria/utils';
 import React, {useContext, useMemo} from 'react';
 
+interface SlotProps {
+  slot?: string
+}
+
 let SlotContext = React.createContext(null);
 
-export function useSlotProps(props: any, defaultSlot?: string): any {
-  let slot = props.slot || defaultSlot;
+export function useSlotProps<T>(props: T, defaultSlot?: string): T {
+  let slot = (props as SlotProps).slot || defaultSlot;
   let {[slot]: slotProps = {}} = useContext(SlotContext) || {};
   return mergeProps(slotProps, props);
 }

--- a/packages/@react-spectrum/view/src/View.tsx
+++ b/packages/@react-spectrum/view/src/View.tsx
@@ -11,11 +11,12 @@
  */
 
 import {DOMRef} from '@react-types/shared';
-import {filterDOMProps, useDOMRef, useStyleProps, viewStyleProps} from '@react-spectrum/utils';
+import {filterDOMProps, useDOMRef, useSlotProps, useStyleProps, viewStyleProps} from '@react-spectrum/utils';
 import React, {forwardRef} from 'react';
 import {ViewProps} from '@react-types/view';
 
 function View(props: ViewProps, ref: DOMRef) {
+  props = useSlotProps(props);
   let {
     elementType: ElementType = 'div',
     children,

--- a/packages/@react-spectrum/well/src/Well.tsx
+++ b/packages/@react-spectrum/well/src/Well.tsx
@@ -10,14 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-import {classNames, filterDOMProps, useDOMRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
+import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import React, {forwardRef} from 'react';
 import {SpectrumWellProps} from '@react-types/well';
 import styles from '@adobe/spectrum-css-temp/components/well/vars.css';
 
 function Well(props: SpectrumWellProps, ref: DOMRef<HTMLDivElement>) {
-  props = useSlotProps(props);
   let {
     children,
     ...otherProps

--- a/packages/@react-types/divider/src/index.d.ts
+++ b/packages/@react-types/divider/src/index.d.ts
@@ -23,5 +23,11 @@ export interface SpectrumDividerProps extends DOMProps, StyleProps {
    * The axis the Divider should align with.
    * @default 'horizontal'
    */
-  orientation?: Orientation
+  orientation?: Orientation,
+
+  /**
+   * A slot to place the divider in.
+   * @default "divider"
+   */
+  slot?: string
 }

--- a/packages/@react-types/image/src/index.d.ts
+++ b/packages/@react-types/image/src/index.d.ts
@@ -22,5 +22,9 @@ export interface ImageProps {
 }
 
 export interface SpectrumImageProps extends ImageProps, DOMProps, StyleProps {
-
+  /**
+   * A slot to place the image in.
+   * @default "image"
+   */
+  slot?: string
 }

--- a/packages/@react-types/layout/src/flex.d.ts
+++ b/packages/@react-types/layout/src/flex.d.ts
@@ -16,6 +16,5 @@ import {ReactElement} from 'react';
 export type Slots = {[key: string]: any};
 
 export interface FlexProps extends DOMProps, FlexStyleProps {
-  children: ReactElement | ReactElement[],
-  slots?: Slots
+  children: ReactElement | ReactElement[]
 }

--- a/packages/@react-types/layout/src/grid.d.ts
+++ b/packages/@react-types/layout/src/grid.d.ts
@@ -12,9 +12,7 @@
 
 import {DOMProps, GridStyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
-import {Slots} from './flex';
 
 export interface GridProps extends DOMProps, GridStyleProps {
-  children: ReactNode,
-  slots: Slots
+  children: ReactNode
 }

--- a/packages/@react-types/shared/src/style.d.ts
+++ b/packages/@react-types/shared/src/style.d.ts
@@ -19,8 +19,6 @@ export interface StyleProps {
   UNSAFE_className?: string,
   UNSAFE_style?: CSSProperties,
 
-  slot?: string,
-
   margin?: DimensionValue,
   marginStart?: DimensionValue,
   marginEnd?: DimensionValue,

--- a/packages/@react-types/typography/src/heading.d.ts
+++ b/packages/@react-types/typography/src/heading.d.ts
@@ -14,5 +14,13 @@ import {DOMProps, StyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
 
 export interface HeadingProps extends DOMProps, StyleProps {
-  children: ReactNode
+  /**
+   * Heading content
+   */
+  children: ReactNode,
+  /**
+   * A slot to place the heading in.
+   * @default "heading"
+   */
+  slot?: string
 }

--- a/packages/@react-types/typography/src/keyboard.d.ts
+++ b/packages/@react-types/typography/src/keyboard.d.ts
@@ -14,5 +14,13 @@ import {DOMProps, StyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
 
 export interface KeyboardProps extends DOMProps, StyleProps {
-  children: ReactNode
+  /**
+   * Keyboard shortcut text
+   */
+  children: ReactNode,
+  /**
+   * A slot to place the keyboard shortcut in.
+   * @default "keyboard"
+   */
+  slot?: string
 }

--- a/packages/@react-types/typography/src/text.d.ts
+++ b/packages/@react-types/typography/src/text.d.ts
@@ -14,5 +14,13 @@ import {DOMProps, StyleProps} from '@react-types/shared';
 import {ReactNode} from 'react';
 
 export interface TextProps extends DOMProps, StyleProps {
-  children: ReactNode
+  /**
+   * Text content
+   */
+  children: ReactNode,
+  /**
+   * A slot to place the text in.
+   * @default "text"
+   */
+  slot?: string
 }


### PR DESCRIPTION
Removes the `slot` prop from everything except "content" components (typography, icon, image, etc.). A few additional "container" components can receive slot props from context but not have a custom slot name (e.g. header, footer, content) - they have a default slot name derived from the component name.

In addition, this separates `<SlotProvider>` from `<Grid>` and `<Flex>` so the layout components can be used without providing slots.