### PR TITLE
Fix provider blowup

### DIFF
--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -42,10 +42,12 @@ function Provider(props: ProviderProps, ref: DOMRef<HTMLDivElement>) {
   let autoColorScheme = useColorScheme(theme, defaultColorScheme);
   let autoScale = useScale(theme);
   let {locale: prevLocale} = useLocale();
+  // if the new theme doesn't support the prevColorScheme, we must resort to the auto
+  let usePrevColorScheme = !!theme[prevColorScheme];
 
   // importance of color scheme props > parent > auto:(OS > default > omitted)
   let {
-    colorScheme = prevColorScheme || autoColorScheme,
+    colorScheme = usePrevColorScheme ? prevColorScheme : autoColorScheme,
     scale = prevContext ? prevContext.scale : autoScale,
     typekitId,
     locale = prevContext ? prevLocale : null,

--- a/packages/@react-spectrum/provider/test/Provider.test.js
+++ b/packages/@react-spectrum/provider/test/Provider.test.js
@@ -128,6 +128,28 @@ describe('Provider', () => {
     onPressSpy.mockClear();
   });
 
+  it('will render an available color scheme automatically if the previous does not exist on the new theme', () => {
+    matchMedia.useMediaQuery(mediaQueryDark);
+    let {getByTestId} = render(
+      <Provider theme={theme} data-testid="testid1">
+        <Provider
+          theme={{
+            global: {},
+            light: {'spectrum--light': 'spectrum--light'},
+            medium: {'spectrum--medium': 'spectrum--medium'},
+            large: {'spectrum--large': 'spectrum--large'}
+          }}
+          data-testid="testid2">
+          <Button>Hello!</Button>
+        </Provider>
+      </Provider>
+    );
+    let provider1 = getByTestId('testid1');
+    let provider2 = getByTestId('testid2');
+    expect(provider1.classList.contains('spectrum--dark')).toBeTruthy();
+    expect(provider2.classList.contains('spectrum--light')).toBeTruthy();
+  });
+
   it('Provider will rerender if the OS preferred changes and it is on auto', () => {
     matchMedia.useMediaQuery(mediaQueryLight);
     let {getByTestId} = render(


### PR DESCRIPTION
Fix provider blows up if using previous colorScheme on theme without the colorScheme

if the new theme doesn't support the prevColorScheme, we must resort to the auto


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
