### PR TITLE
Removing split button example in MenuTrigger story

### DIFF
--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -216,44 +216,6 @@ storiesOf('MenuTrigger', module)
         </div>
       </>
     )
-  )
-  .add(
-    'more than 2 children (split button)',
-    () => (
-      <div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>
-        <Button
-          variant="primary"
-          onPress={action('press 1')}
-          onPressStart={action('pressstart 1')}
-          onPressEnd={action('pressend 1')}
-          UNSAFE_className={classNames(
-            styles,
-            'spectrum-SplitButton-action'
-          )}>
-          Hi
-        </Button>
-        <MenuTrigger onOpenChange={action('onOpenChange')}>
-          <Button
-            variant="primary"
-            onPress={action('press 2')}
-            onPressStart={action('pressstart 2')}
-            onPressEnd={action('pressend 2')}
-            UNSAFE_className={classNames(
-              styles,
-              'spectrum-SplitButton-trigger'
-            )}>
-            <ChevronDownMedium />
-          </Button>
-          <Menu items={withSection} itemKey="name" onAction={action('action')}>
-            {item => (
-              <Section items={item.children} title={item.name}>
-                {item => <Item childItems={item.children}>{item.name}</Item>}
-              </Section>
-            )}
-          </Menu>
-        </MenuTrigger>
-      </div>
-    )
   );
 
 function render({isDisabled, ...props}: any = {}, menuProps = {}) {

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -11,13 +11,11 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ActionButton, Button} from '@react-spectrum/button';
+import {ActionButton} from '@react-spectrum/button';
 import AlignCenter from '@spectrum-icons/workflow/AlignCenter';
 import AlignLeft from '@spectrum-icons/workflow/AlignLeft';
 import AlignRight from '@spectrum-icons/workflow/AlignRight';
-import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
 import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
-import {classNames} from '@react-spectrum/utils';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
 import {Item, Menu, MenuTrigger, Section} from '../';
@@ -25,7 +23,6 @@ import {Keyboard, Text} from '@react-spectrum/typography';
 import Paste from '@spectrum-icons/workflow/Paste';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import styles from '@adobe/spectrum-css-temp/components/splitbutton/vars.css';
 
 let withSection = [
   {name: 'Animals', children: [


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
