### PR TITLE
Fix strange issue with ButtonGroup in dialog

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/buttongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/buttongroup/index.css
@@ -16,9 +16,9 @@ governing permissions and limitations under the License.
 
 .spectrum-ButtonGroup {
   display: inline-flex;
-  /* Added this so it would wrap */
-  flex-wrap: wrap;
   align-items: flex-start;
+  /* necessary so that offsetLeft on button children is correct */
+  position: relative;
 
   .spectrum-ButtonGroup-Button {
     flex-shrink: 0;

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -38,7 +38,7 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
   let checkForOverflow = useCallback(() => {
     if (domRef.current && orientation === 'horizontal') {
       setHasOverflow(false);
-      let buttonGroupChildren = Array.from(domRef.current.children);
+      let buttonGroupChildren = Array.from(domRef.current.children) as HTMLElement[];
       let maxX = domRef.current.offsetWidth + 1; // + 1 to account for rounding errors
 
       // If any buttons have negative X positions (align="end") or extend beyond

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -39,9 +39,11 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
     if (domRef.current && orientation === 'horizontal') {
       setHasOverflow(false);
       let buttonGroupChildren = Array.from(domRef.current.children);
-      let childrenY = buttonGroupChildren.map(child => child.getBoundingClientRect().top);
-      // If any button's top is different from the others, overflow is happening
-      if (!childrenY.every(itemY => itemY === childrenY[0])) {
+      let maxX = domRef.current.offsetWidth + 1; // + 1 to account for rounding errors
+
+      // If any buttons have negative X positions (align="end") or extend beyond
+      // the width of the button group (align="start"), then switch to vertical.
+      if (buttonGroupChildren.some(child => child.offsetLeft < 0 || child.offsetLeft + child.offsetWidth > maxX)) {
         setHasOverflow(true);
       }
     }


### PR DESCRIPTION
It seems that `flex-wrap` inside CSS grid caused it to take up extra space. Adjusting the overflow computation to be based on the X position rather than the Y position.