### PR TITLE
Fix close button placement

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -88,17 +88,16 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog .spectrum-Dialog-grid {
   display: grid;
-  grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto minmax(0, auto) auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding));
-  grid-template-rows: auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding)) auto auto auto 1fr auto var(--spectrum-dialog-padding);
+  grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto minmax(0, auto) minmax(var(--spectrum-dialog-padding), var(--spectrum-dialog-close-button-size));
+  grid-template-rows: auto minmax(var(--spectrum-dialog-padding), var(--spectrum-dialog-close-button-size)) auto auto 1fr auto var(--spectrum-dialog-padding);
   grid-template-areas:
-    "hero hero    hero    hero        hero        hero        hero"
-    ".    .       .       .           .           .           ."
-    ".    .       .       .           .           closeButton ."
-    ".    heading header  header      typeIcon    .           ."
-    ".    divider divider divider     divider     .           ."
-    ".    content content content     content     .           ."
-    ".    footer  footer  buttonGroup buttonGroup .           ."
-    ".    .       .       .           .           .           .";
+    "hero hero    hero    hero        hero        hero"
+    ".    .       .       .           .           closeButton"
+    ".    heading header  header      typeIcon    ."
+    ".    divider divider divider     divider     ."
+    ".    content content content     content     ."
+    ".    footer  footer  buttonGroup buttonGroup ."
+    ".    .       .       .           .           .";
   width: 100%;
 }
 
@@ -215,6 +214,9 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog-closeButton {
   grid-area: closeButton;
+  /* align and justify so it doesn't do the default 'stretch' and end up with forced height/width */
+  align-self: end;
+  justify-self: start;
 }
 
 /* Alert Dialog is a specific type of Dialog */
@@ -274,18 +276,17 @@ governing permissions and limitations under the License.
 
 @media screen and (max-width: 700px) {
   .spectrum-Dialog .spectrum-Dialog-grid {
-    grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto auto auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding));
-    grid-template-rows: auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding)) auto auto auto auto 1fr auto var(--spectrum-dialog-padding);
+    grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto auto minmax(var(--spectrum-dialog-padding), var(--spectrum-dialog-close-button-size));
+    grid-template-rows: auto minmax(var(--spectrum-dialog-padding), var(--spectrum-dialog-close-button-size)) auto auto auto 1fr auto var(--spectrum-dialog-padding);
     grid-template-areas:
-      "hero hero    hero    hero        hero        hero        hero"
-      ".    .       .       .           .           .           ."
-      ".    .       .       .           .           closeButton ."
-      ".    heading heading heading     typeIcon    .           ."
-      ".    header  header  header      header      .           ."
-      ".    divider divider divider     divider     .           ."
-      ".    content content content     content     .           ."
-      ".    footer  footer  buttonGroup buttonGroup .           ."
-      ".    .       .       .           .           .           .";
+      "hero hero    hero    hero        hero        hero"
+      ".    .       .       .           .           closeButton"
+      ".    heading heading heading     typeIcon    ."
+      ".    header  header  header      header      ."
+      ".    divider divider divider     divider     ."
+      ".    content content content     content     ."
+      ".    footer  footer  buttonGroup buttonGroup ."
+      ".    .       .       .           .           .";
   }
 
   .spectrum-Dialog .spectrum-Dialog-header {

--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -88,8 +88,8 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog .spectrum-Dialog-grid {
   display: grid;
-  grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto minmax(0, auto) auto calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size));
-  grid-template-rows: auto calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)) auto auto auto 1fr auto var(--spectrum-dialog-padding);
+  grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto minmax(0, auto) auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding));
+  grid-template-rows: auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding)) auto auto auto 1fr auto var(--spectrum-dialog-padding);
   grid-template-areas:
     "hero hero    hero    hero        hero        hero        hero"
     ".    .       .       .           .           .           ."
@@ -274,17 +274,18 @@ governing permissions and limitations under the License.
 
 @media screen and (max-width: 700px) {
   .spectrum-Dialog .spectrum-Dialog-grid {
-    grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto auto var(--spectrum-dialog-padding);
-    grid-template-rows: auto var(--spectrum-dialog-padding) auto auto auto 1fr auto var(--spectrum-dialog-padding);
+    grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto auto auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding));
+    grid-template-rows: auto minmax(calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)), var(--spectrum-dialog-padding)) auto auto auto auto 1fr auto var(--spectrum-dialog-padding);
     grid-template-areas:
-      "hero hero    hero    hero        hero        hero"
-      ".    .       .       .           .           closeButton"
-      ".    heading heading heading     typeIcon    ."
-      ".    header  header  header      header      ."
-      ".    divider divider divider     divider     ."
-      ".    content content content     content     ."
-      ".    footer  footer  buttonGroup buttonGroup ."
-      ".    .       .       .           .           .";
+      "hero hero    hero    hero        hero        hero        hero"
+      ".    .       .       .           .           .           ."
+      ".    .       .       .           .           closeButton ."
+      ".    heading heading heading     typeIcon    .           ."
+      ".    header  header  header      header      .           ."
+      ".    divider divider divider     divider     .           ."
+      ".    content content content     content     .           ."
+      ".    footer  footer  buttonGroup buttonGroup .           ."
+      ".    .       .       .           .           .           .";
   }
 
   .spectrum-Dialog .spectrum-Dialog-header {

--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -39,6 +39,7 @@ governing permissions and limitations under the License.
 
   /* 12px desktop (medium scale) and 8px mobile (large scale) */
   --spectrum-dialog-close-button-padding: calc(26px - var(--spectrum-global-dimension-size-175));
+  --spectrum-dialog-close-button-size: var(--spectrum-global-dimension-size-400);
 
   --spectrum-dialog-gap-size: var(--spectrum-global-dimension-size-200);
 }
@@ -87,16 +88,17 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog .spectrum-Dialog-grid {
   display: grid;
-  grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto minmax(0, auto) var(--spectrum-dialog-padding);
-  grid-template-rows: auto var(--spectrum-dialog-padding) auto auto 1fr auto var(--spectrum-dialog-padding);
+  grid-template-columns: var(--spectrum-dialog-padding) auto 1fr auto minmax(0, auto) auto calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size));
+  grid-template-rows: auto calc(var(--spectrum-dialog-padding) - var(--spectrum-dialog-close-button-size)) auto auto auto 1fr auto var(--spectrum-dialog-padding);
   grid-template-areas:
-    "hero hero    hero    hero        hero        hero"
-    ".    .       .       .           .           closeButton"
-    ".    heading header  header      typeIcon    ."
-    ".    divider divider divider     divider     ."
-    ".    content content content     content     ."
-    ".    footer  footer  buttonGroup buttonGroup ."
-    ".    .       .       .           .           .";
+    "hero hero    hero    hero        hero        hero        hero"
+    ".    .       .       .           .           .           ."
+    ".    .       .       .           .           closeButton ."
+    ".    heading header  header      typeIcon    .           ."
+    ".    divider divider divider     divider     .           ."
+    ".    content content content     content     .           ."
+    ".    footer  footer  buttonGroup buttonGroup .           ."
+    ".    .       .       .           .           .           .";
   width: 100%;
 }
 
@@ -213,12 +215,6 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog-closeButton {
   grid-area: closeButton;
-  /* align and justify so it doesn't do the default 'stretch' and end up with forced height/width */
-  align-self: start;
-  justify-self: end;
-
-  inset-block-start: var(--spectrum-dialog-close-button-padding);
-  inset-inline-end: var(--spectrum-dialog-close-button-padding);
 }
 
 /* Alert Dialog is a specific type of Dialog */

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -11,13 +11,11 @@
  */
 
 import {action} from '@storybook/addon-actions';
-import {ActionButton, Button} from '@react-spectrum/button';
+import {ActionButton} from '@react-spectrum/button';
 import AlignCenter from '@spectrum-icons/workflow/AlignCenter';
 import AlignLeft from '@spectrum-icons/workflow/AlignLeft';
 import AlignRight from '@spectrum-icons/workflow/AlignRight';
-import ChevronDownMedium from '@spectrum-icons/ui/ChevronDownMedium';
 import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
-import {classNames} from '@react-spectrum/utils';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
 import {Item, Menu, MenuTrigger, Section} from '../';
@@ -25,7 +23,6 @@ import {Keyboard, Text} from '@react-spectrum/typography';
 import Paste from '@spectrum-icons/workflow/Paste';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
-import styles from '@adobe/spectrum-css-temp/components/splitbutton/vars.css';
 
 let withSection = [
   {name: 'Animals', children: [
@@ -215,44 +212,6 @@ storiesOf('MenuTrigger', module)
           <input placeholder="Tab here" />
         </div>
       </>
-    )
-  )
-  .add(
-    'more than 2 children (split button)',
-    () => (
-      <div style={{display: 'flex', width: 'auto', margin: '100px 0'}}>
-        <Button
-          variant="primary"
-          onPress={action('press 1')}
-          onPressStart={action('pressstart 1')}
-          onPressEnd={action('pressend 1')}
-          UNSAFE_className={classNames(
-            styles,
-            'spectrum-SplitButton-action'
-          )}>
-          Hi
-        </Button>
-        <MenuTrigger onOpenChange={action('onOpenChange')}>
-          <Button
-            variant="primary"
-            onPress={action('press 2')}
-            onPressStart={action('pressstart 2')}
-            onPressEnd={action('pressend 2')}
-            UNSAFE_className={classNames(
-              styles,
-              'spectrum-SplitButton-trigger'
-            )}>
-            <ChevronDownMedium />
-          </Button>
-          <Menu items={withSection} itemKey="name" onAction={action('action')}>
-            {item => (
-              <Section items={item.children} title={item.name}>
-                {item => <Item childItems={item.children}>{item.name}</Item>}
-              </Section>
-            )}
-          </Menu>
-        </MenuTrigger>
-      </div>
     )
   );
 


### PR DESCRIPTION
fix close button  position in grid so that it always has room and affects layout

rely on negative width columns having a width of zero
it does look a little funny in large scale because the padding on the close button side is bigger :-/


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
