### PR TITLE
Fix hover state of picker

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/skin.css
@@ -60,16 +60,19 @@ governing permissions and limitations under the License.
 .spectrum-Dropdown-label {
   &.is-placeholder {
     color: var(--spectrum-dropdown-placeholder-text-color);
-
-    &:hover {
-      color: var(--spectrum-dropdown-placeholder-text-color-hover);
-    }
-
-    &:active {
-      color: var(--spectrum-dropdown-placeholder-text-color-mouse-focus);
-    }
   }
 }
+
+.spectrum-Dropdown-trigger {
+  &:hover .spectrum-Dropdown-label {
+    color: var(--spectrum-dropdown-placeholder-text-color-hover);
+  }
+
+  &:active .spectrum-Dropdown-label {
+    color: var(--spectrum-dropdown-placeholder-text-color-mouse-focus);
+  }
+}
+
 .spectrum-Dropdown-trigger.focus-ring {
   .spectrum-Dropdown-label.is-placeholder {
     color: var(--spectrum-dropdown-placeholder-text-color-key-focus);


### PR DESCRIPTION
when the picker trigger is focused, then the focus styles should be applied, not just when it's the label


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
