### PR TITLE
refactoring autofocus on form elements to pass ref to useFocusable

### DIFF
--- a/packages/@react-aria/checkbox/src/useCheckbox.ts
+++ b/packages/@react-aria/checkbox/src/useCheckbox.ts
@@ -20,7 +20,7 @@ export interface CheckboxAria {
 }
 
 export function useCheckbox(props: CheckboxProps, state: ToggleState, inputRef: RefObject<HTMLInputElement>): CheckboxAria {
-  let {inputProps} = useToggle(props, state);
+  let {inputProps} = useToggle(props, state, inputRef);
   let {isSelected} = state;
 
   let {isIndeterminate} = props;

--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {InputHTMLAttributes} from 'react';
+import {InputHTMLAttributes, RefObject} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {RadioGroupState} from '@react-stately/radio';
 import {RadioProps} from '@react-types/radio';
@@ -27,14 +27,13 @@ interface RadioAria {
   inputProps: InputHTMLAttributes<HTMLElement>
 }
 
-export function useRadio(props: RadioAriaProps, state: RadioGroupState): RadioAria {
+export function useRadio(props: RadioAriaProps, state: RadioGroupState, ref: RefObject<HTMLElement>): RadioAria {
   let {
     value,
     isRequired,
     isReadOnly,
     isDisabled,
-    name,
-    autoFocus
+    name
   } = props;
   let {
     selectedRadio,
@@ -57,7 +56,7 @@ export function useRadio(props: RadioAriaProps, state: RadioGroupState): RadioAr
 
   let {focusableProps} = useFocusable(mergeProps(props, {
     onFocus: () => setFocusableRadio(value)
-  }));
+  }), ref);
   let interactions = mergeProps(pressProps, focusableProps);
 
   return {
@@ -71,7 +70,6 @@ export function useRadio(props: RadioAriaProps, state: RadioGroupState): RadioAr
       checked,
       'aria-checked': checked,
       onChange,
-      autoFocus,
       ...interactions
     }
   };

--- a/packages/@react-aria/switch/src/useSwitch.ts
+++ b/packages/@react-aria/switch/src/useSwitch.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {InputHTMLAttributes} from 'react';
+import {InputHTMLAttributes, RefObject} from 'react';
 import {SwitchProps} from '@react-types/switch';
 import {ToggleState} from '@react-stately/toggle';
 import {useToggle} from '@react-aria/toggle';
@@ -19,8 +19,8 @@ export interface SwitchAria {
   inputProps: InputHTMLAttributes<HTMLInputElement>
 }
 
-export function useSwitch(props: SwitchProps, state: ToggleState): SwitchAria {
-  let {inputProps} = useToggle(props, state);
+export function useSwitch(props: SwitchProps, state: ToggleState, ref: RefObject<HTMLElement>): SwitchAria {
+  let {inputProps} = useToggle(props, state, ref);
   let {isSelected} = state;
 
   return {

--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {ChangeEvent, InputHTMLAttributes, LabelHTMLAttributes} from 'react';
+import {ChangeEvent, InputHTMLAttributes, LabelHTMLAttributes, RefObject} from 'react';
 import {TextFieldProps} from '@react-types/textfield';
 import {TextInputDOMProps} from '@react-types/shared';
 import {useFocusable} from '@react-aria/focus';
@@ -22,18 +22,18 @@ interface TextFieldAria {
 }
 
 export function useTextField(
-  props: TextFieldProps & TextInputDOMProps
+  props: TextFieldProps & TextInputDOMProps,
+  ref: RefObject<HTMLElement>
 ): TextFieldAria {
   let {
     isDisabled = false,
     isRequired = false,
     isReadOnly = false,
-    autoFocus = false,
     validationState,
     type = 'text',
     onChange = () => {}
   } = props;
-  let {focusableProps} = useFocusable(props);
+  let {focusableProps} = useFocusable(props, ref);
   let {labelProps, fieldProps} = useLabel(props);
 
   return {
@@ -45,7 +45,6 @@ export function useTextField(
       'aria-required': isRequired || undefined,
       'aria-invalid': validationState === 'invalid' || undefined,
       onChange: (e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
-      autoFocus,
       ...focusableProps,
       ...fieldProps
     }

--- a/packages/@react-aria/textfield/test/useTextField.test.js
+++ b/packages/@react-aria/textfield/test/useTextField.test.js
@@ -72,14 +72,6 @@ describe('useTextField hook', () => {
       expect(props['aria-invalid']).toBeUndefined();
     });
 
-    it('with appropriate props if autoFocus is defined', () => {
-      let props = renderTextFieldHook({autoFocus: true, 'aria-label': 'mandatory label'});
-      expect(props.autoFocus).toBeTruthy();
-
-      props = renderTextFieldHook({autoFocus: false, 'aria-label': 'mandatory label'});
-      expect(props.autoFocus).toBeFalsy();
-    });
-
     it('with an onChange that calls user specified onChange with appropriate values', () => {
       let onChange = jest.fn();
       let props = renderTextFieldHook({onChange, 'aria-label': 'mandatory label'});

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -11,7 +11,7 @@
  */
 
 import {DOMProps} from '@react-types/shared';
-import {InputHTMLAttributes} from 'react';
+import {InputHTMLAttributes, RefObject} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {SwitchProps} from '@react-types/switch';
 import {ToggleState} from '@react-stately/toggle';
@@ -22,9 +22,8 @@ export interface ToggleAria {
   inputProps: InputHTMLAttributes<HTMLInputElement>
 }
 
-export function useToggle(props: SwitchProps & DOMProps, state: ToggleState): ToggleAria {
+export function useToggle(props: SwitchProps & DOMProps, state: ToggleState, ref: RefObject<HTMLElement>): ToggleAria {
   let {
-    autoFocus = false,
     isDisabled = false,
     isRequired,
     isReadOnly,
@@ -54,7 +53,7 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState): To
     isDisabled
   });
 
-  let {focusableProps} = useFocusable(props);
+  let {focusableProps} = useFocusable(props, ref);
   let interactions = mergeProps(pressProps, focusableProps);
 
   return {
@@ -68,7 +67,6 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState): To
       value,
       name,
       type: 'checkbox',
-      autoFocus,
       ...interactions
     }
   };

--- a/packages/@react-spectrum/radio/src/Radio.tsx
+++ b/packages/@react-spectrum/radio/src/Radio.tsx
@@ -32,6 +32,9 @@ function Radio(props: SpectrumRadioProps, ref: FocusableRef<HTMLLabelElement>) {
   } = props;
   let {styleProps} = useStyleProps(otherProps);
 
+  let inputRef = useRef<HTMLInputElement>(null);
+  let domRef = useFocusableRef(ref, inputRef);
+
   let radioGroupProps = useRadioProvider();
   let {
     isEmphasized,
@@ -44,10 +47,7 @@ function Radio(props: SpectrumRadioProps, ref: FocusableRef<HTMLLabelElement>) {
     ...props,
     ...radioGroupProps,
     isDisabled: isDisabled || isGroupDisabled
-  }, state);
-
-  let inputRef = useRef<HTMLInputElement>(null);
-  let domRef = useFocusableRef(ref, inputRef);
+  }, state, inputRef);
 
   return (
     <label

--- a/packages/@react-spectrum/switch/src/Switch.tsx
+++ b/packages/@react-spectrum/switch/src/Switch.tsx
@@ -31,10 +31,11 @@ function Switch(props: SpectrumSwitchProps, ref: FocusableRef<HTMLLabelElement>)
   } = props;
   let {styleProps} = useStyleProps(otherProps);
 
-  let state = useToggleState(props);
-  let {inputProps} = useSwitch(props, state);
   let inputRef = useRef<HTMLInputElement>(null);
   let domRef = useFocusableRef(ref, inputRef);
+  let state = useToggleState(props);
+  let {inputProps} = useSwitch(props, state, inputRef);
+
 
   return (
     <label

--- a/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
+++ b/packages/@react-spectrum/textfield/src/TextFieldBase.tsx
@@ -75,7 +75,7 @@ function TextFieldBase(props: TextFieldBaseProps, ref: Ref<TextFieldRef>) {
   }));
 
   let {styleProps} = useStyleProps(otherProps);
-  let {labelProps, textFieldProps} = useTextField(props);
+  let {labelProps, textFieldProps} = useTextField(props, inputRef);
   let ElementType: React.ElementType = multiLine ? 'textarea' : 'input';
   let isInvalid = validationState === 'invalid';
 


### PR DESCRIPTION
## 📝 Test Instructions:

goto dialog form story, close the modal, tab to the trigger button, press enter, (opens modal), press escape, (closes) and the trigger button has focus

also tested with checkbox, switch, and radio

## 🧢 Your Team:
RSP
