### PR TITLE
Fix tray scrolling

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -35,12 +35,12 @@ governing permissions and limitations under the License.
 
 .spectrum-Menu {
   text-align: start;
-  display: inline-block;
+  display: block;
 
   box-sizing: border-box;
 
-  margin: var(--spectrum-popover-padding-y) 0;
-  padding: 0;
+  padding: var(--spectrum-popover-padding-y) 0;
+  margin: 0;
 
   list-style-type: none;
 

--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -44,7 +44,7 @@ governing permissions and limitations under the License.
 
   list-style-type: none;
 
-  overflow: auto;
+  overflow-y: auto;
   user-select: none;
 
   max-height: inherit; /* inherit from parent popover */

--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -16,7 +16,6 @@
 :root {
   /* Bug: this must be 0ms, not 0 */
   --spectrum-dialog-exit-animation-delay: 0ms;
-  --spectrum-tray-margin-top: 64px;
 }
 
 .spectrum-Tray-wrapper {
@@ -43,6 +42,9 @@
 
 .spectrum-Tray {
   @inherit: %spectrum-overlay;
+
+  /* defined here so it can be accessed from JS */
+  --spectrum-tray-margin-top: 64px;
 
   width: var(--spectrum-tray-width);
   max-width: var(--spectrum-tray-max-width);

--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -61,7 +61,6 @@
 
   /* Exit animations */
   transition: opacity var(--spectrum-dialog-exit-animation-duration) cubic-bezier(0.5, 0, 1, 1) var(--spectrum-dialog-exit-animation-delay),
-    visibility 0ms linear calc(var(--spectrum-dialog-exit-animation-delay) + var(--spectrum-dialog-exit-animation-duration)),
     transform var(--spectrum-dialog-exit-animation-duration) cubic-bezier(0.5, 0, 1, 1) var(--spectrum-dialog-exit-animation-delay);
 
   &.is-open {

--- a/packages/@react-aria/collections/src/CollectionView.tsx
+++ b/packages/@react-aria/collections/src/CollectionView.tsx
@@ -29,11 +29,12 @@ interface CollectionViewProps<T extends object, V> extends HTMLAttributes<HTMLEl
   layout: Layout<T>,
   collection: Collection<T>,
   focusedKey?: Key,
-  sizeToFit?: 'width' | 'height'
+  sizeToFit?: 'width' | 'height',
+  scrollDirection?: 'horizontal' | 'vertical' | 'both'
 }
 
 function CollectionView<T extends object, V>(props: CollectionViewProps<T, V>, ref: RefObject<HTMLDivElement>) {
-  let {children: renderView, renderWrapper, layout, collection, focusedKey, sizeToFit, ...otherProps} = props;
+  let {children: renderView, renderWrapper, layout, collection, focusedKey, sizeToFit, scrollDirection, ...otherProps} = props;
   let {
     visibleViews,
     visibleRect,
@@ -101,7 +102,8 @@ function CollectionView<T extends object, V>(props: CollectionViewProps<T, V>, r
       onVisibleRectChange={setVisibleRect}
       onScrollStart={startScrolling}
       onScrollEnd={endScrolling}
-      sizeToFit={sizeToFit}>
+      sizeToFit={sizeToFit}
+      scrollDirection={scrollDirection}>
       {visibleViews}
     </ScrollView>
   );

--- a/packages/@react-aria/collections/src/ScrollView.tsx
+++ b/packages/@react-aria/collections/src/ScrollView.tsx
@@ -22,7 +22,8 @@ interface ScrollViewProps extends HTMLAttributes<HTMLElement> {
   innerStyle: CSSProperties,
   sizeToFit: 'width' | 'height',
   onScrollStart?: () => void,
-  onScrollEnd?: () => void
+  onScrollEnd?: () => void,
+  scrollDirection?: 'horizontal' | 'vertical' | 'both'
 }
 
 function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
@@ -35,6 +36,7 @@ function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
     sizeToFit,
     onScrollStart,
     onScrollEnd,
+    scrollDirection = 'both',
     ...otherProps
   } = props;
 
@@ -150,8 +152,25 @@ function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
     }
   }, [ref, state.scrollLeft, state.scrollTop, visibleRect.x, visibleRect.y]);
 
+  let style: React.CSSProperties = {
+    ...otherProps.style,
+    position: 'relative',
+    // Reset padding so that relative positioning works correctly. Padding will be done in JS layout.
+    padding: 0
+  };
+
+  if (scrollDirection === 'horizontal') {
+    style.overflowX = 'auto';
+    style.overflowY = 'hidden';
+  } else if (scrollDirection === 'vertical') {
+    style.overflowY = 'auto';
+    style.overflowX = 'hidden';
+  } else {
+    style.overflow = 'auto';
+  }
+
   return (
-    <div {...otherProps} style={{position: 'relative', overflow: 'auto', ...otherProps.style}} ref={ref} onScroll={onScroll}>
+    <div {...otherProps} style={style} ref={ref} onScroll={onScroll}>
       <div role="presentation" style={{width: contentSize.width, height: contentSize.height, pointerEvents: isScrolling ? 'none' : 'auto', ...innerStyle}}>
         {children}
       </div>

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -377,6 +377,7 @@ export function usePress(props: PressHookProps): PressResult {
         }
 
         state.isPressed = true;
+        state.isOverTarget = true;
         state.target = e.currentTarget;
 
         if (!isDisabled) {
@@ -391,6 +392,7 @@ export function usePress(props: PressHookProps): PressResult {
       pressProps.onMouseEnter = (e) => {
         e.stopPropagation();
         if (state.isPressed && !state.ignoreEmulatedMouseEvents) {
+          state.isOverTarget = true;
           triggerPressStart(e, 'mouse');
         }
       };
@@ -398,6 +400,7 @@ export function usePress(props: PressHookProps): PressResult {
       pressProps.onMouseLeave = (e) => {
         e.stopPropagation();
         if (state.isPressed && !state.ignoreEmulatedMouseEvents) {
+          state.isOverTarget = false;
           triggerPressEnd(e, 'mouse', false);
         }
       };
@@ -417,12 +420,18 @@ export function usePress(props: PressHookProps): PressResult {
         state.isPressed = false;
         document.removeEventListener('mouseup', onMouseUp, false);
 
-        if (state.ignoreEmulatedMouseEvents || !state.target || !state.target.contains(e.target as HTMLElement)) {
+        if (state.ignoreEmulatedMouseEvents) {
           state.ignoreEmulatedMouseEvents = false;
           return;
         }
 
-        triggerPressEnd(createEvent(state.target, e), 'mouse');
+        if (isOverTarget(e, state.target)) {
+          triggerPressEnd(createEvent(state.target, e), 'mouse');
+        } else if (state.isOverTarget) {
+          triggerPressEnd(createEvent(state.target, e), 'mouse', false);
+        }
+
+        state.isOverTarget = false;
       };
 
       pressProps.onTouchStart = (e) => {

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -616,8 +616,8 @@ interface EventPoint {
 
 function isOverTarget(point: EventPoint, target: HTMLElement) {
   let rect = target.getBoundingClientRect();
-  return point.clientX >= rect.left && 
-    point.clientX <= rect.right && 
-    point.clientY >= rect.top && 
-    point.clientY <= rect.bottom;
+  return (point.clientX || 0) >= (rect.left || 0) && 
+    (point.clientX || 0) <= (rect.right || 0) && 
+    (point.clientY || 0) >= (rect.top || 0) && 
+    (point.clientY || 0) <= (rect.bottom || 0);
 }

--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -428,7 +428,7 @@ describe('usePress', function () {
       let el = res.getByText('test');
       fireEvent.mouseDown(el);
       fireEvent.mouseLeave(el);
-      fireEvent.mouseUp(document.body);
+      fireEvent.mouseUp(document.body, {clientX: 100, clientY: 100});
       fireEvent.mouseEnter(el);
 
       expect(events).toEqual([

--- a/packages/@react-aria/overlays/src/usePreventScroll.ts
+++ b/packages/@react-aria/overlays/src/usePreventScroll.ts
@@ -16,9 +16,12 @@ export function usePreventScroll() {
   // Add overflow: hidden to the body on mount, and restore on unmount.
   useEffect(() => {
     let overflow = document.body.style.overflow;
+    let paddingRight = document.body.style.paddingRight;
+    document.body.style.paddingRight = window.innerWidth - document.documentElement.clientWidth + 'px';
     document.body.style.overflow = 'hidden';
     return () => {
       document.body.style.overflow = overflow;
+      document.body.style.paddingRight = paddingRight;
     };
   }, []);
 }

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -98,6 +98,7 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
       ref={ref}
       focusedKey={state.selectionManager.focusedKey}
       sizeToFit="height"
+      scrollDirection="vertical"
       className={
         classNames(
           styles,

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -45,6 +45,7 @@ export function useListBoxLayout<T>(state: ListState<T>) {
     new ListLayout({
       estimatedRowHeight: scale === 'large' ? 48 : 35,
       estimatedHeadingHeight: scale === 'large' ? 37 : 30,
+      padding: scale === 'large' ? 5 : 4, // TODO: get from DNA
       collator
     })
   , [collator, scale]);

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -78,7 +78,7 @@ export function MenuTrigger(props: SpectrumMenuTriggerProps) {
   let overlay;
   if (isMobile) {
     overlay = (
-      <Tray isOpen={state.isOpen} onClose={state.close}>
+      <Tray isOpen={state.isOpen} onClose={state.close} shouldCloseOnBlur>
         {contents}
       </Tray>
     );

--- a/packages/@react-spectrum/overlays/src/Tray.tsx
+++ b/packages/@react-spectrum/overlays/src/Tray.tsx
@@ -24,11 +24,12 @@ import {useModal, useOverlay, usePreventScroll} from '@react-aria/overlays';
 interface TrayWrapperProps extends HTMLAttributes<HTMLElement> {
   children: ReactNode,
   isOpen?: boolean,
-  onClose?: () => void
+  onClose?: () => void,
+  shouldCloseOnBlur?: boolean
 }
 
 function Tray(props: TrayProps, ref: DOMRef<HTMLDivElement>) {
-  let {children, onClose, ...otherProps} = props;
+  let {children, onClose, shouldCloseOnBlur, ...otherProps} = props;
   let domRef = useDOMRef(ref);
   let {styleProps} = useStyleProps(props);
 
@@ -39,6 +40,7 @@ function Tray(props: TrayProps, ref: DOMRef<HTMLDivElement>) {
         {...filterDOMProps(otherProps)}
         {...styleProps}
         onClose={onClose}
+        shouldCloseOnBlur={shouldCloseOnBlur}
         ref={domRef}>
         {children}
       </TrayWrapper>
@@ -50,10 +52,11 @@ let TrayWrapper = forwardRef(function (props: TrayWrapperProps, ref: RefObject<H
   let {
     children,
     onClose,
+    shouldCloseOnBlur,
     isOpen,
     ...otherProps
   } = props;
-  let {overlayProps} = useOverlay({ref, onClose, isOpen, isDismissable: true});
+  let {overlayProps} = useOverlay({ref, onClose, shouldCloseOnBlur, isOpen, isDismissable: true});
   usePreventScroll();
   useModal();
 

--- a/packages/@react-spectrum/overlays/test/Tray.test.js
+++ b/packages/@react-spectrum/overlays/test/Tray.test.js
@@ -11,6 +11,7 @@
  */
 
 import {cleanup, fireEvent, render, waitForDomChange} from '@testing-library/react';
+import {Dialog} from '@react-spectrum/dialog';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
 import scaleMedium from '@adobe/spectrum-css-temp/vars/spectrum-medium-unique.css';
@@ -81,6 +82,25 @@ describe('Tray', function () {
     await waitForDomChange(); // wait for animation
     fireEvent.mouseDown(document.body);
     fireEvent.mouseUp(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the tray on blur when shouldCloseOnBlur is true', async function () {
+    let onClose = jest.fn();
+    let {getByRole} = render(
+      <Provider theme={theme}>
+        <Tray isOpen onClose={onClose} shouldCloseOnBlur>
+          <Dialog>contents</Dialog>
+        </Tray>
+      </Provider>
+    );
+
+    await waitForDomChange(); // wait for animation
+
+    let dialog = getByRole('dialog');
+    expect(document.activeElement).toBe(dialog);
+
+    dialog.blur();
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -116,7 +116,7 @@ function Picker<T>(props: SpectrumPickerProps<T>, ref: DOMRef<HTMLDivElement>) {
   let overlay;
   if (isMobile) {
     overlay = (
-      <Tray isOpen={state.isOpen} onClose={state.close}>
+      <Tray isOpen={state.isOpen} onClose={state.close} shouldCloseOnBlur>
         {listbox}
       </Tray>
     );

--- a/packages/@react-stately/collections/src/ListLayout.ts
+++ b/packages/@react-stately/collections/src/ListLayout.ts
@@ -26,6 +26,7 @@ type ListLayoutOptions<T> = {
   estimatedRowHeight?: number,
   headingHeight?: number,
   estimatedHeadingHeight?: number,
+  padding?: number,
   indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number,
   collator?: Intl.Collator
 };
@@ -54,6 +55,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   private estimatedRowHeight: number;
   private headingHeight: number;
   private estimatedHeadingHeight: number;
+  private padding: number;
   private indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number;
   private layoutInfos: {[key: string]: LayoutInfo};
   private contentHeight: number;
@@ -73,6 +75,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
     this.estimatedRowHeight = options.estimatedRowHeight;
     this.headingHeight = options.headingHeight;
     this.estimatedHeadingHeight = options.estimatedHeadingHeight;
+    this.padding = options.padding || 0;
     this.indentationForItem = options.indentationForItem;
     this.collator = options.collator;
     this.layoutInfos = {};
@@ -188,8 +191,8 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
       return [y - startY, layoutNodes];
     };
 
-    let [height, nodes] = build(this.collection);
-    this.contentHeight = height;
+    let [height, nodes] = build(this.collection, this.padding);
+    this.contentHeight = height + this.padding * 2;
     this.rootNodes = nodes;
 
     this.lastWidth = width;

--- a/packages/@react-types/overlays/src/index.d.ts
+++ b/packages/@react-types/overlays/src/index.d.ts
@@ -65,5 +65,6 @@ export interface PopoverProps extends DOMProps, StyleProps, OverlayProps {
 export interface TrayProps extends DOMProps, StyleProps, OverlayProps {
   children: ReactElement,
   isOpen?: boolean,
-  onClose?: () => void
+  onClose?: () => void,
+  shouldCloseOnBlur?: boolean
 }


### PR DESCRIPTION
We need to calculate the max-height for Tray in JS rather than relying on percentages or viewport units in CSS. When only percentages are used, there is nothing for the browser to base them off of. Viewport units are out of the question due to them changing on scroll on mobile when the addressbar/toolbar hide.

This also fixes menus to use padding instead of margin for the top and bottom of their content. This ensures that the entire tray/popover is scrollable and the padding is only at the top and bottom of all of the list items rather than outside the scrollable region. For ListBox we also have to do this in JS due to absolute positioning.

Finally, I found that Chrome on Windows sometimes displays unwanted horizontal scrollbars due to rounding errors in `clientWidth`. The real width could have subpixel precision, but `clientWidth` only reports integers. This caused the inner div inside CollectionView to be 1px bigger than the outer width, when vertical scrollbars were present, causing horizontal scrollbars to appear. Now there's a `scrollDirection` prop that only sets `overflow` in the direction we want to scroll to prevent this from happening.