### PR TITLE
Breadcrumbs bug fixes

### DIFF
--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -22,8 +22,14 @@ import styles from '@adobe/spectrum-css-temp/components/breadcrumb/vars.css';
 import {useBreadcrumbs} from '@react-aria/breadcrumbs';
 import {useProviderProps} from '@react-spectrum/provider';
 
-const MIN_VISIBLE_ITEMS = 2;
-const MAX_VISIBLE_ITEMS = 4;
+// This value doesn't include the "menu", or the root if showRoot = true. The reason we ignore the menu and root is
+// because we always want to make sure we show the current breadcrumb.
+const MIN_VISIBLE_ITEMS = 1;
+
+// When dealing with the maximum number of items, we consider the root an item if showRoot = true (which is different
+// to the minimum). This means you'll see the root, the menu, and 4 other items when showRoot = true. When the root is
+// not showing, you'll see the menu and 5 other items.
+const MAX_VISIBLE_ITEMS = 5;
 
 function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
   props = useProviderProps(props);
@@ -45,46 +51,71 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
   let domRef = useDOMRef(ref);
   let listRef = useRef(null);
 
-  const [visibleItems, setVisibleItems] = useState(isCollapsible ? childArray.length : maxVisibleItems);
+  let defaultVisibleItems: number;
+
+  if (isCollapsible) {
+    defaultVisibleItems = childArray.length;
+  } else {
+    defaultVisibleItems = showRoot ? maxVisibleItems as number - 1 : maxVisibleItems as number;
+  }
+
+  const [visibleItems, setVisibleItems] = useState(defaultVisibleItems);
 
   let {breadcrumbsProps} = useBreadcrumbs(props);
   let {styleProps} = useStyleProps(otherProps);
 
   useEffect(() => {
-    let listItems = [...listRef.current.children];
-    let childrenWidthTotals = listItems.reduce((acc, item, index) => (
-      [...acc, acc[index] + item.getBoundingClientRect().width]
-    ), [0]);
+    // Only run the resize logic if the menu is collapsible to avoid the risk of performance problems.
+    if (isCollapsible && listRef.current) {
+      let listItems = [...listRef.current.children];
+      // Ignore the last item when the size is large because it wraps onto a new line and doesn't take up horizontal space.
+      let listItemsToMeasure = size === 'L' ? listItems.slice(0, listItems.length - 1) : listItems;
+      let childrenWidths = listItemsToMeasure.map((item) => item.getBoundingClientRect().width);
 
-    let onResize = () => {
-      if (isCollapsible && listRef.current) {
+      let onResize = () => {
         let containerWidth = listRef.current.getBoundingClientRect().width;
-        let index = childrenWidthTotals.findIndex(totalWidth => totalWidth > containerWidth);
+        let [rootBreadcrumbWidth, ...otherBreadcrumbWidths] = childrenWidths;
+        let calculatedWidth = 0;
 
-        let visibleItemsCount;
-        let minVisibleItems = showRoot ? MIN_VISIBLE_ITEMS + 1 : MIN_VISIBLE_ITEMS;
-
-        if (index ===  -1) {
-          visibleItemsCount = childArray.length;
-        } else if (index < minVisibleItems) {
-          visibleItemsCount = minVisibleItems;
-        } else {
-          visibleItemsCount = index;
+        // Make sure we account for the root breadcrumb if it's enabled.
+        if (showRoot) {
+          calculatedWidth += rootBreadcrumbWidth;
         }
 
-        setVisibleItems(visibleItemsCount);
-      }
-    };
+        let otherVisibleItemsCount = 0;
 
-    window.addEventListener('resize', onResize);
-    onResize();
-    return () => {
-      window.removeEventListener('resize', onResize);
-    };
-  }, [isCollapsible, childArray.length, listRef, showRoot]);
+        // See how many other breadcrumbs we can fit (starting from the right).
+        otherBreadcrumbWidths.reverse().forEach(breadcrumbWidth => {
+          calculatedWidth += breadcrumbWidth;
+          if (calculatedWidth < containerWidth) {
+            otherVisibleItemsCount++;
+          }
+        });
+
+        let minVisibleItems = showRoot ? MIN_VISIBLE_ITEMS + 1 : MIN_VISIBLE_ITEMS;
+
+        if (otherVisibleItemsCount < minVisibleItems) {
+          otherVisibleItemsCount = MIN_VISIBLE_ITEMS;
+        }
+
+        let maxVisibleOtherItems = showRoot ? MAX_VISIBLE_ITEMS - 1 : MAX_VISIBLE_ITEMS;
+
+        if (isCollapsible && otherVisibleItemsCount > maxVisibleOtherItems) {
+          otherVisibleItemsCount = maxVisibleOtherItems;
+        }
+
+        setVisibleItems(otherVisibleItemsCount);
+      };
+
+      window.addEventListener('resize', onResize);
+      onResize();
+      return () => {
+        window.removeEventListener('resize', onResize);
+      };
+    }
+  }, [isCollapsible, childArray.length, listRef, showRoot, size]);
 
   if (childArray.length > visibleItems) {
-    let rootItems = showRoot ? [childArray[0]] : [];
     let selectedItem = childArray[childArray.length - 1];
     let selectedKey = selectedItem.props.uniqueKey || selectedItem.key;
     let onMenuAction = (key: Key) => {
@@ -109,13 +140,14 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
         </MenuTrigger>
       </BreadcrumbItem>
     );
-    rootItems.push(menuItem);
 
-    let restItems = childArray.slice(-visibleItems + rootItems.length);
+    let [rootBreadcrumb, ...otherBreadcrumbs] = childArray;
+    let rootItems = showRoot ? [rootBreadcrumb, menuItem] : [menuItem];
+    let visibleBreadcrumbs = otherBreadcrumbs.slice(-visibleItems);
 
     childArray = [
       ...rootItems,
-      ...restItems
+      ...visibleBreadcrumbs
     ];
   }
 

--- a/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
+++ b/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 
 let styles = {
-  width: '50vw'
+  width: '100vw'
 };
 const CenterDecorator = storyFn => <div style={styles}><div>{storyFn()}</div></div>;
 
@@ -25,8 +25,12 @@ storiesOf('Breadcrumbs', module)
   .addDecorator(CenterDecorator)
   .addParameters({providerSwitcher: {status: 'negative'}})
   .add(
-    'Default',
-    () => render({})
+    'Default (with 3 items)',
+    () => render()
+  )
+  .add(
+    'Default (with 7 items)',
+    () => renderMany({})
   )
   .add(
     'size: S',
@@ -38,11 +42,11 @@ storiesOf('Breadcrumbs', module)
   )
   .add(
     'maxVisibleItems: 4',
-    () => renderMany({})
+    () => renderMany({maxVisibleItems: 4})
   )
   .add(
     'maxVisibleItems: 4, showRoot: true',
-    () => renderMany({showRoot: true})
+    () => renderMany({maxVisibleItems: 4, showRoot: true})
   )
   .add(
     'maxVisibleItems: auto',
@@ -53,6 +57,14 @@ storiesOf('Breadcrumbs', module)
     () => (
       <div style={{width: '100px'}}>
         {renderMany({maxVisibleItems: 'auto'})}
+      </div>
+    )
+  )
+  .add(
+    'collapsed, maxVisibleItems: auto, size: L',
+    () => (
+      <div style={{width: '100px'}}>
+        {renderMany({maxVisibleItems: 'auto', size: 'L'})}
       </div>
     )
   )
@@ -78,7 +90,7 @@ storiesOf('Breadcrumbs', module)
   )
   .add(
     'isDisabled: true, maxVisibleItems: 4',
-    () => renderMany({isDisabled: true})
+    () => renderMany({isDisabled: true, maxVisibleItems: 4})
   )
   .add(
     'isHeading: true',
@@ -92,9 +104,9 @@ storiesOf('Breadcrumbs', module)
 function render(props = {}) {
   return (
     <Breadcrumbs {...props} onAction={action('onAction')}>
-      <Item uniqueKey="Folder 1">Vestibulum bibendum odio non</Item>
-      <Item uniqueKey="Folder 2">Cras aliquet</Item>
-      <Item uniqueKey="Folder 3">Quisque ut turpis</Item>
+      <Item uniqueKey="Folder 1">The quick brown fox jumps over</Item>
+      <Item uniqueKey="Folder 2">My Documents</Item>
+      <Item uniqueKey="Folder 3">Kangaroos jump high</Item>
     </Breadcrumbs>
   );
 }
@@ -102,13 +114,13 @@ function render(props = {}) {
 function renderMany(props = {}) {
   return (
     <Breadcrumbs {...props} onAction={action('onAction')}>
-      <Item uniqueKey="Folder 1">Vestibulum bibendum odio non</Item>
-      <Item uniqueKey="Folder 2">Cras aliquet</Item>
-      <Item uniqueKey="Folder 3">Quisque ut turpis</Item>
-      <Item uniqueKey="Folder 4">Curabitur convallis</Item>
-      <Item uniqueKey="Folder 5">Curabitur quis</Item>
-      <Item uniqueKey="Folder 6">Cras fringilla</Item>
-      <Item uniqueKey="Folder 7">Etiam ut</Item>
+      <Item uniqueKey="Folder 1">The quick brown fox jumps over</Item>
+      <Item uniqueKey="Folder 2">My Documents</Item>
+      <Item uniqueKey="Folder 3">Kangaroos jump high</Item>
+      <Item uniqueKey="Folder 4">Koalas are very cute</Item>
+      <Item uniqueKey="Folder 5">Wombat's noses</Item>
+      <Item uniqueKey="Folder 6">Wattle trees</Item>
+      <Item uniqueKey="Folder 7">April 7</Item>
     </Breadcrumbs>
   );
 }

--- a/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
+++ b/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
@@ -65,6 +65,10 @@ storiesOf('Breadcrumbs', module)
     () => renderMany({maxVisibleItems: 'auto', size: 'L'})
   )
   .add(
+    'maxVisibleItems: auto, size: L, showRoot: true',
+    () => renderMany({maxVisibleItems: 'auto', size: 'L', showRoot: true})
+  )
+  .add(
     'isDisabled: true',
     () => render({isDisabled: true})
   )
@@ -88,9 +92,9 @@ storiesOf('Breadcrumbs', module)
 function render(props = {}) {
   return (
     <Breadcrumbs {...props} onAction={action('onAction')}>
-      <Item uniqueKey="Folder 1">Folder 1</Item>
-      <Item uniqueKey="Folder 2">Folder 2</Item>
-      <Item uniqueKey="Folder 3">Folder 3</Item>
+      <Item uniqueKey="Folder 1">Vestibulum bibendum odio non</Item>
+      <Item uniqueKey="Folder 2">Cras aliquet</Item>
+      <Item uniqueKey="Folder 3">Quisque ut turpis</Item>
     </Breadcrumbs>
   );
 }
@@ -98,13 +102,13 @@ function render(props = {}) {
 function renderMany(props = {}) {
   return (
     <Breadcrumbs {...props} onAction={action('onAction')}>
-      <Item uniqueKey="Folder 1">Folder 1</Item>
-      <Item uniqueKey="Folder 2">Folder 2</Item>
-      <Item uniqueKey="Folder 3">Folder 3</Item>
-      <Item uniqueKey="Folder 4">Folder 4</Item>
-      <Item uniqueKey="Folder 5">Folder 5</Item>
-      <Item uniqueKey="Folder 6">Folder 6</Item>
-      <Item uniqueKey="Folder 7">Folder 7</Item>
+      <Item uniqueKey="Folder 1">Vestibulum bibendum odio non</Item>
+      <Item uniqueKey="Folder 2">Cras aliquet</Item>
+      <Item uniqueKey="Folder 3">Quisque ut turpis</Item>
+      <Item uniqueKey="Folder 4">Curabitur convallis</Item>
+      <Item uniqueKey="Folder 5">Curabitur quis</Item>
+      <Item uniqueKey="Folder 6">Cras fringilla</Item>
+      <Item uniqueKey="Folder 7">Etiam ut</Item>
     </Breadcrumbs>
   );
 }

--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -32,9 +32,9 @@ describe('Breadcrumbs', function () {
         return {width: 100};
       }
       if (this.className === 'spectrum-Breadcrumbs') {
-        return {width: 250};
+        return {width: 350};
       }
-      return {top: 0, bottom: 0, eft: 0, right: 0};
+      return {top: 0, bottom: 0, left: 0, right: 0};
     });
 
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
@@ -139,7 +139,7 @@ describe('Breadcrumbs', function () {
     expect(within(children[0]).getByRole('button')).toBeTruthy();
     expect(() => getByText('Folder 1')).toThrow();
     expect(() => getByText('Folder 2')).toThrow();
-    expect(() => getByText('Folder 3')).toThrow();
+    expect(getByText('Folder 3')).toBeTruthy();
     expect(getByText('Folder 4')).toBeTruthy();
     expect(getByText('Folder 5')).toBeTruthy();
   });
@@ -161,7 +161,7 @@ describe('Breadcrumbs', function () {
     expect(within(children[1]).getByRole('button')).toBeTruthy();
     expect(() => getByText('Folder 2')).toThrow();
     expect(() => getByText('Folder 3')).toThrow();
-    expect(() => getByText('Folder 4')).toThrow();
+    expect(getByText('Folder 4')).toBeTruthy();
     expect(getByText('Folder 5')).toBeTruthy();
   });
 
@@ -197,7 +197,7 @@ describe('Breadcrumbs', function () {
     expect(within(children[0]).getByRole('button')).toBeTruthy();
     expect(() => getByText('Folder 1')).toThrow();
     expect(() => getByText('Folder 2')).toThrow();
-    expect(() => getByText('Folder 3')).toThrow();
+    expect(getByText('Folder 3')).toBeTruthy();
     expect(getByText('Folder 4')).toBeTruthy();
     expect(getByText('Folder 5')).toBeTruthy();
   });
@@ -218,6 +218,32 @@ describe('Breadcrumbs', function () {
     let {children} = getByRole('list');
     expect(getByText('Folder 1')).toBeTruthy();
     expect(within(children[1]).getByRole('button')).toBeTruthy();
+    expect(() => getByText('Folder 2')).toThrow();
+    expect(() => getByText('Folder 3')).toThrow();
+    expect(getByText('Folder 4')).toBeTruthy();
+    expect(getByText('Folder 5')).toBeTruthy();
+  });
+
+  it('Handles max visible items auto with showRoot and folders of different widths', () => {
+    // Change the width of "Folder 1" from 100px to 200px, which means there's only room for 1 other breadcrumb.
+    HTMLElement.prototype.getBoundingClientRect.mockReturnValueOnce({width: 200});
+
+    let {getByText, getByRole} = render(
+      <Provider theme={theme}>
+        <Breadcrumbs maxVisibleItems="auto" showRoot>
+          <Item>Folder 1</Item>
+          <Item>Folder 2</Item>
+          <Item>Folder 3</Item>
+          <Item>Folder 4</Item>
+          <Item>Folder 5</Item>
+        </Breadcrumbs>
+      </Provider>
+    );
+
+    let {children} = getByRole('list');
+    expect(within(children[1]).getByRole('button')).toBeTruthy();
+    expect(getByText('Folder 1')).toBeTruthy();
+    // expect(() => getByText('Folder 1')).toThrow();
     expect(() => getByText('Folder 2')).toThrow();
     expect(() => getByText('Folder 3')).toThrow();
     expect(() => getByText('Folder 4')).toThrow();


### PR DESCRIPTION
Functional changes:
* The maximum number of breadcrumbs has been changed from 4 to 5.
* The root breadcrumb will count towards the 5 breadcrumb limit when showRoot is true.

Bug fixes:
* The sizing logic for collapsing breadcrumbs now takes into account the root breadcrumb (when showRoot is true).
* The sizing logic now ignores the last breadcrumb when the size is large (because the last breadcrumb will wrap onto a new line).