### PR TITLE
Creating a hook for window resize and overflow detection

### DIFF
--- a/packages/@react-spectrum/buttongroup/src/useHasOverflow.ts
+++ b/packages/@react-spectrum/buttongroup/src/useHasOverflow.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {useEffect, useState} from 'react';
+import {useProvider} from '@react-spectrum/provider';
+import {useWindowWidth} from '@react-spectrum/utils';
+
+interface UseHasOverflowOptions {
+  skip: boolean
+}
+
+export function useHasOverflow(containerRef, options?: UseHasOverflowOptions) {
+  let {scale} = useProvider();
+  let windowWidth = useWindowWidth({debounce: 150});
+  let [hasOverflow, setHasOverflow] = useState(false);
+  let [totalChildWidth, setTotalChildWidth] = useState(0);
+
+  // Only recalculate the size of the children if the scale changes.
+  useEffect(() => {
+    if (!options.skip && containerRef.current) {
+      let children = Array.from(containerRef.current.children) as HTMLElement[];
+      let widthOfAllChildren = children.reduce((aggregateWidth, child) => {
+        let style = getComputedStyle(child);
+        let outerWidth = child.getBoundingClientRect().width + parseInt(style.marginLeft, 10) + parseInt(style.marginRight, 10);
+        return aggregateWidth + outerWidth;
+      }, 0);
+      setTotalChildWidth(widthOfAllChildren);
+    }
+  }, [containerRef, scale, options.skip]);
+
+  // Check for overflow when the window width or the scale changes.
+  useEffect(() => {
+    if (!options.skip && containerRef.current) {
+      const parentWidth = containerRef.current.parentElement.getBoundingClientRect().width;
+      setHasOverflow(totalChildWidth > parentWidth);
+    }
+  }, [containerRef, totalChildWidth, options.skip, windowWidth, scale]);
+
+  return hasOverflow;
+}

--- a/packages/@react-spectrum/utils/package.json
+++ b/packages/@react-spectrum/utils/package.json
@@ -20,7 +20,8 @@
     "@react-aria/i18n": "^3.0.0-rc.1",
     "@react-aria/utils": "^3.0.0-rc.1",
     "@react-types/shared": "^3.0.0-rc.1",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-spectrum/utils/src/index.ts
+++ b/packages/@react-spectrum/utils/src/index.ts
@@ -18,3 +18,4 @@ export * from './useDOMRef';
 export * from './styleProps';
 export * from './Slots';
 export * from './useHasChild';
+export * from './useWindowWidth';

--- a/packages/@react-spectrum/utils/src/useWindowWidth.ts
+++ b/packages/@react-spectrum/utils/src/useWindowWidth.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import debounce from 'lodash.debounce';
+import {useEffect, useState} from 'react';
+
+interface UseWindowWidthOptions {
+  debounce?: number;
+}
+
+export function useWindowWidth(options?: UseWindowWidthOptions) {
+  let [width, setWidth] = useState(window.innerWidth);
+
+  const resizeStateChange = () => {
+    setWidth(window.innerWidth);
+  };
+
+  useEffect(() => {
+    let onResize = options && options.debounce ? debounce(resizeStateChange, options.debounce) : resizeStateChange;
+    window.addEventListener('resize', onResize);
+    return () => {
+      if (options && options.debounce) {
+        onResize.cancel();
+      }
+      window.removeEventListener('resize', onResize);
+    };
+  });
+
+  return width;
+}


### PR DESCRIPTION
**Noteworthy:**
* Makes a lot of the ButtonGroup logic generic and reduces the component complexity significantly.
* Gives a centralized place to improve a future performance issue (when there are many different components on a page adding event listeners for resize events).
* Improves the performance on the ButtonGroup component by debouncing the switch between horizontal and vertical on resize.

**Could be improved:**
* Might be a way to get Breadcrumbs to use useHasOverflow. Not sure if this is worth it though.
* ScrollView, useOverlayPosition and useSplitView are still adding their own event listener. These could be removed if we add a useWindowHeight hook as well (or just make the hook useWindowSize).
* Could add a throttle option for useWindowWidth, but I'm not sure this is necessary after seeing how well the debounce experience works.

**Questions:**
* How do you feel about introducing a dependency on "lodash.debounce"? I used the same version that was already in the yarn.lock.