### PR TITLE
(WIP) (RSP-1640) Fix FocusScope so display:none elements aren't included as focusable elements

### DIFF
--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -147,7 +147,7 @@ function getFocusableElementsInScope(scope: HTMLElement[], opts: FocusManagerOpt
     }
     res.push(...Array.from(node.querySelectorAll(selector)));
   }
-
+  // Filter out elements that have display: none or whose parents have display: none. https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent
   return res.filter(node => node.offsetParent !== null);
 }
 

--- a/packages/@react-aria/focus/src/FocusScope.tsx
+++ b/packages/@react-aria/focus/src/FocusScope.tsx
@@ -147,7 +147,8 @@ function getFocusableElementsInScope(scope: HTMLElement[], opts: FocusManagerOpt
     }
     res.push(...Array.from(node.querySelectorAll(selector)));
   }
-  return res;
+
+  return res.filter(node => node.offsetParent !== null);
 }
 
 function useFocusContainment(scopeRef: RefObject<HTMLElement[]>, contain: boolean) {

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -19,14 +19,14 @@ describe('FocusScope', function () {
   let offsetParent;
   afterEach(cleanup);
 
-  beforeEach(() => {
-    offsetParent = jest.spyOn(window.HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(() => this.parentNode);
+  beforeAll(() => {
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+    offsetParent = jest.spyOn(window.HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(() => this.parentNode);
   });
   
-  afterEach(() => {
-    offsetParent.mockReset();
+  afterAll(() => {
     window.requestAnimationFrame.mockRestore();
+    offsetParent.mockReset();
   });
 
   describe('focus containment', function () {

--- a/packages/@react-aria/focus/test/FocusScope.test.js
+++ b/packages/@react-aria/focus/test/FocusScope.test.js
@@ -16,13 +16,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 describe('FocusScope', function () {
+  let offsetParent;
   afterEach(cleanup);
 
   beforeEach(() => {
+    offsetParent = jest.spyOn(window.HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(() => this.parentNode);
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
   });
   
   afterEach(() => {
+    offsetParent.mockReset();
     window.requestAnimationFrame.mockRestore();
   });
 

--- a/packages/@react-spectrum/datepicker/test/DatePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePicker.test.js
@@ -24,7 +24,16 @@ let theme = {
 };
 
 describe('DatePicker', function () {
+  let offsetParent;
   afterEach(cleanup);
+
+  beforeAll(() => {
+    offsetParent = jest.spyOn(window.HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(() => this.parentNode);
+  });
+  
+  afterAll(() => {
+    offsetParent.mockReset();
+  });
 
   describe('basics', function () {
     it('should render a datepicker with a specified date', function () {

--- a/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
+++ b/packages/@react-spectrum/datepicker/test/DatePickerBase.test.js
@@ -24,7 +24,16 @@ let theme = {
 };
 
 describe('DatePickerBase', function () {
+  let offsetParent;
   afterEach(cleanup);
+
+  beforeAll(() => {
+    offsetParent = jest.spyOn(window.HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(() => this.parentNode);
+  });
+  
+  afterAll(() => {
+    offsetParent.mockReset();
+  });
 
   describe('basics', function () {
     it.each`

--- a/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
+++ b/packages/@react-spectrum/datepicker/test/DateRangePicker.test.js
@@ -24,7 +24,16 @@ let theme = {
 };
 
 describe('DateRangePicker', function () {
+  let offsetParent;
   afterEach(cleanup);
+
+  beforeAll(() => {
+    offsetParent = jest.spyOn(window.HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(() => this.parentNode);
+  });
+  
+  afterAll(() => {
+    offsetParent.mockReset();
+  });
 
   describe('basics', function () {
     it('should render a DateRangePicker with a specified date range', function () {

--- a/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
+++ b/packages/@react-spectrum/dialog/stories/Dialog.stories.tsx
@@ -243,11 +243,10 @@ function render({width = 'auto', isDismissable = undefined, ...props}) {
             <Header><StatusLight variant="positive">Life is good</StatusLight></Header>
             <Divider />
             <Content>{singleParagraph()}</Content>
-            {!isDismissable &&
-              <ButtonGroup>
-                <Button variant="secondary" onPress={close}>Cancel</Button>
-                <Button variant="cta" onPress={close}>Confirm</Button>
-              </ButtonGroup>}
+            <ButtonGroup>
+              <Button variant="secondary" onPress={close}>Cancel</Button>
+              <Button variant="cta" onPress={close}>Confirm</Button>
+            </ButtonGroup>
           </Dialog>
         )}
       </DialogTrigger>
@@ -267,11 +266,10 @@ function renderHero({width = 'auto', isDismissable = undefined, ...props}) {
             <Header><StatusLight variant="positive">Life is good</StatusLight></Header>
             <Divider />
             <Content>{singleParagraph()}</Content>
-            {!isDismissable &&
-              <ButtonGroup>
-                <Button variant="secondary" onPress={close}>Cancel</Button>
-                <Button variant="cta" onPress={close} autoFocus>Confirm</Button>
-              </ButtonGroup>}
+            <ButtonGroup>
+              <Button variant="secondary" onPress={close}>Cancel</Button>
+              <Button variant="cta" onPress={close} autoFocus>Confirm</Button>
+            </ButtonGroup>
           </Dialog>
           )}
       </DialogTrigger>
@@ -291,11 +289,10 @@ function renderFooter({width = 'auto', isDismissable = undefined, ...props}) {
             <Divider />
             <Content>{singleParagraph()}</Content>
             <Footer><Checkbox>I accept</Checkbox></Footer>
-            {!isDismissable &&
             <ButtonGroup>
               <Button variant="secondary" onPress={close}>Cancel</Button>
               <Button variant="cta" onPress={close}>Confirm</Button>
-            </ButtonGroup>}
+            </ButtonGroup>
           </Dialog>
         )}
       </DialogTrigger>

--- a/packages/@react-spectrum/overlays/test/Popover.test.js
+++ b/packages/@react-spectrum/overlays/test/Popover.test.js
@@ -27,14 +27,17 @@ function PopoverWithDialog({children}) {
 }
 
 describe('Popover', function () {
+  let offsetParent;
   afterEach(cleanup);
 
-  beforeEach(() => {
+  beforeAll(() => {
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+    offsetParent = jest.spyOn(window.HTMLElement.prototype, 'offsetParent', 'get').mockImplementation(() => this.parentNode);
   });
-
-  afterEach(() => {
+  
+  afterAll(() => {
     window.requestAnimationFrame.mockRestore();
+    offsetParent.mockReset();
   });
 
   describe('parity', function () {


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1640

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to the Dialog stories that have isDismissable = true. Attempt to tab to the dismiss button (you should be able to)

