### PR TITLE
RSP-1678: Fix Popover position in Edge

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/overlay/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/overlay/index.css
@@ -37,6 +37,12 @@ governing permissions and limitations under the License.
 }
 
 %spectrum-overlay--top--open {
+  /*
+  Edge does not support combination of translate, calc and var.
+  New var equal to negative calculation result is added instead.
+  TODO: for Chromium Edge return to
+  transform: translateX(calc(var(--spectrum-global-dimension-size-75) * -1));
+  */
   transform: translateY(var(--spectrum-overlay-negative-transform-distance));
 }
 

--- a/packages/@adobe/spectrum-css-temp/components/overlay/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/overlay/index.css
@@ -10,10 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-:root {
-  --spectrum-overlay-animation-distance: var(--spectrum-dropdown-flyout-menu-offset-y);
-}
-
 %spectrum-overlay {
   visibility: hidden;
 
@@ -37,17 +33,17 @@ governing permissions and limitations under the License.
 }
 
 %spectrum-overlay--bottom--open {
-  transform: translateY(var(--spectrum-overlay-animation-distance));
+  transform: translateY(var(--spectrum-overlay-positive-transform-distance));
 }
 
 %spectrum-overlay--top--open {
-  transform: translateY(calc(var(--spectrum-overlay-animation-distance) * -1));
+  transform: translateY(var(--spectrum-overlay-negative-transform-distance));
 }
 
 %spectrum-overlay--right--open {
-  transform: translateX(var(--spectrum-overlay-animation-distance));
+  transform: translateX(var(--spectrum-overlay-positive-transform-distance));
 }
 
 %spectrum-overlay--left--open {
-  transform: translateX(calc(var(--spectrum-overlay-animation-distance) * -1));
+  transform: translateX(var(--spectrum-overlay-negative-transform-distance));
 }

--- a/packages/@adobe/spectrum-css-temp/vars/spectrum-large.css
+++ b/packages/@adobe/spectrum-css-temp/vars/spectrum-large.css
@@ -244,6 +244,8 @@
   --spectrum-meter-large-border-radius: 4px;
   --spectrum-meter-small-border-radius: 3px;
   --spectrum-pagination-page-button-line-height: 32px;
+  --spectrum-overlay-positive-transform-distance: 8px;
+  --spectrum-overlay-negative-transform-distance: -8px;
   --spectrum-radio-text-gap-key-focus: var(--spectrum-global-dimension-static-size-150);
   --spectrum-radio-text-gap-selected-key-focus: var(--spectrum-global-dimension-static-size-150);
   --spectrum-radio-text-gap-error-key-focus: var(--spectrum-global-dimension-static-size-150);

--- a/packages/@adobe/spectrum-css-temp/vars/spectrum-medium.css
+++ b/packages/@adobe/spectrum-css-temp/vars/spectrum-medium.css
@@ -244,6 +244,8 @@
   --spectrum-meter-large-border-radius: 3px;
   --spectrum-meter-small-border-radius: var(--spectrum-global-dimension-static-size-25);
   --spectrum-pagination-page-button-line-height: 26px;
+  --spectrum-overlay-positive-transform-distance: 6px;
+  --spectrum-overlay-negative-transform-distance: -6px;
   --spectrum-radio-text-gap-key-focus: var(--spectrum-global-dimension-static-size-115);
   --spectrum-radio-text-gap-selected-key-focus: var(--spectrum-global-dimension-static-size-115);
   --spectrum-radio-text-gap-error-key-focus: var(--spectrum-global-dimension-static-size-115);


### PR DESCRIPTION
Closes <!-- Github issue # here -->
https://jira.corp.adobe.com/browse/RSP-1678

fix for top and left position... edge doesnt like translate-calc-var combo

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
