### PR TITLE
RSP-1686: WIP - add isPending prop to <Button />

### DIFF
--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -15,6 +15,7 @@ import {mergeProps} from '@react-aria/utils';
 import {RefObject} from 'react';
 import {useDOMPropsResponder, usePress} from '@react-aria/interactions';
 import {useFocusable} from '@react-aria/focus';
+import {useLabels} from '@react-aria/utils';
 
 interface AriaButtonProps extends ButtonProps {
   isSelected?: boolean,
@@ -48,7 +49,8 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
     validationState,
     'aria-expanded': ariaExpanded,
     'aria-haspopup': ariaHasPopup,
-    type = 'button'
+    type = 'button',
+    ...otherProps
   } = props;
   let additionalProps;
   if (elementType !== 'button') {
@@ -74,6 +76,7 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
 
   let {contextProps} = useDOMPropsResponder(ref);
   let {focusableProps} = useFocusable(props, ref);
+  let {id} = useLabels(otherProps);
   let handlers = mergeProps(pressProps, focusableProps);
   let interactions = mergeProps(contextProps, handlers);
 
@@ -87,6 +90,7 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
       'aria-invalid': validationState === 'invalid' ? true : null,
       disabled: isDisabled,
       type,
+      id,
       ...(additionalProps || {}),
       onClick: (e) => {
         if (deprecatedOnClick) {

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -26,7 +26,8 @@ interface AriaButtonProps extends ButtonProps {
 
 interface ButtonAria {
   buttonProps: React.ButtonHTMLAttributes<HTMLButtonElement>,
-  isPressed: boolean
+  isPressed: boolean,
+  isPending: boolean,
 }
 
 export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): ButtonAria {
@@ -41,6 +42,7 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
     onClick: deprecatedOnClick,
     href,
     target,
+    isPending,
     tabIndex,
     isSelected,
     validationState,
@@ -77,6 +79,7 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
 
   return {
     isPressed, // Used to indicate press state for visual
+    isPending, // Used to indicate pending state for visual
     buttonProps: mergeProps(interactions, {
       'aria-haspopup': ariaHasPopup,
       'aria-expanded': ariaExpanded || (ariaHasPopup && isSelected),

--- a/packages/@react-aria/button/src/useButton.ts
+++ b/packages/@react-aria/button/src/useButton.ts
@@ -52,6 +52,11 @@ export function useButton(props: AriaButtonProps, ref: RefObject<HTMLElement>): 
     type = 'button',
     ...otherProps
   } = props;
+
+  if (isPending) {
+    isDisabled = true;
+  }
+
   let additionalProps;
   if (elementType !== 'button') {
     additionalProps = {

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -32,6 +32,7 @@
     "@react-aria/button": "^3.0.0-rc.2",
     "@react-aria/focus": "^3.0.0-rc.2",
     "@react-aria/utils": "^3.0.0-rc.2",
+    "@react-spectrum/progress": "^3.0.0-rc.2",
     "@react-spectrum/typography": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-rc.2",
     "@react-types/button": "^3.0.0-rc.2",
@@ -43,8 +44,8 @@
     "@react-spectrum/test-utils": "^3.0.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "@react-spectrum/provider": "^3.0.0-rc.1"
+    "@react-spectrum/provider": "^3.0.0-rc.1",
+    "react": "^16.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -13,11 +13,11 @@
 import {classNames, filterDOMProps, SlotProvider, useFocusableRef, useSlotProps, useStyleProps} from '@react-spectrum/utils';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
+import {ProgressCircle} from '@react-spectrum/progress';
 import React from 'react';
 import {SpectrumButtonProps} from '@react-types/button';
 import {SpectrumProgressCircleProps} from '@react-types/progress';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
-import {ProgressCircle} from '@react-spectrum/progress';
 import {Text} from '@react-spectrum/typography';
 import {useButton} from '@react-aria/button';
 import {useProviderProps} from '@react-spectrum/provider';
@@ -48,7 +48,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
     isIndeterminate: true,
     size: 'S',
     'aria-labelledby': buttonId,
-    ...variant === 'overBackground' && { variant: 'overBackground' }
+    ...variant === 'overBackground' && {variant: 'overBackground'}
   };
 
   let buttonVariant = variant;
@@ -87,14 +87,8 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
               UNSAFE_className: classNames(styles, 'spectrum-Button-label')
             }
           }}>
-          {isPending
-            ? <ProgressCircle {...progressCircleProps} />
-            : (
-              typeof children === 'string'
-                ? <Text>{children}</Text>
-                : children
-            )
-          }
+          {isPending && <ProgressCircle {...progressCircleProps} />}
+          {!isPending && typeof children === 'string' ? <Text>{children}</Text> : children}
         </SlotProvider>
       </ElementType>
     </FocusRing>

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -16,6 +16,7 @@ import {FocusRing} from '@react-aria/focus';
 import React from 'react';
 import {SpectrumButtonProps} from '@react-types/button';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
+import {ProgressCircle} from '@react-spectrum/progress';
 import {Text} from '@react-spectrum/typography';
 import {useButton} from '@react-aria/button';
 import {useProviderProps} from '@react-spectrum/provider';
@@ -38,7 +39,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
     ...otherProps
   } = props;
   let domRef = useFocusableRef(ref);
-  let {buttonProps, isPressed} = useButton(props, domRef);
+  let {buttonProps, isPressed, isPending} = useButton(props, domRef);
   let {styleProps} = useStyleProps(otherProps);
 
   let buttonVariant = variant;
@@ -61,6 +62,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
             {
               'spectrum-Button--quiet': isQuiet,
               'is-disabled': isDisabled,
+              'is-pending': isPending,
               'is-active': isPressed
             },
             styleProps.className
@@ -76,9 +78,14 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
               UNSAFE_className: classNames(styles, 'spectrum-Button-label')
             }
           }}>
-          {typeof children === 'string' 
-            ? <Text>{children}</Text> 
-            : children}
+          {isPending
+            ? <ProgressCircle isIndeterminate size="S" />
+            : (
+              typeof children === 'string'
+                ? <Text>{children}</Text>
+                : children
+            )
+          }
         </SlotProvider>
       </ElementType>
     </FocusRing>

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -48,6 +48,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
     isIndeterminate: true,
     size: 'S',
     'aria-labelledby': buttonId,
+    ...variant === 'overBackground' && { variant: 'overBackground' }
   };
 
   let buttonVariant = variant;

--- a/packages/@react-spectrum/button/src/Button.tsx
+++ b/packages/@react-spectrum/button/src/Button.tsx
@@ -15,6 +15,7 @@ import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
 import React from 'react';
 import {SpectrumButtonProps} from '@react-types/button';
+import {SpectrumProgressCircleProps} from '@react-types/progress';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {ProgressCircle} from '@react-spectrum/progress';
 import {Text} from '@react-spectrum/typography';
@@ -41,6 +42,13 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
   let domRef = useFocusableRef(ref);
   let {buttonProps, isPressed, isPending} = useButton(props, domRef);
   let {styleProps} = useStyleProps(otherProps);
+  let {id: buttonId} = buttonProps;
+
+  let progressCircleProps: SpectrumProgressCircleProps = {
+    isIndeterminate: true,
+    size: 'S',
+    'aria-labelledby': buttonId,
+  };
 
   let buttonVariant = variant;
   if (VARIANT_MAPPING[variant]) {
@@ -79,7 +87,7 @@ function Button(props: SpectrumButtonProps, ref: FocusableRef) {
             }
           }}>
           {isPending
-            ? <ProgressCircle isIndeterminate size="S" />
+            ? <ProgressCircle {...progressCircleProps} />
             : (
               typeof children === 'string'
                 ? <Text>{children}</Text>

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -97,18 +97,16 @@ storiesOf('Button', module)
           onPressStart={action('pressstart')}
           onPressEnd={action('pressend')}
           variant="primary"
-          isPending={true}
-          aria-label="Loading">
-        </Button>
+          isPending
+          aria-label="Loading" />
         <Button
           onPress={action('press')}
           onPressStart={action('pressstart')}
           onPressEnd={action('pressend')}
           isQuiet
           variant="primary"
-          isPending={true}
-          aria-labelledby="loading-label">
-        </Button>
+          isPending
+          aria-labelledby="loading-label" />
       </div>
     )
   )
@@ -124,18 +122,16 @@ storiesOf('Button', module)
           onPressStart={action('pressstart')}
           onPressEnd={action('pressend')}
           variant="overBackground"
-          isPending={true}
-          aria-label="Loading">
-        </Button>
+          isPending
+          aria-label="Loading" />
         <Button
           onPress={action('press')}
           onPressStart={action('pressstart')}
           onPressEnd={action('pressend')}
           isQuiet
           variant="overBackground"
-          isPending={true}
-          aria-labelledby="loading-label">
-        </Button>
+          isPending
+          aria-labelledby="loading-label" />
       </div>
     )
   );

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -16,6 +16,7 @@ import {Button} from '../';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/typography';
+import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 storiesOf('Button', module)
   .addParameters({providerSwitcher: {status: 'positive'}})
@@ -83,6 +84,42 @@ storiesOf('Button', module)
   .add(
     'element: a, href: \'//example.com\', target: \'_self\'',
     () => render({elementType: 'a', href: '//example.com', target: '_self', variant: 'primary'})
+  )
+  .add(
+    'is pending',
+    () => (
+      <div>
+        <VisuallyHidden>
+          <span id="loading-label">Visually hidden loading label</span>
+        </VisuallyHidden>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          variant="primary"
+          isPending={true}
+          aria-label="Loading">
+        </Button>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isDisabled
+          variant="primary"
+          isPending={true}
+          aria-label="Loading">
+        </Button>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isQuiet
+          variant="primary"
+          isPending={true}
+          aria-labelledby="loading-label">
+        </Button>
+      </div>
+    )
   );
 
 function render(props: any = {}) {

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -111,6 +111,33 @@ storiesOf('Button', module)
         </Button>
       </div>
     )
+  )
+  .add(
+    'is pending, variant: overBackground',
+    () => (
+      <div style={{backgroundColor: 'rgb(15, 121, 125)', color: 'rgb(15, 121, 125)', padding: '15px 20px', display: 'inline-block'}}>
+        <VisuallyHidden>
+          <span id="loading-label">Visually hidden loading label</span>
+        </VisuallyHidden>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          variant="overBackground"
+          isPending={true}
+          aria-label="Loading">
+        </Button>
+        <Button
+          onPress={action('press')}
+          onPressStart={action('pressstart')}
+          onPressEnd={action('pressend')}
+          isQuiet
+          variant="overBackground"
+          isPending={true}
+          aria-labelledby="loading-label">
+        </Button>
+      </div>
+    )
   );
 
 function render(props: any = {}) {

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -104,15 +104,6 @@ storiesOf('Button', module)
           onPress={action('press')}
           onPressStart={action('pressstart')}
           onPressEnd={action('pressend')}
-          isDisabled
-          variant="primary"
-          isPending={true}
-          aria-label="Loading">
-        </Button>
-        <Button
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
           isQuiet
           variant="primary"
           isPending={true}

--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -167,4 +167,20 @@ describe('Button', function () {
     let button = getByRole('button');
     expect(document.activeElement).toBe(button);
   });
+
+  it.each`
+    Name                | Component | props
+    ${'Button'}         | ${Button} | ${{id: 'button', isPending: true, 'aria-label': 'Loading'}}
+  `('$Name supports isPending', function ({Component, props}) {
+    let {getByRole, queryByText} = render(<Component {...props}>Click me</Component>);
+
+    let button = getByRole('button');
+    expect(button).toBeDisabled();
+
+    let text = queryByText('Click Me');
+    expect(text).toBeNull();
+
+    let progressCircle = getByRole('progressbar');
+    expect(progressCircle).toHaveAttribute('aria-labelledby', 'button');
+  });
 });

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -27,6 +27,8 @@ export interface ButtonProps extends DOMProps, StyleProps, PressEvents, Focusabl
   href?: string,
   /** The target window for the link. */
   target?: string
+  /** Whether the button is in an indeterminate loading state */
+  isPending?: boolean,
 }
 
 export interface SpectrumButtonProps extends ButtonProps {


### PR DESCRIPTION
First stab at adding an `isPending` state for button components. 

Spectrum team confirmed today that the button should have a first state where it _acts_ disabled but _looks_ default and a second state where we replace the text label with a spinner. Disabling the button will remove focus, which we don't want.

To start, in this PR I just disable the button if `isPending` exists and don't handle the delay.

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [JIRA ticket](https://jira.corp.adobe.com/browse/RSP-1686).
- [x] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

View the two new "isPending" Button stories.

## 🧢 Your Team:

RSP, AEP
