### PR TITLE
Update browser targets for docs website

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/adobe-private/react-spectrum-v3"
   },
+  "browserslist": ["chrome >= 61", "firefox >= 60", "safari >= 11", "edge >= 16"],
   "scripts": {
     "check-types": "tsc --skipLibCheck",
     "start": "make run",


### PR DESCRIPTION
Causes babel to compile less. Smaller bundle sizes. Also fixes a bug in babel loose mode that breaks some of our examples by not compiling it and letting the browser handle that syntax instead. 😄 