### PR TITLE
Initial react-stately docs

### DIFF
--- a/packages/@react-aria/listbox/docs/useListBox.mdx
+++ b/packages/@react-aria/listbox/docs/useListBox.mdx
@@ -104,11 +104,14 @@ interface, which is a generic interface to access sequential unique keyed data. 
 implement this interface yourself, e.g. by using a prop to pass a list of item objects, 
 but <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useListState} /> from
 `@react-stately/list` implements a JSX based interface for building collections instead.
+See [Collection Components](/react-stately/collections.html) for more information, 
+and [Collection Interface](/react-stately/Collection.html) for internal details.
 
 In addition, <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useListState} />
 manages the state necessary for multiple selection and exposes
 a <TypeLink links={selectionDocs.links} type={selectionDocs.exports.SelectionManager} />,
 which makes use of the collection to provide an interface to update the selection state.
+For more information, see [Selection](/react-stately/selection.html).
 
 ## Example
 

--- a/packages/@react-aria/menu/docs/useMenu.mdx
+++ b/packages/@react-aria/menu/docs/useMenu.mdx
@@ -101,11 +101,14 @@ interface, which is a generic interface to access sequential unique keyed data. 
 implement this interface yourself, e.g. by using a prop to pass a list of item objects, 
 but <TypeLink links={treeDocs.links} type={treeDocs.exports.useTreeState} /> from 
 `@react-stately/tree` implements a JSX based interface for building collections instead.
+See [Collection Components](/react-stately/collections.html) for more information, 
+and [Collection Interface](/react-stately/Collection.html) for internal details.
 
 In addition, <TypeLink links={treeDocs.links} type={treeDocs.exports.useTreeState} />
 manages the state necessary for multiple selection and exposes
 a <TypeLink links={selectionDocs.links} type={selectionDocs.exports.SelectionManager} />,
 which makes use of the collection to provide an interface to update the selection state.
+For more information, see [Selection](/react-stately/selection.html).
 
 ## Example
 

--- a/packages/@react-aria/menu/docs/useMenuTrigger.mdx
+++ b/packages/@react-aria/menu/docs/useMenuTrigger.mdx
@@ -24,7 +24,7 @@ import {useMenuTrigger} from '@react-aria/menu';
 ```
 
 ---
-category: Collections
+category: Overlays
 ---
 
 # useMenuTrigger

--- a/packages/@react-aria/select/docs/useSelect.mdx
+++ b/packages/@react-aria/select/docs/useSelect.mdx
@@ -25,7 +25,7 @@ import {useSelect} from '@react-aria/select';
 ```
 
 ---
-category: Collections
+category: Forms
 ---
 
 # useSelect
@@ -92,12 +92,15 @@ interface, which is a generic interface to access sequential unique keyed data. 
 implement this interface yourself, e.g. by using a prop to pass a list of item objects, 
 but <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useSelectState} /> from 
 `@react-stately/select` implements a JSX based interface for building collections instead.
+See [Collection Components](/react-stately/collections.html) for more information, 
+and [Collection Interface](/react-stately/Collection.html) for internal details.
 
 In addition, <TypeLink links={statelyDocs.links} type={statelyDocs.exports.useSelectState} />
 manages the state necessary for multiple selection and exposes
 a <TypeLink links={selectionDocs.links} type={selectionDocs.exports.SelectionManager} />,
 which makes use of the collection to provide an interface to update the selection state.
 It also holds state to track if the popup is open.
+For more information about selection, see [Selection](/react-stately/selection.html).
 
 ## Example
 

--- a/packages/@react-stately/collections/docs/Collection.mdx
+++ b/packages/@react-stately/collections/docs/Collection.mdx
@@ -1,0 +1,66 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/collections';
+import treeDocs from 'docs:@react-stately/tree';
+import listDocs from 'docs:@react-stately/list';
+import listboxDocs from 'docs:@react-aria/listbox';
+import selectDocs from 'docs:@react-aria/select';
+import {HeaderInfo, TypeContext, InterfaceType, ClassAPI, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Collections
+---
+
+# Collection Interface
+
+<p>{docs.exports.Collection.description}</p>
+
+## Introduction
+
+The <TypeLink links={docs.links} type={docs.exports.Collection} /> interface provides a generic representation
+for many types of collections. The collection is read only (immutable), and sequential (ordered). Each item
+has a unique key that identifies it, which can be used to access items. It's like a combination
+of an array and a map: you can iterate over items in a well defined order, and also access items by key.
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.exports.Collection} />
+
+## Building a collection
+
+The <TypeLink links={docs.links} type={docs.exports.Collection} /> interface can be implemented in many ways.
+For example, you could write a class to expose the required methods and properties for an underlying data structure
+like an array or [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).
+
+As discussed on the [Collection Components](collections.html) page, React Spectrum implements a JSX-based
+API for defining collections. This is implemented by the <TypeLink links={docs.links} type={docs.exports.CollectionBuilder} />
+class. `CollectionBuilder` iterates over the JSX tree, and recursively builds a collection 
+of <TypeLink links={docs.links} type={docs.exports.Node} /> objects. Each node includes the value of the item
+it represents, along with some metadata about its place in the collection.
+
+These nodes are then wrapped in a class that implements the <TypeLink links={docs.links} type={docs.exports.Collection} />
+interface, and exposes the nodes. State management hooks like <TypeLink links={listDocs.links} type={listDocs.exports.useListState} />
+and <TypeLink links={treeDocs.links} type={treeDocs.exports.useTreeState} /> handle building the collection and exposing
+the necessary interface to components.
+
+When implementing collection components using [react-aria](/react-aria/index.html) hooks 
+like <TypeLink links={listboxDocs.links} type={listboxDocs.exports.useListBox} />,
+and <TypeLink links={selectDocs.links} type={selectDocs.exports.useSelect} />, you'll iterate over these nodes
+to render the data in the collection. The properties exposed by a node are described below.
+
+## Node interface
+
+<TypeContext.Provider value={docs.links}>
+  <InterfaceType properties={docs.exports.Node.properties} />
+</TypeContext.Provider>

--- a/packages/@react-stately/collections/docs/collections.mdx
+++ b/packages/@react-stately/collections/docs/collections.mdx
@@ -32,9 +32,9 @@ tables, trees, and grids. These collections can usually be navigated with the ke
 many have some form of selection. Many support loading data asynchronously, updating that data over time,
 virtualized scrolling for performance with large collections, and more.
 
-There are many ways one could design an API for components like this: JSX children, a prop that accepts a
-list of option objects, as a datasource object with getter functions for each item, etc.. Selection, and 
-other states like disabled, could be passed as options to each item, or as a separate top-level prop.
+There are many ways one could design an API for components like this: JSX children, a
+list of option objects, or a datasource object. Selection, and 
+other states like disabled, could be passed in to each item, or as a top-level prop.
 Each of these has various tradeoffs. This page describes how we do it in React Spectrum, and covers some
 of these tradeoffs in detail.
 
@@ -59,7 +59,7 @@ we considered were:
 ## Static collections
 
 React Spectrum implements a JSX-based API for defining collections. This allows an intuitive way to provide
-items, which can contain rich rendering of item contents, and various options as props. Building heirarchical
+items, which can contain rich rendering, and various options as props. Building heirarchical
 collections, e.g. sections, or a tree of items is also very natural in JSX.
 
 A **static collection** is a collection that does not change over time (e.g. hard coded). This is common for
@@ -102,7 +102,7 @@ interface that can be learned once and applied everywhere.
 &lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt; and 
 &lt;<TypeLink links={docs.links} type={docs.exports.Section} />&gt; only define the data for 
 the items and sections, not the rendering, visual appearance, or behavior. This is up to 
-the parent component (e.g. Menu or ListBox).
+the individual collection component (e.g. Menu or ListBox) to implement.
 
 ## Dynamic collections
 
@@ -152,7 +152,7 @@ let [animals, setAnimals] = useState([
 
 ### Why not array map?
 
-If you're an experienced React developer, you may be wondering why we didn't use `animals.map` in this example.
+You may be wondering why we didn't use `animals.map` in this example.
 In fact, you can do this if you want and it will work, but it will not be as performant.
 
 ```tsx
@@ -178,11 +178,13 @@ has big performance benefits for large collections.
 When you need to update the data to add, remove, or change an item, you can do so using a standard React state update.
 
 **IMPORTANT: all items passed to a collection component must be immutable. Changing a property on an item, or calling 
-`array.push()` or other mutating methods will not work as expected. To make this easier, see the 
-[useListData](useListData.html) hook.**
+`array.push()` or other mutating methods will not work as expected.**
 
-The following example shows how you might append a new item to the list 
-using <TypeLink links={dataDocs.links} type={dataDocs.exports.useListData} />.
+The <TypeLink links={dataDocs.links} type={dataDocs.exports.useListData} /> hook can be used to manage the 
+data and state for a list of items, and update it over time. It will also handle removing items from the selection
+state when they are removed from the list. See the [useListBox docs](useListBox.html) for more details.
+
+The following example shows how you might append a new item to the list.
 
 ```tsx
 import {useListData} from '@react-stately/data';
@@ -243,10 +245,13 @@ let [sections, setSections] = useState([
 
 When updating nested data, be sure that all parent items change accordingly. Items are immutable,
 so don't use mutating methods like push, or replace a property on a parent item. Instead, copy
-the items that changed as needed. You can do this by hand if you like, but it can be challenging.
-To make it easier, you can use the <TypeLink links={dataDocs.links} type={dataDocs.exports.useTreeData} />
-hook. `useTreeData` will also handle automatically removing items from the selection when they are
-removed from the list. See the [useTreeData docs](useTreeData.html) for more details.
+the items that changed as needed.
+
+The <TypeLink links={dataDocs.links} type={dataDocs.exports.useTreeData} /> hook can be used to
+manage data and state for a tree of items. This is similar to `useListData`, but with support for
+heirarchical data. Like `useListData`, `useTreeData` will also handle automatically 
+removing items from the selection when they are removed from the list. See the
+[useTreeData docs](useTreeData.html) for more details.
 
 ```tsx
 import {useTreeData} from '@react-stately/data';

--- a/packages/@react-stately/collections/docs/collections.mdx
+++ b/packages/@react-stately/collections/docs/collections.mdx
@@ -1,0 +1,387 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/collections';
+import dataDocs from 'docs:@react-stately/data';
+import {HeaderInfo, PropTable, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Collections
+---
+
+# Collection Components
+
+Many components display a collection of items, and provide functionality such as keyboard 
+navigation, selection, and more. React Spectrum has a unified API to define the items
+displayed in these components.
+
+## Introduction
+
+There are many components that display a collection of items of some kind. For example, lists, menus, selects,
+tables, trees, and grids. These collections can usually be navigated with the keyboard using arrow keys, and
+many have some form of selection. Many support loading data asynchronously, updating that data over time,
+virtualized scrolling for performance with large collections, and more.
+
+There are many ways one could design an API for components like this: JSX children, a prop that accepts a
+list of option objects, as a datasource object with getter functions for each item, etc.. Selection, and 
+other states like disabled, could be passed as options to each item, or as a separate top-level prop.
+Each of these has various tradeoffs. This page describes how we do it in React Spectrum, and covers some
+of these tradeoffs in detail.
+
+## Design goals
+
+Our main design goal was to provide a consistent API across many types of collection components that is
+easy to learn, performant on large collections, and extensible for advanced features. Some of the usecases
+we considered were:
+
+- Static data
+- Dynamic data
+- Async loading
+- Sections/groups of data from a single source
+- Sections from different sources
+- Single and multiple selection (controlled and uncontrolled)
+- Controlled and uncontrolled expanded states for components like trees and accordions
+- Marking items as selected, expanded, disabled, etc. prior to loading them from a server
+- Drag and drop of items
+- Virtualization for large collections
+- Infinite scrolling to load more items on demand
+
+## Static collections
+
+React Spectrum implements a JSX-based API for defining collections. This allows an intuitive way to provide
+items, which can contain rich rendering of item contents, and various options as props. Building heirarchical
+collections, e.g. sections, or a tree of items is also very natural in JSX.
+
+A **static collection** is a collection that does not change over time (e.g. hard coded). This is common for
+components like action menus where the items are built into the application rather than representing user data.
+
+A simple static collection could be constructed as in the following example.
+
+```tsx
+<Menu>
+  <Item>Open</Item>
+  <Item>Edit</Item>
+  <Item>Delete</Item>
+</Menu>
+```
+
+### Sections
+
+Sections or groups of items can be constructed by wrapping the items as needed.
+
+```tsx
+<ListBox>
+  <Section title="People">
+    <Item>David</Item>
+    <Item>Sam</Item>
+    <Item>Jane</Item>
+  </Section>
+  <Section title="Animals">
+    <Item>Aardvark</Item>
+    <Item>Kangaroo</Item>
+    <Item>Snake</Item>
+  </Section>
+</ListBox>
+```
+
+The &lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt; and 
+&lt;<TypeLink links={docs.links} type={docs.exports.Section} />&gt; components
+are shared between many collection components. This ensures that they have a consistent
+interface that can be learned once and applied everywhere.
+
+&lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt; and 
+&lt;<TypeLink links={docs.links} type={docs.exports.Section} />&gt; only define the data for 
+the items and sections, not the rendering, visual appearance, or behavior. This is up to 
+the parent component (e.g. Menu or ListBox).
+
+## Dynamic collections
+
+Static collections are great when the items never changes, but how about dynamic data? A **dynamic collection**
+is a collection that is based on data, for example from an API. In addition, it may change over time as
+items are added, updated, or removed from the collection by a user.
+
+React Spectrum implements a JSX-based interface for dynamic collections, which maps over your data and
+applies a function for each item to render it. The following example shows how a collection can be 
+rendered based on dynamic data, stored in React state.
+
+```tsx
+let [animals, setAnimals] = useState([
+  {id: 1, name: 'Aardvark'},
+  {id: 2, name: 'Kangaroo'},
+  {id: 3, name: 'Snake'}
+]);
+
+<ListBox items={animals}>
+  {item => <Item>{item.name}</Item>}
+</ListBox>
+```
+
+As you can see, the items are passed to the `items` prop of the top-level component, which iterates over each 
+item and calls the function passed as children to the component. The item object is passed to the function, which
+returns an &lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt;.
+
+### Unique keys
+
+All items in a collection must have a unique key or id, which is used to determine what items in the collection changed
+when updates occur. By default, React Spectrum looks for an `id` or `key` property on each item, which is often returned 
+from a database. You can also specify a custom key on each item that should be used as the unique key for the item with 
+the `itemKey` prop. For example, if all animals in the example had a unique `name` property, then `itemKey` could be set 
+to `"name"` to use it as the unique key.
+
+```tsx
+let [animals, setAnimals] = useState([
+  {name: 'Aardvark'},
+  {name: 'Kangaroo'},
+  {name: 'Snake'}
+]);
+
+<ListBox items={animals} itemKey="name">
+  {item => <Item>{item.name}</Item>}
+</ListBox>
+```
+
+### Why not array map?
+
+If you're an experienced React developer, you may be wondering why we didn't use `animals.map` in this example.
+In fact, you can do this if you want and it will work, but it will not be as performant.
+
+```tsx
+let [animals, setAnimals] = useState([
+  {name: 'Aardvark'},
+  {name: 'Kangaroo'},
+  {name: 'Snake'}
+]);
+
+<ListBox>
+  {animals.map(item => 
+    <Item key={item.name}>{item.name}</Item>
+  )}
+</ListBox>
+```
+
+Using the `items` prop and providing a render function allows React Spectrum to automatically cache the results
+of rendering each item and avoid re-rendering all items in the collection when only one of them changes. This 
+has big performance benefits for large collections.
+
+### Updating data
+
+When you need to update the data to add, remove, or change an item, you can do so using a standard React state update.
+
+**IMPORTANT: all items passed to a collection component must be immutable. Changing a property on an item, or calling 
+`array.push()` or other mutating methods will not work as expected. To make this easier, see the 
+[useListData](useListData.html) hook.**
+
+The following example shows how you might append a new item to the list 
+using <TypeLink links={dataDocs.links} type={dataDocs.exports.useListData} />.
+
+```tsx
+import {useListData} from '@react-stately/data';
+
+let list = useListData({
+  initialItems: [
+    {name: 'Aardvark'},
+    {name: 'Kangaroo'},
+    {name: 'Snake'}
+  ],
+  initialSelectedKeys: ['Kangaroo'],
+  getKey: item => item.name
+});
+
+function addAnimal(name) {
+  list.append({name});
+}
+
+<ListBox items={list.items} itemKey="name">
+  {item => <Item>{item.name}</Item>}
+</ListBox>
+```
+
+### Sections
+
+Sections can be built by returning a &lt;<TypeLink links={docs.links} type={docs.exports.Section} />&gt; instead of
+an &lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt; item from the top-level item renderer. Sections
+also support an `items` prop with `itemKey` and a renderer function for their children.
+
+```tsx
+let [sections, setSections] = useState([
+  {
+    name: 'People',
+    items: [
+      {name: 'David'},
+      {name: 'Same'},
+      {name: 'Jane'}
+    ]
+  },
+  {
+    name: 'Animals',
+    items: [
+      {name: 'Aardvark'},
+      {name: 'Kangaroo'},
+      {name: 'Snake'}
+    ]
+  }
+]);
+
+<Picker items={sections} itemKey="name">
+  {section =>
+    <Section title={section.name} items={section.items} itemKey="name">
+      {item => <Item>{item.name}</Item>}
+    </Section>
+  }
+</Picker>
+```
+
+When updating nested data, be sure that all parent items change accordingly. Items are immutable,
+so don't use mutating methods like push, or replace a property on a parent item. Instead, copy
+the items that changed as needed. You can do this by hand if you like, but it can be challenging.
+To make it easier, you can use the <TypeLink links={dataDocs.links} type={dataDocs.exports.useTreeData} />
+hook. `useTreeData` will also handle automatically removing items from the selection when they are
+removed from the list. See the [useTreeData docs](useTreeData.html) for more details.
+
+```tsx
+import {useTreeData} from '@react-stately/data';
+
+let tree = useTreeData({
+  initialItems: [
+    {
+      name: 'People',
+      items: [
+        {name: 'David'},
+        {name: 'Sam'},
+        {name: 'Jane'}
+      ]
+    },
+    {
+      name: 'Animals',
+      items: [
+        {name: 'Aardvark'},
+        {name: 'Kangaroo'},
+        {name: 'Snake'}
+      ]
+    }
+  ],
+  getKey: item => item.name,
+  getChildren: item => item.items
+});
+
+function addPerson(name) {
+  tree.append('People', {name});
+}
+
+<ListBox items={tree.items}>
+  {node =>
+    <Section title={node.value.name} items={node.children}>
+      {node => <Item>{node.value.name}</Item>}
+    </Section>
+  }
+</ListBox>
+```
+
+## Heirarchical data
+
+Sections only allow a single level of heirarchy. Some components like trees allow arbitrary heirarchical
+data of any depth to be displayed. This can be accomplished by nesting 
+&lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt; components, and using the `title` prop 
+to specify the contents of items with children.
+
+```tsx
+<Tree>
+  <Item title="Animals">
+    <Item>Aardvark</Item>
+    <Item>Kangaroo</Item>
+    <Item>Snake</Item>
+  </Item>
+  <Item title="People">
+    <Item>Danni</Item>
+    <Item>Devon</Item>
+    <Item>Ross</Item>
+  </Item>
+</Tree>
+```
+
+To support dynamic data, &lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt; supports a
+`childItems` prop, which causes your item renderer function to be called recursively for each child.
+
+```tsx
+let [items, setItems] = useState([
+  {name: 'Animals', children: [
+    {name: 'Aardvark'},
+    {name: 'Kangaroo'},
+    {name: 'Snake'}
+  ]},
+  {name: 'People', children: [
+    {name: 'Danni'},
+    {name: 'Devon'},
+    {name: 'Ross'}
+  ]}
+]);
+
+<Tree items={items} itemKey="name">
+  {item =>
+    <Item childItems={item.children}>{item.name}</Item>
+  }
+</Tree>
+```
+
+## Asynchronous loading
+
+Many collection components support loading data asynchronously. This is supported by passing an `isLoading` prop,
+which is `true` while the data is loading. Once the data is loaded, `isLoading` should be set to `false`, and the
+`items` prop should be set to the loaded data.
+
+TODO: useAsyncList/useAsyncTree
+
+```tsx
+let [items, setItems] = useState([]);
+let [isLoading, setLoading] = useState(true);
+
+// Load data once the component mounts.
+useEffect(() => {
+  fetch('http://example.com/api')
+    .then(res => res.json())
+    .then(json => {
+      // Update items and set isLoading to false.
+      setItems(json.data);
+      setLoading(false);
+    });
+}, []);
+
+<Picker items={items} isLoading={isLoading}>
+  {item => <Item>{item.name}</Item>}
+</Picker>
+```
+
+### Infinite loading
+
+TODO
+
+### Sections with separate data sources
+
+TODO
+
+```tsx
+<Tree>
+  <Section 
+    title="Local Files"
+    items={local.items}
+    isLoading={local.isLoading}>
+    {item => <Item>{item.name}</Item>}
+  </Section>
+  <Section 
+    title="In the Cloud" 
+    items={cloud.items} 
+    isLoading={cloud.isLoading}>
+    {item => <Item>{item.name}</Item>}
+  </Section>
+</Tree>
+```

--- a/packages/@react-stately/collections/src/CollectionBuilder.ts
+++ b/packages/@react-stately/collections/src/CollectionBuilder.ts
@@ -33,7 +33,7 @@ export class CollectionBuilder<T extends object> {
     return iterable(() => this.iterateCollection(props));
   }
 
-  *iterateCollection(props: CollectionBase<T>) {
+  private *iterateCollection(props: CollectionBase<T>) {
     let {children, items} = props;
 
     if (typeof children === 'function') {
@@ -56,7 +56,7 @@ export class CollectionBuilder<T extends object> {
     }
   }
 
-  getKey(item: CollectionElement<T>, partialNode: PartialNode<T>, state: CollectionBuilderState, parentKey?: Key): Key {
+  private getKey(item: CollectionElement<T>, partialNode: PartialNode<T>, state: CollectionBuilderState, parentKey?: Key): Key {
     if (item.props.uniqueKey != null) {
       return item.props.uniqueKey;
     }
@@ -82,14 +82,14 @@ export class CollectionBuilder<T extends object> {
     return key;
   }
 
-  getChildState(state: CollectionBuilderState, partialNode: PartialNode<T>) {
+  private getChildState(state: CollectionBuilderState, partialNode: PartialNode<T>) {
     return {
       renderer: partialNode.renderer || state.renderer,
       childKey: partialNode.childKey || state.childKey
     };
   }
 
-  *getFullNode(partialNode: PartialNode<T>, state: CollectionBuilderState, parentKey?: Key, parentNode?: Node<T>): Generator<Node<T>> {
+  private *getFullNode(partialNode: PartialNode<T>, state: CollectionBuilderState, parentKey?: Key, parentNode?: Node<T>): Generator<Node<T>> {
     // If there's a value instead of an element on the node, and a parent renderer function is available,
     // use it to render an element for the value.
     let element = partialNode.element;

--- a/packages/@react-stately/collections/src/types.ts
+++ b/packages/@react-stately/collections/src/types.ts
@@ -27,13 +27,13 @@ export interface Node<T> {
   value: T,
   /** The level of depth this node is at in the heirarchy. */
   level: number,
-  /** Whether the node has children (whether loaded or not). */
+  /** Whether this item has children, even if not loaded yet. */
   hasChildNodes: boolean,
   /** The loaded children of this node. */
   childNodes: Iterable<Node<T>>,
   /** The rendered contents of this node (e.g. JSX). */
   rendered: ReactNode,
-  /** A string value for this node, for accessibility features like typeahead. */
+  /** A string value for this node, used for features like typeahead. */
   textValue: string,
   /** An accessibility label for this node. */
   'aria-label'?: string,

--- a/packages/@react-stately/collections/src/types.ts
+++ b/packages/@react-stately/collections/src/types.ts
@@ -19,20 +19,35 @@ import {Transaction} from './Transaction';
 
 export interface Node<T> {
   // TODO: determine how to keep this limited to shared node types
+  /** The type of item this node represents. */
   type: 'section' | 'item' | 'column' | 'cell' | 'rowheader' | 'placeholder' | 'headerrow',
+  /** A unique key for the node. */
   key: Key,
+  /** The object value the node was created from. */
   value: T,
+  /** The level of depth this node is at in the heirarchy. */
   level: number,
+  /** Whether the node has children (whether loaded or not). */
   hasChildNodes: boolean,
+  /** The loaded children of this node. */
   childNodes: Iterable<Node<T>>,
+  /** The rendered contents of this node (e.g. JSX). */
   rendered: ReactNode,
+  /** A string value for this node, for accessibility features like typeahead. */
   textValue: string,
+  /** An accessibility label for this node. */
   'aria-label'?: string,
+  /** The index of this node within its parent. */
   index?: number,
+  /** A function that should be called to wrap the rendered node. */
   wrapper?: (element: ReactElement) => ReactElement,
+  /** The key of the parent node. */
   parentKey?: Key,
+  /** The key of the node before this node. */
   prevKey?: Key,
+  /** The key of the node after this node. */
   nextKey?: Key,
+  /** Additional properties specific to a particular node type. */
   props?: any
 }
 

--- a/packages/@react-stately/data/docs/useListData.mdx
+++ b/packages/@react-stately/data/docs/useListData.mdx
@@ -1,0 +1,148 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/data';
+import {HeaderInfo, TypeContext, ClassAPI, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Data
+---
+
+# useListData
+
+<p>{docs.exports.useListData.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useListData']} />
+
+## Introduction
+
+React requires all data structures passed as props to be immutable. This enables them to be diffed correctly to determine
+what has changed since the last render. This can be challenging to accomplish from scratch in a performant way in JavaScript. 
+
+`useListData` helps manage an immutable list data structure, with helper methods to update the data in an efficient way.
+Since the data is stored in React state, calling these methods to update the data automatically causes the component
+to re-render accordingly.
+
+In addition, `useListData` stores selection state for the list, based on unique item keys. This can be updated programmatically,
+and is automatically updated when items are removed from the list.
+
+## API
+
+<FunctionAPI function={docs.exports.useListData} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useListData.return.base.id]} />
+
+## Example
+
+To construct a list, pass an initial set of items along with a function to get a key for each item.
+You can use the state returned by `useListData` to render a [collection component](collections.html).
+
+This example renders a `ListBox` using the items managed by `useListData`. It uses the `name` property of each item
+as the unique key for that item, and the `items` property as the children. In addition, it manages the selection state
+for the listbox, which will automatically be updated when items are removed from the tree.
+
+```tsx
+let list = useListData({
+  initialItems: [
+    {name: 'Aardvark'},
+    {name: 'Kangaroo'},
+    {name: 'Snake'}
+  ],
+  initialSelectedKeys: ['Kangaroo'],
+  getKey: item => item.name
+});
+
+<ListBox
+  items={list.items}
+  itemKey="name"
+  selectedKeys={list.selectedKeys}
+  onSelectionChange={list.setSelectedKeys}>
+  {item => <Item>{item.name}</Item>}
+</ListBox>
+```
+
+### Inserting items
+
+To insert a new item into the list, use the `insert` method or one of the convenience methods.
+Each of these methods also accepts multiple items, so you can insert multiple items at once.
+
+```tsx
+// Insert an item after the first one
+list.insert(1, {name: 'Horse'});
+
+// Insert multiple items
+list.insert(1, {name: 'Horse'}, {name: 'Giraffe'});
+```
+
+```tsx
+// Insert an item before another item
+list.insertAfter('Kangaroo', {name: 'Horse'});
+
+// Insert multiple items before another item
+list.insertAfter('Kangaroo', {name: 'Horse'}, {name: 'Giraffe'});
+```
+
+```tsx
+// Insert an item after another item
+list.insertAfter('Kangaroo', {name: 'Horse'});
+
+// Insert multiple items after another item
+list.insertAfter('Kangaroo', {name: 'Horse'}, {name: 'Giraffe'});
+```
+
+```tsx
+// Append an item
+list.append({name: 'Horse'});
+
+// Append multiple items
+list.append({name: 'Horse'}, {name: 'Giraffe'});
+```
+
+```tsx
+// Prepend an item
+list.prepend({name: 'Horse'});
+
+// Prepend multiple items
+list.prepend({name: 'Horse'}, {name: 'Giraffe'});
+```
+
+### Removing items
+
+```tsx
+// Remove an item
+list.remove('Kangaroo');
+
+// Remove multiple items
+list.remove('Kangaroo', 'Snake');
+```
+
+```tsx
+// Remove all selected items
+list.removeSelectedItems();
+```
+
+### Moving items
+
+```tsx
+list.move('Snake', 0);
+```
+
+### Updating items
+
+```tsx
+list.update('Snake', {name: 'Rattle Snake'});
+```

--- a/packages/@react-stately/data/docs/useListData.mdx
+++ b/packages/@react-stately/data/docs/useListData.mdx
@@ -77,7 +77,7 @@ let list = useListData({
 
 ### Inserting items
 
-To insert a new item into the list, use the `insert` method or one of the convenience methods.
+To insert a new item into the list, use the `insert` method or one of the other convenience methods.
 Each of these methods also accepts multiple items, so you can insert multiple items at once.
 
 ```tsx

--- a/packages/@react-stately/data/docs/useTreeData.mdx
+++ b/packages/@react-stately/data/docs/useTreeData.mdx
@@ -1,0 +1,170 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/data';
+import {HeaderInfo, TypeContext, ClassAPI, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Data
+---
+
+# useTreeData
+
+<p>{docs.exports.useTreeData.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useTreeData']} />
+
+## Introduction
+
+React requires all data structures passed as props to be immutable. This enables them to be diffed correctly to determine
+what has changed since the last render. This can be challenging to accomplish from scratch in a performant way in JavaScript. 
+
+`useTreeData` helps manage an immutable tree data structure, with helper methods to update the data in an efficient way.
+Since the data is stored in React state, calling these methods to update the data automatically causes the component
+to re-render accordingly.
+
+In addition, `useTreeData` stores selection state for the tree, based on unique item keys. This can be updated programmatically,
+and is automatically updated when items are removed from the tree.
+
+## API
+
+<FunctionAPI function={docs.exports.useTreeData} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useTreeData.return.base.id]} />
+
+## Example
+
+To construct a tree, pass an initial set of items along with functions to get a key for each item, and its children.
+`useTreeData` processes these items into nodes, which you can use to render a [collection component](collections.html).
+Each node has `key`, `value`, and `children` properties.
+
+This example renders a `ListBox` with two sections, each with three child items. It uses the `name` property of each item
+as the unique key for that item, and the `items` property as the children. In addition, it manages the selection state
+for the listbox, which will automatically be updated when items are removed from the tree.
+
+```tsx
+let tree = useTreeData({
+  initialItems: [
+    {
+      name: 'People',
+      items: [
+        {name: 'David'},
+        {name: 'Sam'},
+        {name: 'Jane'}
+      ]
+    },
+    {
+      name: 'Animals',
+      items: [
+        {name: 'Aardvark'},
+        {name: 'Kangaroo'},
+        {name: 'Snake'}
+      ]
+    }
+  ],
+  initialSelectedKeys: ['Sam', 'Kangaroo'],
+  getKey: item => item.name,
+  getChildren: item => item.items
+});
+
+<ListBox
+  items={tree.items}
+  selectedKeys={tree.selectedKeys}
+  onSelectionChange={tree.setSelectedKeys}>
+  {node =>
+    <Section title={node.value.name} items={node.children}>
+      {node => <Item>{node.value.name}</Item>}
+    </Section>
+  }
+</ListBox>
+```
+
+### Inserting items
+
+To insert a new item into the tree, use the `insert` method or use one of the convenience methods.
+Pass a `parentKey` to insert into, or `null` to insert a root item.
+
+```tsx
+// Insert an item into the root, after 'People'
+tree.insert(null, 1, {name: 'Plants'});
+
+// Insert an item into the 'People' node, after 'David'
+tree.insert('People', 1, {name: 'Judy'});
+```
+
+```tsx
+// Insert an item before another item
+tree.insertAfter('Kangaroo', {name: 'Horse'});
+
+// Insert multiple items before another item
+tree.insertAfter('Kangaroo', {name: 'Horse'}, {name: 'Giraffe'});
+```
+
+```tsx
+// Insert an item after another item
+tree.insertAfter('Kangaroo', {name: 'Horse'});
+
+// Insert multiple items after another item
+tree.insertAfter('Kangaroo', {name: 'Horse'}, {name: 'Giraffe'});
+```
+
+```tsx
+// Append an item to the root
+tree.append(null, {name: 'Plants'});
+
+// Append an item to the 'People' node
+tree.append('People', {name: 'Plants'});
+```
+
+```tsx
+// Prepend an item to the root
+tree.prepend(null, {name: 'Plants'});
+
+// Prepend an item at the start of the 'People' node
+tree.prepend('People', {name: 'Plants'});
+```
+
+### Removing items
+
+```tsx
+// Remove an item
+list.remove('Kangaroo');
+
+// Remove multiple items
+list.remove('Kangaroo', 'Snake');
+```
+
+```tsx
+// Remove all selected items
+list.removeSelectedItems();
+```
+
+### Moving items
+
+```tsx
+// Move an item within the same parent
+tree.move('Sam', 'People', 0);
+
+// Move an item to a different parent
+tree.move('Sam', 'Animals', 1);
+```
+
+### Updating items
+
+```tsx
+tree.update('Sam', {name: 'Samantha'});
+```

--- a/packages/@react-stately/data/docs/useTreeData.mdx
+++ b/packages/@react-stately/data/docs/useTreeData.mdx
@@ -95,7 +95,7 @@ let tree = useTreeData({
 
 ### Inserting items
 
-To insert a new item into the tree, use the `insert` method or use one of the convenience methods.
+To insert a new item into the tree, use the `insert` method or use one of the other convenience methods.
 Pass a `parentKey` to insert into, or `null` to insert a root item.
 
 ```tsx

--- a/packages/@react-stately/data/src/useListData.ts
+++ b/packages/@react-stately/data/src/useListData.ts
@@ -30,7 +30,7 @@ interface ListData<T extends object> {
 
   /**
    * Gets an item from the list by key.
-   * @param key 
+   * @param key - the key of the item to retrieve.
    */
   getItem(key: Key): T,
 

--- a/packages/@react-stately/data/src/useTreeData.ts
+++ b/packages/@react-stately/data/src/useTreeData.ts
@@ -38,7 +38,7 @@ interface TreeData<T extends object> {
 
   /**
    * Gets a node from the tree by key.
-   * @param key 
+   * @param key - the key of the item to retrieve.
    */
   getItem(key: Key): TreeNode<T>,
 

--- a/packages/@react-stately/dialog/docs/useDialogTriggerState.mdx
+++ b/packages/@react-stately/dialog/docs/useDialogTriggerState.mdx
@@ -1,0 +1,35 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/dialog';
+import {ClassAPI, HeaderInfo, FunctionAPI} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Overlays
+---
+
+# useDialogTriggerState
+
+<p>{docs.exports.useDialogTriggerState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useDialogTriggerState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useDialogTriggerState} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useDialogTriggerState.return.id]} />

--- a/packages/@react-stately/dialog/src/useDialogTriggerState.ts
+++ b/packages/@react-stately/dialog/src/useDialogTriggerState.ts
@@ -14,13 +14,22 @@ import {DialogTriggerProps} from '@react-types/dialog';
 import {useControlledState} from '@react-stately/utils';
 
 export interface DialogTriggerState {
+  /** Whether the dialog is currently open. */
   isOpen: boolean,
+  /** Sets whether the dialog is open. */
   setOpen: (value: boolean) => void,
+  /** Opens the dialog. */
   open(): void,
+  /** Closes the dialog. */
   close(): void,
+  /** Toggles the dialog's visibility. */
   toggle(): void
 }
 
+/**
+ * Manages state for a dialog trigger. Tracks whether the dialog is open, and provides
+ * methods to toggle this state.
+ */
 export function useDialogTriggerState(props: DialogTriggerProps): DialogTriggerState  {
   let [isOpen, setOpen] = useControlledState(props.isOpen, props.defaultOpen || false, props.onOpenChange);
 

--- a/packages/@react-stately/list/docs/useListState.mdx
+++ b/packages/@react-stately/list/docs/useListState.mdx
@@ -1,0 +1,41 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/list';
+import {HeaderInfo, TypeContext, InterfaceType, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Collections
+---
+
+# useListState
+
+<p>{docs.exports.useListState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useListState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useListState} links={docs.links} />
+
+## Interface
+
+<TypeContext.Provider value={docs.links}>
+  <InterfaceType properties={docs.links[docs.exports.useListState.return.base.id].properties} />
+</TypeContext.Provider>
+
+## Example
+
+See the docs for [useListBox](/react-aria/useListBox.html) in react-aria for an example of `useListState`.

--- a/packages/@react-stately/menu/docs/useMenuTriggerState.mdx
+++ b/packages/@react-stately/menu/docs/useMenuTriggerState.mdx
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/menu';
+import {ClassAPI, HeaderInfo, TypeContext, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Overlays
+---
+
+# useMenuTriggerState
+
+<p>{docs.exports.useMenuTriggerState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useMenuTriggerState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useMenuTriggerState} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useMenuTriggerState.return.id]} />
+
+## Example
+
+See the docs for [useMenuTrigger](/react-aria/useMenuTrigger.html) in react-aria for an example of `useMenuTriggerState`.

--- a/packages/@react-stately/radio/docs/useRadioGroupState.mdx
+++ b/packages/@react-stately/radio/docs/useRadioGroupState.mdx
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/radio';
+import {ClassAPI, HeaderInfo, TypeContext, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Forms
+---
+
+# useRadioGroupState
+
+<p>{docs.exports.useRadioGroupState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useRadioGroupState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useRadioGroupState} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useRadioGroupState.return.id]} />
+
+## Example
+
+See the docs for [useRadioGroup](/react-aria/useRadioGroup.html) in react-aria for an example of `useRadioGroupState`.

--- a/packages/@react-stately/searchfield/docs/useSearchFieldState.mdx
+++ b/packages/@react-stately/searchfield/docs/useSearchFieldState.mdx
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/searchfield';
+import {ClassAPI, HeaderInfo, TypeContext, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Forms
+---
+
+# useSearchFieldState
+
+<p>{docs.exports.useSearchFieldState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useSearchFieldState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useSearchFieldState} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useSearchFieldState.return.id]} />
+
+## Example
+
+See the docs for [useSearchField](/react-aria/useSearchField.html) in react-aria for an example of `useSearchField`.

--- a/packages/@react-stately/select/docs/useSelectState.mdx
+++ b/packages/@react-stately/select/docs/useSelectState.mdx
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/select';
+import {ClassAPI, HeaderInfo, TypeContext, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Forms
+---
+
+# useSelectState
+
+<p>{docs.exports.useSelectState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useSelectState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useSelectState} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useSelectState.return.base.id]} />
+
+## Example
+
+See the docs for [useSelect](/react-aria/useSelect.html) in react-aria for an example of `useSelectState`.

--- a/packages/@react-stately/selection/docs/SelectionManager.mdx
+++ b/packages/@react-stately/selection/docs/SelectionManager.mdx
@@ -1,0 +1,56 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/selection';
+import collectionsDocs from 'docs:@react-stately/collections';
+import ariaDocs from 'docs:@react-aria/selection';
+import listDocs from 'docs:@react-stately/list';
+import treeDocs from 'docs:@react-stately/tree';
+import {HeaderInfo, ClassAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+```jsx import
+import '@react-spectrum/docs/src/client';
+```
+
+---
+category: Selection
+---
+
+# SelectionManager
+
+<p>{docs.exports.SelectionManager.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['SelectionManager']} />
+
+## Introduction
+
+A <TypeLink links={docs.links} type={docs.exports.SelectionManager} /> provides a generic interface for reading and
+updating selection and focus state based on a <TypeLink links={collectionsDocs.links} type={collectionsDocs.exports.Collection} />.
+As discussed in the [selection introduction](selection.html), a selection is represented
+by a [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) of item keys. Focus
+is represented by a single item key.
+
+Focus state is updated when navigating a collection with the keyboard. Selection state is updated when a user
+clicks or taps an item, or uses the keyboard to select an item. These interactions are handled by 
+the <TypeLink links={ariaDocs.links} type={ariaDocs.exports.useSelectableCollection} /> hook in [react-aria](/react-aria/index.html).
+
+A `SelectionManager` wraps the state returned by <TypeLink links={docs.links} type={docs.exports.useMultipleSelectionState} />.
+Oftentimes, you won't need to construct these directly because hooks like <TypeLink links={listDocs.links} type={listDocs.exports.useListState} />
+and <TypeLink links={treeDocs.links} type={treeDocs.exports.useTreeState} /> already handle this and return
+a `SelectionManager` for you.
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.exports.SelectionManager} />

--- a/packages/@react-stately/selection/docs/selection.mdx
+++ b/packages/@react-stately/selection/docs/selection.mdx
@@ -1,0 +1,133 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/selection';
+import dataDocs from 'docs:@react-stately/data';
+import {HeaderInfo, PropTable, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Selection
+---
+
+# Selection
+
+Many [collection components](collections.html) support selecting items by clicking or tapping them, or by using the keyboard.
+This page discusses how to handle selection events, how to control selection programmatically, and the
+data structures used to represent a selection.
+
+## Multiple Selection
+
+Selection is handled by the `onSelectionChange` event, which is supported on most collection components. Controlled
+behavior is supported by the `selectedKeys` prop, and uncontrolled behavior is supported by the `defaultSelectedKeys`
+prop. These props are passed to the top-level collection component, and accept a set of unique item keys that are selected.
+This allows marking items as selected by their key even before they are loaded, which can be useful when you know
+what items should be selected on initial render, before data loading has completed.
+
+Selection is represented by a [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
+object. You can also pass any iterable collection (e.g. an array) to the `selectedKeys` and `defaultSelectedKeys` props,
+but the `onSelectionChange` event will always pass back a Set.
+
+Selection is supported on both [static](collections.html#static-collections) and [dynamic](collections.html#dynamic-collections) 
+collections. The following example show how to implement controlled selection
+behavior on a static collection, but could be applied to a dynamic collection the same way.
+
+```tsx
+let [selectedKeys, setSelectedKeys] = useState(new Set());
+
+<ListBox selectedKeys={selectedKeys} onSelectionChange={setSelectedKeys}>
+  <Item uniqueKey="one">One</Item>
+  <Item uniqueKey="two">Two</Item>
+  <Item uniqueKey="three">Three</Item>
+</ListBox>
+```
+
+## Single selection
+
+So far, we've discussed multiple selection. However, you may wish to limit selection to a single item instead.
+In some components, like a select or combo box, only single selection is supported. In this case, the singular 
+`selectedKey` and `defaultSelectedKey` props are available instead of their plural variants. These accept a 
+single key instead of a Set as their value, and `onSelectionChange` is also called with a single key.
+
+```tsx
+let [selectedKey, setSelectedKey] = useState(null);
+
+<ComboBox selectedKey={selectedKey} onSelectionChange={setSelectedKey}>
+  <Item uniqueKey="one">One</Item>
+  <Item uniqueKey="two">Two</Item>
+  <Item uniqueKey="three">Three</Item>
+</ComboBox>
+```
+
+In components which support multiple selection, you can limit the selection to a single item using the
+`selectionMode` prop. This continues to accept `selectedKeys` and `defaultSelectedKeys` as a Set, but it will
+only contain a single key at a time.
+
+```tsx
+let [selectedKeys, setSelectedKeys] = useState(new Set());
+
+<ListBox 
+  selectionMode="single"
+  selectedKeys={selectedKeys}
+  onSelectionChange={setSelectedKeys}>
+  <Item uniqueKey="one">One</Item>
+  <Item uniqueKey="two">Two</Item>
+  <Item uniqueKey="three">Three</Item>
+</ListBox>
+```
+
+## Select All
+
+Some components support a checkbox to select all items in the collection, or a keyboard shortcut like <kbd>⌘ Cmd</kbd> + <kbd>A</kbd>.
+This represents a selection of all items in the collection, regardless of whether or not all items have been loaded from the network.
+For example, when using a component with infinite scrolling support, the user will be unaware that all items are not yet loaded because
+it loads more transparently to them as they scroll down. For this reason, it makes sense for select all to represent all items, not just
+the loaded ones.
+
+When a select all event occurs, a special flag is set on the selection object: `isSelectAll`. When this is set, the selection represents
+all items in the collection, whether currently loaded or not. The application must adjust its handling of bulk actions in this case
+to apply to the entire collection rather than only the keys available to it locally.
+
+TODO: example
+
+## Dynamic data
+
+When data in a collection changes, the selection state may need to be updated accordingly. For example, if a selected item is
+deleted, it should be removed from the set of selected keys. You can do this yourself, but the <TypeLink links={dataDocs.links} type={dataDocs.exports.useListData} />
+and <TypeLink links={dataDocs.links} type={dataDocs.exports.useTreeData} /> hooks can handle this automatically.
+
+```tsx
+let list = useListData({
+  initialItems: [
+    {name: 'Aardvark'},
+    {name: 'Kangaroo'},
+    {name: 'Snake'}
+  ],
+  initialSelectedKeys: ['Kangaroo'],
+  getKey: item => item.name
+});
+
+function removeItem() {
+  // Removing the list item will also remove it from the selection state.
+  list.remove('Kangaroo');
+}
+
+<ListBox
+  items={list.items}
+  itemKey="name"
+  selectedKeys={list.selectedKeys}
+  onSelectionChange={list.setSelectedKeys}>
+  {item => <Item>{item.name}</Item>}
+</ListBox>
+```
+
+For more information, see [useListData](useListData.html) and [useTreeData](useTreeData.html).

--- a/packages/@react-stately/selection/docs/useMultipleSelectionState.mdx
+++ b/packages/@react-stately/selection/docs/useMultipleSelectionState.mdx
@@ -1,0 +1,50 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/selection';
+import listDocs from 'docs:@react-stately/list';
+import selectDocs from 'docs:@react-stately/select';
+import {HeaderInfo, ClassAPI, FunctionAPI, TypeContext, InterfaceType, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+```jsx import
+import '@react-spectrum/docs/src/client';
+```
+
+---
+category: Selection
+---
+
+# useMultipleSelectionState
+
+<p>{docs.exports.useMultipleSelectionState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useMultipleSelectionState']} />
+
+## Introduction
+
+`useMultipleSelectionState` manages selection state for many components. Oftentimes, you won't
+need to use this hook directly, since it's included in hooks 
+like <TypeLink links={listDocs.links} type={listDocs.exports.useListState} />,
+and <TypeLink links={selectDocs.links} type={selectDocs.exports.useSelectState} />.
+These expose a [SelectionManager](SelectionManager.html), which provides a higher level way
+to manipulate selection state.
+
+## API
+
+<FunctionAPI links={docs.links} function={docs.exports.useMultipleSelectionState} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useMultipleSelectionState.return.id]} />

--- a/packages/@react-stately/selection/src/SelectionManager.ts
+++ b/packages/@react-stately/selection/src/SelectionManager.ts
@@ -36,43 +36,77 @@ export class SelectionManager implements MultipleSelectionManager {
     this._isSelectAll = null;
   }
 
+  /**
+   * The type of selection that is allowed in the collection.
+   */
   get selectionMode(): SelectionMode {
     return this.state.selectionMode;
   }
 
+  /**
+   * Whether the collection is currently focused.
+   */
   get isFocused(): boolean {
     return this.state.isFocused;
   }
 
+  /**
+   * Sets whether the collection is focused.
+   */
   setFocused(isFocused: boolean) {
     this.state.setFocused(isFocused);
   }
 
+  /**
+   * The current focused key in the collection.
+   */
   get focusedKey(): Key {
     return this.state.focusedKey;
   }
 
+  /**
+   * Sets the focused key.
+   */
   setFocusedKey(key: Key) {
     this.state.setFocusedKey(key);
   }
 
+  /**
+   *The currently selected keys in the collection.
+   */
   get selectedKeys(): Set<Key> {
     return this.state.selectedKeys;
   }
 
+  /**
+   * Replaces all selected keys in the collection with a new set.
+   */
   setSelectedKeys(keys: Selection) {
     this.state.setSelectedKeys(keys);
   }
 
+  /**
+   * Returns whether a key is selected.
+   */
   isSelected(key: Key) {
     return this.state.selectedKeys.has(key);
   }
 
+  /**
+   * Whether the selection is empty.
+   */
   get isEmpty() {
     return this.state.selectedKeys.size === 0;
   }
 
+  /**
+   * Whether all items in the collection are selected.
+   */
   get isSelectAll() {
+    if (this.isEmpty) {
+      return false;
+    }
+
     if (this._isSelectAll != null) {
       return this._isSelectAll;
     }
@@ -86,6 +120,9 @@ export class SelectionManager implements MultipleSelectionManager {
     return this._isSelectAll;
   }
 
+  /**
+   * Extends the selection to the given key.
+   */
   extendSelection(toKey: Key) {
     toKey = this.getKey(toKey);
     this.state.setSelectedKeys((selectedKeys: Selection) => {
@@ -160,6 +197,9 @@ export class SelectionManager implements MultipleSelectionManager {
     return item.key;
   }
 
+  /**
+   * Toggles whether the given key is selected.
+   */
   toggleSelection(key: Key) {
     key = this.getKey(key);
     if (key == null) {
@@ -182,6 +222,9 @@ export class SelectionManager implements MultipleSelectionManager {
     });
   }
 
+  /**
+   * Replaces the selection with only the given key.
+   */
   replaceSelection(key: Key) {
     key = this.getKey(key);
     if (key == null) {
@@ -213,15 +256,24 @@ export class SelectionManager implements MultipleSelectionManager {
     return keys;
   }
 
+  /**
+   * Selects all items in the collection.
+   */
   selectAll() {
     let keys = this.getSelectAllKeys();
     this.state.setSelectedKeys(new Selection(keys, keys[0], keys[keys.length - 1]));
   }
 
+  /**
+   * Removes all keys from the selection.
+   */
   clearSelection() {
     this.state.setSelectedKeys(new Selection());
   }
 
+  /**
+   * Toggles between select all and an empty selection.
+   */
   toggleSelectAll() {
     if (this.isSelectAll) {
       this.clearSelection();

--- a/packages/@react-stately/selection/src/SelectionManager.ts
+++ b/packages/@react-stately/selection/src/SelectionManager.ts
@@ -72,7 +72,7 @@ export class SelectionManager implements MultipleSelectionManager {
   }
 
   /**
-   *The currently selected keys in the collection.
+   * The currently selected keys in the collection.
    */
   get selectedKeys(): Set<Key> {
     return this.state.selectedKeys;

--- a/packages/@react-stately/toggle/docs/useToggleState.mdx
+++ b/packages/@react-stately/toggle/docs/useToggleState.mdx
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/toggle';
+import {ClassAPI, HeaderInfo, TypeContext, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Forms
+---
+
+# useToggleState
+
+<p>{docs.exports.useToggleState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useToggleState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useToggleState} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useToggleState.return.id]} />
+
+## Example
+
+See the docs for [useCheckbox](/react-aria/useCheckbox.html) in react-aria for an example of `useToggleState`.

--- a/packages/@react-stately/tree/docs/useTreeState.mdx
+++ b/packages/@react-stately/tree/docs/useTreeState.mdx
@@ -1,0 +1,39 @@
+<!-- Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License. -->
+
+import {Layout} from '@react-spectrum/docs';
+export default Layout;
+
+import docs from 'docs:@react-stately/tree';
+import {ClassAPI, HeaderInfo, TypeContext, FunctionAPI, TypeLink} from '@react-spectrum/docs';
+import packageData from '../package.json';
+
+---
+category: Collections
+---
+
+# useTreeState
+
+<p>{docs.exports.useTreeState.description}</p>
+
+<HeaderInfo
+  packageData={packageData}
+  componentNames={['useTreeState']} />
+
+## API
+
+<FunctionAPI function={docs.exports.useTreeState} links={docs.links} />
+
+## Interface
+
+<ClassAPI links={docs.links} class={docs.links[docs.exports.useTreeState.return.base.id]} />
+
+## Example
+
+See the docs for [useMenu](/react-aria/useMenu.html) in react-aria for an example of `useTreeState`.

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -13,12 +13,22 @@
 import {Key, ReactElement, ReactNode} from 'react';
 
 export interface ItemProps<T> {
-  title?: ReactNode, // label?? contents?
-  childItems?: Iterable<T>,
-  hasChildItems?: boolean,
+  /** Rendered contents of the item or child items. */
   children: ReactNode,
+  /** Rendered contents of the item if `children` contains child items. */
+  title?: ReactNode, // label?? contents?
+  /** A string representation of the item's contents, used for features like typeahead. */
   textValue?: string,
-  'aria-label'?: string,
+  /** An accessibility label for this item. */
+  'aria-label'?: string,  
+  /** 
+   * Child items of this item. The function that rendered 
+   * this items will be called recursively to render each one.
+   * */
+  childItems?: Iterable<T>,
+  /** Whether this item has children, even if not loaded yet. */
+  hasChildItems?: boolean,
+  /** A unique key for this item. */
   uniqueKey?: Key
 }
 
@@ -26,16 +36,24 @@ export type ItemElement<T> = ReactElement<ItemProps<T>>;
 export type ItemRenderer<T> = (item: T) => ItemElement<T>;
 
 interface AsyncLoadable<T> {
+  /** Item objects in the collection or section. */
   items?: Iterable<T>,
+  /** Property name on each item object to use as the unique key. `id` or `key` by default. */
   itemKey?: string,
+  /** Whether the items are currently loading. */
   isLoading?: boolean, // possibly isLoadingMore
+  /** Handler that is called when more items should be loaded, e.g. while scrolling near the bottom. */
   onLoadMore?: () => any
 }
 
 export interface SectionProps<T> extends AsyncLoadable<T> {
+  /** Rendered contents of the section, e.g. a header. */
   title?: ReactNode,
+  /** An accessibility label for the section. */
   'aria-label'?: string,
+  /** Static child items or a function to render children. */
   children: ItemElement<T> | ItemElement<T>[] | ItemRenderer<T>,
+  /** A unique key for the section. */
   uniqueKey?: Key
 }
 
@@ -44,38 +62,55 @@ export type SectionElement<T> = ReactElement<SectionProps<T>>;
 export type CollectionElement<T> = SectionElement<T> | ItemElement<T>;
 export type CollectionChildren<T> = CollectionElement<T> | CollectionElement<T>[] | ((item: T) => CollectionElement<T>);
 export interface CollectionBase<T> extends AsyncLoadable<T> {
+  /** The contents of the collection. */
   children: CollectionChildren<T>,
+  /** They item keys that are disabled. These items cannot be selected, focused, or otherwise interacted with. */
   disabledKeys?: Iterable<Key>
 }
 
 export interface SingleSelection {
+  /** The currently selected key in the collection (controlled). */
   selectedKey?: Key,
+  /** The initial selected key in the collection (uncontrolled). */
   defaultSelectedKey?: Key,
+  /** Handler that is called when the selection changes. */
   onSelectionChange?: (key: Key) => any
 }
 
 export type SelectionMode = 'none' | 'single' | 'multiple';
 export interface MultipleSelection {
+  /** The type of selection that is allowed in the collection. */
   selectionMode?: SelectionMode,
+  /** The currently selected keys in the collection (controlled). */
   selectedKeys?: Iterable<Key>,
+  /** The initial selected keys in the collection (uncontrolled). */
   defaultSelectedKeys?: Iterable<Key>,
+  /** Handler that is called when the selection changes. */
   onSelectionChange?: (keys: Set<Key>) => any
 }
 
 export interface Expandable {
+  /** The currently expanded keys in the collection (controlled). */
   expandedKeys?: Iterable<Key>,
+  /** The initial expanded keys in the collection (uncontrolled). */
   defaultExpandedKeys?: Iterable<Key>,
+  /** Handler that is called when items are expanded or collapsed. */
   onExpandedChange?: (keys: Set<Key>) => any
 }
 
 export interface Sortable {
+  /** The current sorted column and direction (controlled). */
   sortDescriptor?: SortDescriptor,
+  /** The initial sorted column and direction (uncontrolled). */
   defaultSortDescriptor?: SortDescriptor,
+  /** Handler that is called when the sorted column or direction changes. */
   onSortChange?: (descriptor: SortDescriptor) => any
 }
 
 export interface SortDescriptor {
-  column?: string,
+  /** The key of the column to sort by. */
+  column?: Key,
+  /** The direction to sort by. */
   direction?: SortDirection
 }
 

--- a/packages/dev/docs/src/ClassAPI.js
+++ b/packages/dev/docs/src/ClassAPI.js
@@ -10,13 +10,13 @@
  * governing permissions and limitations under the License.
  */
 
-export * from './Image';
-export * from './Highlights';
-export * from './Layout';
-export * from './PropTable';
-export * from './HeaderInfo';
-export * from './ResourceCard';
-export * from './types';
-export * from './FunctionAPI';
-export * from './TypeLink';
-export * from './ClassAPI';
+import {InterfaceType, TypeContext} from './types';
+import React from 'react';
+
+export function ClassAPI({class: c, links}) {
+  return (
+    <TypeContext.Provider value={links}>
+      <InterfaceType {...c} />
+    </TypeContext.Provider>
+  );
+}

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -95,15 +95,18 @@ function Page({children, title, styles, scripts}) {
         <script
           dangerouslySetInnerHTML={{__html: `(() => {
             let classList = document.documentElement.classList;
+            let style = document.documentElement.style;
             let dark = window.matchMedia('(prefers-color-scheme: dark)');
             let fine = window.matchMedia('(any-pointer: fine)');
             let update = () => {
               if (localStorage.theme === "dark" || (!localStorage.theme && dark.matches)) {
                 classList.remove("${theme.light['spectrum--light']}");
                 classList.add("${theme.dark['spectrum--dark']}");
+                style.colorScheme = 'dark';
               } else {
                 classList.add("${theme.light['spectrum--light']}");
                 classList.remove("${theme.dark['spectrum--dark']}");
+                style.colorScheme = 'light';
               }
 
               if (!fine.matches) {
@@ -218,7 +221,7 @@ function Nav({currentPageName, pages}) {
           <li className={sideNavStyles['spectrum-SideNav-item']}>
             <h3 className={sideNavStyles['spectrum-SideNav-heading']}>{key}</h3>
             <ul className={sideNavStyles['spectrum-SideNav']}>
-              {pageMap[key].map(p => <SideNavItem {...p} />)}
+              {pageMap[key].sort((a, b) => a.title < b.title ? -1 : 1).map(p => <SideNavItem {...p} />)}
             </ul>
           </li>
         ))}

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -18,6 +18,7 @@ html, body {
   min-width: 100vw;
   min-height: 100vh;
   background: var(--spectrum-global-color-gray-50) !important;
+  color-scheme: light dark;
 }
 
 .exampleImage {
@@ -224,11 +225,15 @@ article.inCategory h2.sectionHeader + hr {
 }
 
 article pre {
-  margin-bottom: 0;
   background: var(--spectrum-global-color-gray-75);
   padding: 18px;
-  border-radius: 4px 4px 0 0;
+  border-radius: 4px;
   overflow-x: auto;
+}
+
+article pre:global(.example) {
+  border-radius: 4px 4px 0 0;
+  margin-bottom: 0;
 }
 
 code {
@@ -237,6 +242,15 @@ code {
 
 article > code {
   display: block;
+}
+
+article kbd {
+  font-family: var(--spectrum-font-family-base);
+  background: var(--spectrum-global-color-gray-300);
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin: 0 2px;
+  font-size: 0.95em;
 }
 
 .header {
@@ -356,6 +370,57 @@ h2.sectionHeader {
   }
 }
 
+@define-mixin small-propTable {
+  /* Collapse the prop table into a list with key/value pairs */
+  .propTable tr {
+    display: table;
+    width: 100%;
+    padding: 8px 0;
+  }
+
+  .propTable td {
+    display: table-row;
+  }
+
+  .propTable thead {
+    display: none;
+  }
+
+  .propTable td[data-column] code {
+    display: inline-block;
+    vertical-align: text-top;
+    word-break: break-word;
+    width: calc(100% - 80px);
+  }
+
+  .propTable td[data-column]:before {
+    content: attr(data-column);
+    font-size: var(--spectrum-table-header-text-size);
+    font-weight: var(--spectrum-table-header-text-font-weight);
+    min-height: var(--spectrum-table-header-min-height);
+    letter-spacing: var(--spectrum-table-header-text-letter-spacing);
+    color: var(--spectrum-table-header-text-color);
+    text-transform: uppercase;
+    width: 80px;
+    display: inline-block;
+    vertical-align: middle;
+    padding: 8px 0;
+  }
+
+  .noDefault {
+    text-align: left;
+  }
+
+  .methodTable td[data-column]:before {
+    display: none;
+  }
+
+  .methodTable td > span {
+    display: block;
+    padding-top: 8px;
+  }
+}
+
 @media (max-width: 1020px) {
   /* Turn the sidenav into a hamburger menu */
   .nav {
@@ -408,43 +473,9 @@ h2.sectionHeader {
     max-width: initial !important;
   }
 
-  /* Collapse the prop table into a list with key/value pairs */
-  .propTable tr {
-    display: table;
-    width: 100%;
-    padding: 8px 0;
-  }
+  @mixin small-propTable;
+}
 
-  .propTable td {
-    display: table-row;
-  }
-
-  .propTable thead {
-    display: none;
-  }
-
-  .propTable td[data-column] code {
-    display: inline-block;
-    vertical-align: text-top;
-    word-break: break-word;
-    width: calc(100% - 80px);
-  }
-
-  .propTable td[data-column]:before {
-    content: attr(data-column);
-    font-size: var(--spectrum-table-header-text-size);
-    font-weight: var(--spectrum-table-header-text-font-weight);
-    min-height: var(--spectrum-table-header-min-height);
-    letter-spacing: var(--spectrum-table-header-text-letter-spacing);
-    color: var(--spectrum-table-header-text-color);
-    text-transform: uppercase;
-    width: 80px;
-    display: inline-block;
-    vertical-align: middle;
-    padding: 8px 0;
-  }
-
-  .noDefault {
-    text-align: left;
-  }
+.popover {
+  @mixin small-propTable;
 }

--- a/packages/dev/docs/src/docs.js
+++ b/packages/dev/docs/src/docs.js
@@ -55,7 +55,7 @@ function LinkPopover({id}) {
   }, [breadcrumbs]);
 
   return (
-    <Dialog UNSAFE_className={highlightCss.spectrum} size="L">
+    <Dialog UNSAFE_className={`${highlightCss.spectrum} ${docsStyle.popover}`} size="L">
       <View slot="heading">
         <Breadcrumbs isHeading headingAriaLevel={3} onAction={(key) => setBreadcrumbs(breadcrumbs.slice(0, key))}>
           {breadcrumbs.map((b, i) => (

--- a/packages/dev/docs/src/syntax-highlight.css
+++ b/packages/dev/docs/src/syntax-highlight.css
@@ -142,6 +142,10 @@
   padding: 0;
 }
 
+:global(.constant) {
+  color: var(--hljs-literal-color);
+}
+
 :global(.storage.type),
 :global(.constant.color),
 :global(.support.property-value.css) {
@@ -170,10 +174,6 @@
 
 :global(.punctuation.section) {
   color: var(--hljs-title-color);
-}
-
-:global(.constant.numeric) {
-  color: var(--hljs-literal-color);
 }
 
 :global(.variable.other.object.property) {

--- a/packages/dev/parcel-transformer-docs/DocsTransformer.js
+++ b/packages/dev/parcel-transformer-docs/DocsTransformer.js
@@ -168,13 +168,7 @@ module.exports = new Transformer({
         } else {
           value = {
             type: 'function',
-            parameters: path.get('params').map(p => ({
-              type: 'parameter',
-              name: p.node.name,
-              value: p.node.typeAnnotation
-                ? processExport(p.get('typeAnnotation.typeAnnotation'))
-                : {type: 'any'}
-            })),
+            parameters: path.get('params').map(processParameter),
             return: path.node.returnType
               ? processExport(path.get('returnType.typeAnnotation'))
               : {type: 'void'},
@@ -185,7 +179,7 @@ module.exports = new Transformer({
         }
 
         return Object.assign(node, addDocs({
-          type: 'property',
+          type: value.type === 'function' ? 'method' : 'property',
           name,
           value
         }, docs));
@@ -210,13 +204,7 @@ module.exports = new Transformer({
             type: 'function',
             id: path.node.id ? `${asset.filePath}:${path.node.id.name}` : null,
             name: path.node.id ? path.node.id.name : null,
-            parameters: path.get('params').map(p => ({
-              type: 'parameter',
-              name: p.node.name,
-              value: p.node.typeAnnotation
-                ? processExport(p.get('typeAnnotation.typeAnnotation'))
-                : {type: 'any'}
-            })),
+            parameters: path.get('params').map(processParameter),
             return: path.node.returnType
               ? processExport(path.get('returnType.typeAnnotation'))
               : {type: 'any'},
@@ -326,15 +314,11 @@ module.exports = new Transformer({
         let name = t.isStringLiteral(path.node.key) ? path.node.key.value : path.node.key.name;
         let docs = getJSDocs(path);
         return Object.assign(node, addDocs({
-          type: 'property',
+          type: 'method',
           name,
           value: {
             type: 'function',
-            parameters: path.get('parameters').map(p => ({
-              type: 'parameter',
-              name: p.node.name,
-              value: processExport(p.get('typeAnnotation.typeAnnotation'))
-            })),
+            parameters: path.get('parameters').map(processParameter),
             return: path.node.typeAnnotation
               ? processExport(path.get('typeAnnotation.typeAnnotation'))
               : {type: 'any'},
@@ -429,11 +413,7 @@ module.exports = new Transformer({
       if (path.isTSFunctionType() || path.isTSConstructorType()) {
         return Object.assign(node, {
           type: 'function',
-          parameters: path.get('parameters').map(p => ({
-            type: 'parameter',
-            name: p.node.name,
-            value: p.node.typeAnnotation ? processExport(p.get('typeAnnotation.typeAnnotation')) : {type: 'any'}
-          })),
+          parameters: path.get('parameters').map(processParameter),
           return: path.node.typeAnnotation ? processExport(path.get('typeAnnotation.typeAnnotation')) : {type: 'any'},
           typeParameters: path.node.typeParameters ? path.get('typeParameters.params').map(p => processExport(p)) : []
         });
@@ -455,6 +435,15 @@ module.exports = new Transformer({
       }
 
       console.log('UNKNOWN TYPE', path.node.type);
+    }
+
+    function processParameter(p) {
+      return {
+        type: 'parameter',
+        name: p.isRestElement() ? p.node.argument.name : p.node.name,
+        value: p.node.typeAnnotation ? processExport(p.get('typeAnnotation.typeAnnotation')) : {type: 'any'},
+        rest: p.isRestElement()
+      };
     }
 
     function processExport(path, node = {}) {
@@ -582,7 +571,7 @@ module.exports = new Transformer({
         value.access = docs.access;
       }
 
-      if (value.type === 'property') {
+      if (value.type === 'property' || value.type === 'method') {
         value.default = docs.default || value.default || null;
         if (value.value && value.value.type === 'function') {
           addFunctionDocs(value.value, docs);

--- a/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXTransformer.js
@@ -140,6 +140,21 @@ module.exports = new Transformer({
       return transformer;
     };
 
+    // Adds an `example` class to `pre` tags followed by examples.
+    // This allows us to remove the bottom rounded corners, but only when
+    // there is a rendered example below.
+    function wrapExamples() {
+      return (tree) => (
+        flatMap(tree, node => {
+          if (node.tagName === 'pre' && node.children && node.children.length > 0 && node.children[0].tagName === 'code' && node.children[0].properties.metastring === 'example') {
+            node.properties.className = ['example'];
+          }
+
+          return [node];
+        })
+      );
+    }
+
     const compiled = await mdx(await asset.getCode(), {
       remarkPlugins: [
         slug,
@@ -157,6 +172,9 @@ module.exports = new Transformer({
           }
         ],
         fragmentUnWrap
+      ],
+      rehypePlugins: [
+        wrapExamples
       ]
     });
 


### PR DESCRIPTION
This documents many hooks in react-stately. Most of them just show the API and point to react-aria for an example of using them in context. There are some more in depth pages covering the collections API, collection internals, selection API, and selection internals. Some parts are left as TODOs for later, as they haven't been implemented yet. If they aren't implemented before the release, then we'll need to comment those sections out or something.