### PR TITLE
Support variable row heights in Table and add layout tests

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -126,10 +126,10 @@ governing permissions and limitations under the License.
   box-sizing: border-box;
   font-size: var(--spectrum-table-cell-text-size);
   font-weight: var(--spectrum-table-cell-text-font-weight);
-  line-height: var(--spectrum-table-cell-text-line-height);
+  /* need to subtract 1px here because 14px * 1.5 + 14px + 14px = 49px, and we want 48px */
+  line-height: calc(calc(var(--spectrum-table-cell-text-size) * var(--spectrum-table-cell-text-line-height)) - 1px);
   padding: var(--spectrum-table-cell-padding-y) var(--spectrum-table-cell-padding-x);
-  /* Subtract top/bottom padding for this value to be correct in this implementation */
-  min-height: calc(var(--spectrum-table-cell-min-height) - calc(var(--spectrum-table-cell-padding-y) * 2));
+  min-height: var(--spectrum-table-cell-min-height);
   overflow: hidden;
 }
 

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -27,7 +27,19 @@ import stylesOverrides from './table.css';
 import {TableLayout} from './TableLayout';
 import {useColumnHeader, useGrid, useGridCell, useRow, useRowGroup, useRowHeader, useSelectAllCheckbox, useSelectionCheckbox} from '@react-aria/grid';
 import {useLocale} from '@react-aria/i18n';
-import {useProviderProps} from '@react-spectrum/provider';
+import {useProvider, useProviderProps} from '@react-spectrum/provider';
+
+const MIN_ROW_HEIGHT = 48;
+const MAX_ROW_HEIGHT = 72;
+const DEFAULT_ROW_HEIGHT = {
+  medium: 48,
+  large: 64
+};
+
+const DEFAULT_HEADER_HEIGHT = {
+  medium: 34,
+  large: 40
+};
 
 const TableContext = React.createContext<GridState<unknown>>(null);
 function useTableContext() {
@@ -46,7 +58,22 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
     isVirtualized: true
   }, state);
 
-  let layout = useMemo(() => new TableLayout({}), []);
+  let {scale} = useProvider();
+  let layout = useMemo(() => new TableLayout({
+    // If props.rowHeight is auto, then use estimated heights based on scale, otherwise use fixed heights.
+    rowHeight: props.rowHeight === 'auto' 
+      ? null 
+      : Math.max(MIN_ROW_HEIGHT, Math.min(MAX_ROW_HEIGHT, props.rowHeight)) || DEFAULT_ROW_HEIGHT[scale],
+    estimatedRowHeight: props.rowHeight === 'auto' 
+      ? DEFAULT_ROW_HEIGHT[scale] 
+      : null,
+    headingHeight: props.rowHeight === 'auto' 
+      ? null 
+      : DEFAULT_HEADER_HEIGHT[scale],
+    estimatedHeadingHeight: props.rowHeight === 'auto' 
+      ? DEFAULT_HEADER_HEIGHT[scale] 
+      : null
+  }), [props.rowHeight, scale]);
   let {direction} = useLocale();
   layout.collection = state.collection;
 
@@ -105,7 +132,18 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
         key={reusableView.key}
         reusableView={reusableView}
         parent={parent}
-        className={classNames(styles, 'spectrum-Table-cellWrapper')} />
+        className={
+          classNames(
+            styles,
+            'spectrum-Table-cellWrapper',
+            classNames(
+              stylesOverrides,
+              {
+                'react-spectrum-Table-cellWrapper': !reusableView.layoutInfo.estimatedSize
+              }
+            )
+          )
+        } />
     );
   };
 
@@ -138,6 +176,10 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
             aria-colspan={item.colspan > 1 ? item.colspan : null} />
         );
       case 'column':
+        if (item.props.isSelectionCell) {
+          return <TableSelectAllCell column={item} />;
+        }
+
         return <TableColumnHeader column={item} />;
       case 'loader':
         return (
@@ -280,9 +322,6 @@ function TableColumnHeader({column}) {
     isVirtualized: true
   }, state);
 
-  let isCheckboxCell = state.selectionManager.selectionMode !== 'none' && column.index === 0;
-  let {checkboxProps} = useSelectAllCheckbox(state);
-
   let columnProps = column.props as SpectrumColumnProps<unknown>;
 
   return (
@@ -295,26 +334,56 @@ function TableColumnHeader({column}) {
             styles,
             'spectrum-Table-headCell',
             {
-              'spectrum-Table-checkboxCell': isCheckboxCell,
-              'spectrum-Table-cell--alignCenter': columnProps.align === 'center' || column.colspan > 1,
-              'spectrum-Table-cell--alignEnd': columnProps.align === 'end',
               'is-sortable': columnProps.allowsSorting,
               'is-sorted-desc': state.sortDescriptor?.column === column.key && state.sortDescriptor?.direction === 'descending',
               'is-sorted-asc': state.sortDescriptor?.column === column.key && state.sortDescriptor?.direction === 'ascending'
-            }
+            },
+            classNames(
+              stylesOverrides,
+              'react-spectrum-Table-cell',
+              {
+                'react-spectrum-Table-cell--alignCenter': columnProps.align === 'center' || column.colspan > 1,
+                'react-spectrum-Table-cell--alignEnd': columnProps.align === 'end'  
+              }
+            )
           )
         }>
         {column.rendered}
-        {isCheckboxCell &&
-          <Checkbox
-            {...checkboxProps}
-            UNSAFE_className={classNames(styles, 'spectrum-Table-checkbox')} />
-        }
         {columnProps.allowsSorting &&
           <ArrowDownSmall UNSAFE_className={classNames(styles, 'spectrum-Table-sortedIcon')} />
         }
       </div>
     </FocusRing>
+  );
+}
+
+function TableSelectAllCell({column}) {
+  let ref = useRef();
+  let state = useTableContext();
+  let {columnHeaderProps} = useColumnHeader({
+    node: column,
+    ref,
+    colspan: column.colspan,
+    isVirtualized: true
+  }, state);
+
+  let {checkboxProps} = useSelectAllCheckbox(state);
+
+  return (
+    <div 
+      {...columnHeaderProps}
+      ref={ref}
+      className={
+        classNames(
+          styles,
+          'spectrum-Table-headCell',
+          'spectrum-Table-checkboxCell'
+        )
+      }>
+      <Checkbox
+        {...checkboxProps}
+        UNSAFE_className={classNames(styles, 'spectrum-Table-checkbox')} />
+    </div>
   );
 }
 

--- a/packages/@react-spectrum/table/src/TableLayout.ts
+++ b/packages/@react-spectrum/table/src/TableLayout.ts
@@ -129,12 +129,74 @@ export class TableLayout<T> extends ListLayout<T> {
       columns.push(layoutNode);
     }
 
+    this.setChildHeights(columns, height);
+
     rect.height = height;
     rect.width = x;
 
     return {
       layoutInfo: row,
       children: columns
+    };
+  }
+
+  setChildHeights(children: LayoutNode[], height: number) {
+    for (let child of children) {
+      if (child.layoutInfo.rect.height !== height) {
+        // Need to copy the layout info before we mutate it.
+        child.layoutInfo = child.layoutInfo.copy();
+        this.layoutInfos.set(child.layoutInfo.key, child.layoutInfo);
+
+        child.layoutInfo.rect.height = height;
+      }
+    }
+  }
+
+  getColumnWidth(node: GridNode<T>) {
+    let colspan = node.colspan ?? 1;
+    let width = 0;
+    for (let i = 0; i < colspan; i++) {
+      let column = this.collection.columns[node.index + i];
+      width += this.columnWidths.get(column.key);
+    }
+
+    return width;
+  }
+
+  getEstimatedHeight(node: GridNode<T>, width: number, height: number, estimatedHeight: number) {
+    let isEstimated = false;
+
+    // If no explicit height is available, use an estimated height.
+    if (height == null) {
+      // If a previous version of this layout info exists, reuse its height.
+      // Mark as estimated if the size of the overall collection view changed,
+      // or the content of the item changed.
+      let previousLayoutNode = this.layoutNodes.get(node.key);
+      if (previousLayoutNode) {
+        let curNode = this.collection.getItem(node.key);
+        let lastNode = this.lastCollection ? this.lastCollection.getItem(node.key) : null;
+        height = previousLayoutNode.layoutInfo.rect.height;
+        isEstimated = curNode !== lastNode || width !== previousLayoutNode.layoutInfo.rect.width || previousLayoutNode.layoutInfo.estimatedSize;
+      } else {
+        height = estimatedHeight;
+        isEstimated = true;
+      }
+    }
+
+    return {height, isEstimated};
+  }
+
+  buildColumn(node: GridNode<T>, x: number, y: number): LayoutNode {
+    let width = this.getColumnWidth(node);
+    let {height, isEstimated} = this.getEstimatedHeight(node, width, this.headingHeight, this.estimatedHeadingHeight);
+    let rect = new Rect(x, y, width, height);
+    let layoutInfo = new LayoutInfo(node.type, node.key, rect);
+    layoutInfo.isSticky = node.props?.isSelectionCell;
+    layoutInfo.zIndex = layoutInfo.isSticky ? 2 : 1;
+    layoutInfo.estimatedSize = isEstimated;
+
+    return {
+      layoutInfo
     };
   }
 
@@ -191,9 +253,10 @@ export class TableLayout<T> extends ListLayout<T> {
         return this.buildHeaderRow(node, x, y);
       case 'item':
         return this.buildRow(node, x, y);
-      case 'cell':
-      case 'placeholder':
       case 'column':
+      case 'placeholder':
+        return this.buildColumn(node, x, y);
+      case 'cell':
         return this.buildCell(node, x, y);
       default:
         throw new Error('Unknown node type ' + node.type);
@@ -213,6 +276,8 @@ export class TableLayout<T> extends ListLayout<T> {
       children.push(layoutNode);
     }
 
+    this.setChildHeights(children, height);
+
     rect.width = x;
     rect.height = height + 1; // +1 for bottom border
 
@@ -223,17 +288,13 @@ export class TableLayout<T> extends ListLayout<T> {
   }
 
   buildCell(node: GridNode<T>, x: number, y: number): LayoutNode {
-    let colspan = node.colspan ?? 1;
-    let width = 0;
-    for (let i = 0; i < colspan; i++) {
-      let column = this.collection.columns[node.index + i];
-      width += this.columnWidths.get(column.key);
-    }
-
-    let rect = new Rect(x, y, width, node.type === 'column' || node.type === 'placeholder' ? 34 : 50);
+    let width = this.getColumnWidth(node);
+    let {height, isEstimated} = this.getEstimatedHeight(node, width, this.rowHeight, this.estimatedRowHeight);
+    let rect = new Rect(x, y, width, height);
     let layoutInfo = new LayoutInfo(node.type, node.key, rect);
     layoutInfo.isSticky = node.props?.isSelectionCell;
     layoutInfo.zIndex = layoutInfo.isSticky ? 2 : 1;
+    layoutInfo.estimatedSize = isEstimated;
 
     return {
       layoutInfo

--- a/packages/@react-spectrum/table/src/table.css
+++ b/packages/@react-spectrum/table/src/table.css
@@ -18,6 +18,9 @@
 .react-spectrum-Table-cell {
   display: flex;
   align-items: center;
+}
+
+.react-spectrum-Table-cellWrapper > .react-spectrum-Table-cell {
   height: 100%;
 }
 

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -157,7 +157,7 @@ storiesOf('Table', module)
   .add(
     'dynamic with nested columns',
     () => (
-      <Table width={700} height={300} onSelectionChange={s => onSelectionChange([...s])}>
+      <Table width={700} height={300} rowHeight="auto" onSelectionChange={s => onSelectionChange([...s])}>
         <TableHeader columns={nestedColumns} columnKey="key">
           {column =>
             <Column childColumns={column.children}>{column.name}</Column>
@@ -271,6 +271,54 @@ storiesOf('Table', module)
         <TableBody>
           <Row>
             <Cell>2018 Proposal</Cell>
+            <Cell>PDF</Cell>
+            <Cell>214 KB</Cell>
+          </Row>
+          <Row>
+            <Cell>Budget</Cell>
+            <Cell>XLS</Cell>
+            <Cell>120 KB</Cell>
+          </Row>
+        </TableBody>
+      </Table>
+    )
+  )
+  .add(
+    'rowHeight=72',
+    () => (
+      <Table width={500} height={200} isQuiet rowHeight={80} onSelectionChange={s => onSelectionChange([...s])}>
+        <TableHeader>
+          <Column width={250} showDivider>File Name</Column>
+          <Column>Type</Column>
+          <Column align="end">Size</Column>
+        </TableHeader>
+        <TableBody>
+          <Row>
+            <Cell>2018 Proposal</Cell>
+            <Cell>PDF</Cell>
+            <Cell>214 KB</Cell>
+          </Row>
+          <Row>
+            <Cell>Budget</Cell>
+            <Cell>XLS</Cell>
+            <Cell>120 KB</Cell>
+          </Row>
+        </TableBody>
+      </Table>
+    )
+  )
+  .add(
+    'rowHeight=auto',
+    () => (
+      <Table width={500} height={300} isQuiet rowHeight="auto" onSelectionChange={s => onSelectionChange([...s])}>
+        <TableHeader>
+          <Column width={250} showDivider>File Name</Column>
+          <Column>Type</Column>
+          <Column align="end">Size</Column>
+        </TableHeader>
+        <TableBody>
+          <Row>
+            <Cell>2018 Proposal with very very very very very very long long long long long filename</Cell>
             <Cell>PDF</Cell>
             <Cell>214 KB</Cell>
           </Row>

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, cleanup, fireEvent, render as renderComponent, within} from '@testing-library/react';
+import {act, fireEvent, render as renderComponent, within} from '@testing-library/react';
 import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
 import {CRUDExample} from '../stories/CRUDExample';
 import {Link} from '@react-spectrum/link';

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, render, within} from '@testing-library/react';
+import {act, cleanup, fireEvent, render as renderComponent, within} from '@testing-library/react';
 import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
 import {CRUDExample} from '../stories/CRUDExample';
 import {Link} from '@react-spectrum/link';
@@ -59,6 +59,18 @@ describe('Table', function () {
     offsetWidth.mockReset();
     offsetHeight.mockReset();
   });
+
+  let render = (children, scale = 'medium') => renderComponent(
+    <Provider theme={theme} scale={scale}>
+      {children}
+    </Provider>
+  );
+
+  let rerender = (tree, children, scale = 'medium') => tree.rerender(
+    <Provider theme={theme} scale={scale}>
+      {children}
+    </Provider>
+  );
 
   it('renders a static table', function () {
     let {getByRole} = render(
@@ -1222,7 +1234,7 @@ describe('Table', function () {
       expect(spinner).toHaveAttribute('aria-label', 'Loading...');
       expect(spinner).not.toHaveAttribute('aria-valuenow');
 
-      tree.rerender(defaultTable);
+      rerender(tree, defaultTable);
       act(() => jest.runAllTimers());
 
       rows = within(table).getAllByRole('row');
@@ -1263,7 +1275,7 @@ describe('Table', function () {
       expect(spinner).toHaveAttribute('aria-label', 'Loading more...');
       expect(spinner).not.toHaveAttribute('aria-valuenow');
 
-      tree.rerender(defaultTable);
+      rerender(tree, defaultTable);
       act(() => jest.runAllTimers());
 
       rows = within(table).getAllByRole('row');
@@ -1298,7 +1310,7 @@ describe('Table', function () {
       let scrollView = body.parentNode.parentNode;
 
       let rows = within(body).getAllByRole('row');
-      expect(rows).toHaveLength(20); // each row is 50px tall. table is 1000px tall. 20 rows fit.
+      expect(rows).toHaveLength(21); // each row is 49px tall. table is 1000px tall. 21 rows fit.
 
       scrollView.scrollTop = 250;
       fireEvent.scroll(scrollView);
@@ -1306,7 +1318,7 @@ describe('Table', function () {
       scrollView.scrollTop = 1500;
       fireEvent.scroll(scrollView);
 
-      scrollView.scrollTop = 3000;
+      scrollView.scrollTop = 2800;
       fireEvent.scroll(scrollView);
 
       scrollView.scrollTop = 3500;
@@ -1340,7 +1352,7 @@ describe('Table', function () {
       expect(heading).toBeVisible();
       expect(heading).toHaveTextContent('No results');
 
-      tree.rerender(defaultTable);
+      rerender(tree, defaultTable);
       act(() => jest.runAllTimers());
 
       rows = within(table).getAllByRole('row');
@@ -1554,6 +1566,359 @@ describe('Table', function () {
 
       expect(onSortChange).toHaveBeenCalledTimes(1);
       expect(onSortChange).toHaveBeenCalledWith({column: 'bar', direction: 'ascending'});
+    });
+  });
+
+  describe('layout', function () {
+    describe('row heights', function () {
+      let renderTable = (props, scale) => render(
+        <Table {...props}>
+          <TableHeader columns={columns} columnKey="key">
+            {column => <Column>{column.name}</Column>}
+          </TableHeader>
+          <TableBody items={items} itemKey="foo">
+            {item =>
+              (<Row>
+                {key => <Cell>{item[key]}</Cell>}
+              </Row>)
+            }
+          </TableBody>
+        </Table>
+      , scale);
+  
+      it('should layout rows with default height', function () {
+        let tree = renderTable();
+        let rows = tree.getAllByRole('row');
+        expect(rows).toHaveLength(3);
+
+        expect(rows[0].style.top).toBe('0px');
+        expect(rows[0].style.height).toBe('34px');
+        expect(rows[1].style.top).toBe('0px');
+        expect(rows[1].style.height).toBe('49px');
+        expect(rows[2].style.top).toBe('49px');
+        expect(rows[2].style.height).toBe('49px');
+
+        for (let cell of [...rows[1].childNodes, ...rows[2].childNodes]) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('48px');
+        }
+      });
+
+      it('should layout rows with default height in large scale', function () {
+        let tree = renderTable({}, 'large');
+        let rows = tree.getAllByRole('row');
+        expect(rows).toHaveLength(3);
+
+        expect(rows[0].style.top).toBe('0px');
+        expect(rows[0].style.height).toBe('40px');
+        expect(rows[1].style.top).toBe('0px');
+        expect(rows[1].style.height).toBe('65px');
+        expect(rows[2].style.top).toBe('65px');
+        expect(rows[2].style.height).toBe('65px');
+
+        for (let cell of [...rows[1].childNodes, ...rows[2].childNodes]) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('64px');
+        }
+      });
+
+      it('should layout rows with a custom rowHeight', function () {
+        let tree = renderTable({rowHeight: 72});
+        let rows = tree.getAllByRole('row');
+        expect(rows).toHaveLength(3);
+
+        expect(rows[0].style.top).toBe('0px');
+        expect(rows[0].style.height).toBe('34px');
+        expect(rows[1].style.top).toBe('0px');
+        expect(rows[1].style.height).toBe('73px');
+        expect(rows[2].style.top).toBe('73px');
+        expect(rows[2].style.height).toBe('73px');
+
+        for (let cell of [...rows[1].childNodes, ...rows[2].childNodes]) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('72px');
+        }
+      });
+
+      it('should support variable row heights with rowHeight="auto"', function () {
+        let scrollHeight = jest.spyOn(window.HTMLElement.prototype, 'scrollHeight', 'get')
+          .mockImplementation(function () {
+            return this.textContent === 'Foo 1' ? 64 : 48;
+          });
+        
+        let tree = renderTable({rowHeight: 'auto'});
+        let rows = tree.getAllByRole('row');
+        expect(rows).toHaveLength(3);
+
+        expect(rows[1].style.top).toBe('0px');
+        expect(rows[1].style.height).toBe('65px');
+        expect(rows[2].style.top).toBe('65px');
+        expect(rows[2].style.height).toBe('49px');
+
+        for (let cell of rows[1].childNodes) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('64px');
+        }
+
+        for (let cell of rows[2].childNodes) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('48px');
+        }
+
+        scrollHeight.mockRestore();
+      });
+
+      it('should support variable column header heights with rowHeight="auto"', function () {
+        let scrollHeight = jest.spyOn(window.HTMLElement.prototype, 'scrollHeight', 'get')
+          .mockImplementation(function () {
+            return this.textContent === 'Tier Two Header B' ? 48 : 34;
+          });
+        
+        let tree = render(
+          <Table rowHeight="auto">
+            <TableHeader columns={nestedColumns} columnKey="key">
+              {column => <Column childColumns={column.children}>{column.name}</Column>}
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+        let rows = tree.getAllByRole('row');
+        expect(rows).toHaveLength(5);
+
+        expect(rows[0].style.top).toBe('0px');
+        expect(rows[0].style.height).toBe('34px');
+        expect(rows[1].style.top).toBe('34px');
+        expect(rows[1].style.height).toBe('48px');
+        expect(rows[2].style.top).toBe('82px');
+        expect(rows[2].style.height).toBe('34px');
+
+        for (let cell of rows[0].childNodes) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('34px');
+        }
+
+        for (let cell of rows[1].childNodes) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('48px');
+        }
+
+        for (let cell of rows[2].childNodes) {
+          expect(cell.style.top).toBe('0px');
+          expect(cell.style.height).toBe('34px');
+        }
+
+        scrollHeight.mockRestore();
+      });
+    });
+
+    describe('column widths', function () {
+      it('should divide the available width by default', function () {
+        let tree = render(
+          <Table>
+            <TableHeader columns={columns} columnKey="key">
+              {column => <Column>{column.name}</Column>}
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('55px');
+          expect(row.childNodes[1].style.width).toBe('315px');
+          expect(row.childNodes[2].style.width).toBe('315px');
+          expect(row.childNodes[3].style.width).toBe('315px');  
+        }
+      });
+
+      it('should support explicitly sized columns', function () {
+        let tree = render(
+          <Table>
+            <TableHeader>
+              <Column uniqueKey="foo" width={200}>Foo</Column>
+              <Column uniqueKey="bar" width={500}>Bar</Column>
+              <Column uniqueKey="baz" width={300}>Baz</Column>
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+        
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('55px');
+          expect(row.childNodes[1].style.width).toBe('200px');
+          expect(row.childNodes[2].style.width).toBe('500px');
+          expect(row.childNodes[3].style.width).toBe('300px');  
+        }
+      });
+
+      it('should divide remaining width amoung remaining columns', function () {
+        let tree = render(
+          <Table>
+            <TableHeader>
+              <Column uniqueKey="foo" width={200}>Foo</Column>
+              <Column uniqueKey="bar">Bar</Column>
+              <Column uniqueKey="baz">Baz</Column>
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+        
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('55px');
+          expect(row.childNodes[1].style.width).toBe('200px');
+          expect(row.childNodes[2].style.width).toBe('372.5px');
+          expect(row.childNodes[3].style.width).toBe('372.5px');  
+        }
+      });
+
+      it('should support percentage widths', function () {
+        let tree = render(
+          <Table>
+            <TableHeader>
+              <Column uniqueKey="foo" width="10%">Foo</Column>
+              <Column uniqueKey="bar" width={500}>Bar</Column>
+              <Column uniqueKey="baz">Baz</Column>
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+        
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('55px');
+          expect(row.childNodes[1].style.width).toBe('100px');
+          expect(row.childNodes[2].style.width).toBe('500px');
+          expect(row.childNodes[3].style.width).toBe('345px');  
+        }
+      });
+
+      it('should support minWidth', function () {
+        let tree = render(
+          <Table>
+            <TableHeader>
+              <Column uniqueKey="foo" width={200}>Foo</Column>
+              <Column uniqueKey="bar" minWidth={500}>Bar</Column>
+              <Column uniqueKey="baz">Baz</Column>
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+        
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('55px');
+          expect(row.childNodes[1].style.width).toBe('200px');
+          expect(row.childNodes[2].style.width).toBe('500px');
+          expect(row.childNodes[3].style.width).toBe('245px');  
+        }
+      });
+
+      it('should support maxWidth', function () {
+        let tree = render(
+          <Table>
+            <TableHeader>
+              <Column uniqueKey="foo" width={200}>Foo</Column>
+              <Column uniqueKey="bar" maxWidth={300}>Bar</Column>
+              <Column uniqueKey="baz">Baz</Column>
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+        
+        let rows = tree.getAllByRole('row');
+
+        for (let row of rows) {
+          expect(row.childNodes[0].style.width).toBe('55px');
+          expect(row.childNodes[1].style.width).toBe('200px');
+          expect(row.childNodes[2].style.width).toBe('300px');
+          expect(row.childNodes[3].style.width).toBe('445px');  
+        }
+      });
+
+      it('should compute the correct widths for tiered headings', function () {
+        let tree = render(
+          <Table>
+            <TableHeader columns={nestedColumns} columnKey="key">
+              {column => <Column childColumns={column.children}>{column.name}</Column>}
+            </TableHeader>
+            <TableBody items={items} itemKey="foo">
+              {item =>
+                (<Row>
+                  {key => <Cell>{item[key]}</Cell>}
+                </Row>)
+              }
+            </TableBody>
+          </Table>
+        );
+
+        let rows = tree.getAllByRole('row');
+
+        expect(rows[0].childNodes[0].style.width).toBe('244px');
+        expect(rows[0].childNodes[1].style.width).toBe('756px');
+
+        expect(rows[1].childNodes[0].style.width).toBe('244px');
+        expect(rows[1].childNodes[1].style.width).toBe('378px');
+        expect(rows[1].childNodes[2].style.width).toBe('189px');
+        expect(rows[1].childNodes[3].style.width).toBe('189px');
+
+        for (let row of rows.slice(2)) {
+          expect(row.childNodes[0].style.width).toBe('55px');
+          expect(row.childNodes[1].style.width).toBe('189px');
+          expect(row.childNodes[2].style.width).toBe('189px');
+          expect(row.childNodes[3].style.width).toBe('189px');
+          expect(row.childNodes[4].style.width).toBe('189px');
+          expect(row.childNodes[5].style.width).toBe('189px');
+        }
+      });
     });
   });
 });

--- a/packages/@react-stately/collections/src/ListLayout.ts
+++ b/packages/@react-stately/collections/src/ListLayout.ts
@@ -58,7 +58,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   protected padding: number;
   protected indentationForItem?: (collection: Collection<Node<T>>, key: Key) => number;
   protected layoutInfos: Map<Key, LayoutInfo>;
-  private layoutNodes: Map<Key, LayoutNode>;
+  protected layoutNodes: Map<Key, LayoutNode>;
   protected contentSize: Size;
   collection: Collection<Node<T>>;
   disabledKeys: Set<Key> = new Set();


### PR DESCRIPTION
This adds support for adjusting the row height of rows in a Table. It can be set to a fixed number, or `"auto"` to automatically measure the contents of each cell and size the rows accordingly. This enables each row height to be different potentially. This is also supported for column headers, which may wrap and make the row taller. 

By default, the `"auto"` behavior is off since it is considerably less performant due to all the measuring we have to do. In addition, there is one downside, which is that when horizontal scrolling occurs, we cannot properly measure all of the cells in a row, so it may get taller as you scroll horizontally if a really long cell is off the screen on initial render. I think we'll simply recommend that when horizontal scrolling is on, don't use auto row heights.

The default row heights adjust based on the spectrum scale as well. However, when you use a fixed number to `rowHeight` we cannot do this automatically, so we may want to offer set sizes instead (e.g. small, medium, large?). Might take this to the design team.

This also adds a bunch of tests for the layout behavior of Table, including column sizing and row sizing.