### PR TITLE
Implement page up/page down and typeahead for Table

### DIFF
--- a/packages/@react-aria/grid/src/GridKeyboardDelegate.ts
+++ b/packages/@react-aria/grid/src/GridKeyboardDelegate.ts
@@ -411,6 +411,7 @@ export class GridKeyboardDelegate<T> implements KeyboardDelegate {
       key = startItem.parentKey;
     }
 
+    let hasWrapped = false;
     while (key) {
       let item = collection.getItem(key);
 
@@ -430,6 +431,12 @@ export class GridKeyboardDelegate<T> implements KeyboardDelegate {
       }
 
       key = this.getKeyBelow(key);
+
+      // Wrap around when reaching the end of the collection
+      if (key == null && !hasWrapped) {
+        key = this.getFirstKey();
+        hasWrapped = true;
+      }
     }
 
     return null;

--- a/packages/@react-aria/grid/src/GridKeyboardDelegate.ts
+++ b/packages/@react-aria/grid/src/GridKeyboardDelegate.ts
@@ -13,7 +13,16 @@
 import {Direction, KeyboardDelegate} from '@react-types/shared';
 import {GridCollection} from '@react-stately/grid';
 import {Key, RefObject} from 'react';
-import {Node} from '@react-stately/collections';
+import {Layout, Node, Rect} from '@react-stately/collections';
+
+interface GridKeyboardDelegateOptions<T> {
+  collection: GridCollection<T>,
+  disabledKeys: Set<Key>,
+  ref?: RefObject<HTMLElement>,
+  direction: Direction,
+  collator?: Intl.Collator,
+  layout?: Layout<Node<T>>
+}
 
 export class GridKeyboardDelegate<T> implements KeyboardDelegate {
   private collection: GridCollection<T>;
@@ -21,13 +30,15 @@ export class GridKeyboardDelegate<T> implements KeyboardDelegate {
   private ref: RefObject<HTMLElement>;
   private direction: Direction;
   private collator: Intl.Collator;
+  private layout: Layout<Node<T>>;
 
-  constructor(collection: GridCollection<T>, disabledKeys: Set<Key>, ref: RefObject<HTMLElement>, direction: Direction, collator?: Intl.Collator) {
-    this.collection = collection;
-    this.disabledKeys = disabledKeys;
-    this.ref = ref;
-    this.direction = direction;
-    this.collator = collator;
+  constructor(options: GridKeyboardDelegateOptions<T>) {
+    this.collection = options.collection;
+    this.disabledKeys = options.disabledKeys;
+    this.ref = options.ref;
+    this.direction = options.direction;
+    this.collator = options.collator;
+    this.layout = options.layout;
   }
 
   private isCell(node: Node<T>) {
@@ -319,35 +330,61 @@ export class GridKeyboardDelegate<T> implements KeyboardDelegate {
     return this.ref.current.querySelector(`[data-key="${key}"]`);
   }
 
-  getKeyPageAbove(key: Key) {
-    let menu = this.ref.current;
+  private getItemRect(key: Key): Rect {
+    if (this.layout) {
+      return this.layout.getLayoutInfo(key)?.rect;
+    }
+
     let item = this.getItem(key);
-    if (!item) {
+    if (item) {
+      return new Rect(item.offsetLeft, item.offsetTop, item.offsetWidth, item.offsetHeight);
+    }
+  }
+
+  private getPageHeight(): number {
+    if (this.layout) {
+      return this.layout.collectionManager?.visibleRect.height;
+    }
+
+    return this.ref?.current?.offsetHeight;
+  }
+
+  private getContentHeight(): number {
+    if (this.layout) {
+      return this.layout.getContentSize().height;
+    }
+
+    return this.ref?.current?.scrollHeight;
+  }
+
+  getKeyPageAbove(key: Key) {
+    let itemRect = this.getItemRect(key);
+    if (!itemRect) {
       return null;
     }
 
-    let pageY = Math.max(0, item.offsetTop + item.offsetHeight - menu.offsetHeight);
+    let pageY = Math.max(0, itemRect.maxY - this.getPageHeight());
     
-    while (item && item.offsetTop > pageY) {
+    while (itemRect && itemRect.y > pageY) {
       key = this.getKeyAbove(key);
-      item = this.getItem(key);
+      itemRect = this.getItemRect(key);
     }
 
     return key;
   }
 
   getKeyPageBelow(key: Key) {
-    let menu = this.ref.current;
-    let item = this.getItem(key);
-    if (!item) {
+    let itemRect = this.getItemRect(key);
+    if (!itemRect) {
       return null;
     }
 
-    let pageY = Math.min(menu.scrollHeight, item.offsetTop - item.offsetHeight + menu.offsetHeight);
+    let pageHeight = this.getPageHeight();
+    let pageY = Math.min(this.getContentHeight() - pageHeight, itemRect.y + pageHeight);
 
-    while (item && item.offsetTop < pageY) {
+    while (itemRect && itemRect.maxY < pageY) {
       key = this.getKeyBelow(key);
-      item = this.getItem(key);
+      itemRect = this.getItemRect(key);
     }
 
     return key;
@@ -359,12 +396,37 @@ export class GridKeyboardDelegate<T> implements KeyboardDelegate {
     }
 
     let collection = this.collection;
-    let key = fromKey ? this.getKeyBelow(fromKey) : this.getFirstKey(fromKey);
+    let key: Key;
+    if (fromKey != null) {
+      key = this.getKeyBelow(fromKey);
+    }
+    
+    if (key == null) {
+      key = this.getFirstKey();
+    }
+
+    // If the starting key is a cell, search from its parent row.
+    let startItem = collection.getItem(key);
+    if (startItem.type === 'cell') {
+      key = startItem.parentKey;
+    }
+
     while (key) {
       let item = collection.getItem(key);
-      let substring = item.textValue.slice(0, search.length);
-      if (item.textValue && this.collator.compare(substring, search) === 0) {
-        return key;
+
+      // Check each of the row header cells in this row for a match
+      for (let cell of item.childNodes) {
+        let column = collection.columns[cell.index];
+        if (collection.rowHeaderColumnKeys.has(column.key) && cell.textValue) {
+          let substring = cell.textValue.slice(0, search.length);
+          if (this.collator.compare(substring, search) === 0) {
+            // If we started on a cell, end on the matching cell. Otherwise, end on the row.
+            let fromItem = fromKey != null ? collection.getItem(fromKey) : startItem;
+            return fromItem.type === 'cell' 
+              ? cell.key
+              : item.key;
+          }
+        }
       }
 
       key = this.getKeyBelow(key);

--- a/packages/@react-aria/grid/src/useGrid.ts
+++ b/packages/@react-aria/grid/src/useGrid.ts
@@ -15,32 +15,42 @@ import {GridKeyboardDelegate} from './GridKeyboardDelegate';
 import {GridState} from '@react-stately/grid';
 import {HTMLAttributes, RefObject, useMemo} from 'react';
 import {KeyboardDelegate} from '@react-types/shared';
+import {Layout, Node} from '@react-stately/collections';
 import {useCollator, useLocale} from '@react-aria/i18n';
 import {useId} from '@react-aria/utils';
 import {useSelectableCollection} from '@react-aria/selection';
 
-interface GridProps {
+interface GridProps<T> {
   ref: RefObject<HTMLElement>,
   isVirtualized?: boolean,
   keyboardDelegate?: KeyboardDelegate,
+  layout?: Layout<Node<T>>
 }
 
 interface GridAria {
   gridProps: HTMLAttributes<HTMLElement>
 }
 
-export function useGrid<T>(props: GridProps, state: GridState<T>): GridAria {
+export function useGrid<T>(props: GridProps<T>, state: GridState<T>): GridAria {
   let {
     ref,
     isVirtualized,
-    keyboardDelegate
+    keyboardDelegate,
+    layout
   } = props;
 
   // By default, a KeyboardDelegate is provided which uses the DOM to query layout information (e.g. for page up/page down).
   // When virtualized, the layout object will be passed in as a prop and override this.
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let {direction} = useLocale();
-  let delegate = useMemo(() => keyboardDelegate || new GridKeyboardDelegate(state.collection, state.disabledKeys, ref, direction, collator), [keyboardDelegate, state.collection, state.disabledKeys, ref, direction, collator]);
+  let delegate = useMemo(() => keyboardDelegate || new GridKeyboardDelegate({
+    collection: state.collection,
+    disabledKeys: state.disabledKeys,
+    ref,
+    direction,
+    collator,
+    layout
+  }), [keyboardDelegate, state.collection, state.disabledKeys, ref, direction, collator, layout]);
   let {collectionProps} = useSelectableCollection({
     ref,
     selectionManager: state.selectionManager,

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -52,11 +52,6 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
   let {styleProps} = useStyleProps(props);
   let state = useGridState({...props, showSelectionCheckboxes: true});
   let domRef = useDOMRef(ref);
-  let {gridProps} = useGrid({
-    ...props,
-    ref: domRef,
-    isVirtualized: true
-  }, state);
 
   let {scale} = useProvider();
   let layout = useMemo(() => new TableLayout({
@@ -76,6 +71,13 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
   }), [props.rowHeight, scale]);
   let {direction} = useLocale();
   layout.collection = state.collection;
+
+  let {gridProps} = useGrid({
+    ...props,
+    ref: domRef,
+    isVirtualized: true,
+    layout
+  }, state);
 
   // This overrides collection view's renderWrapper to support DOM heirarchy.
   type View = ReusableView<Node<T>, unknown>;

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -465,7 +465,7 @@ function AsyncLoadingExample() {
           (<Row uniqueKey={item.data.id}>
             {key => 
               key === 'title'
-                ? <Cell><Link isQuiet><a href={item.data.url} target="_blank">{item.data.title}</a></Link></Cell>
+                ? <Cell textValue={item.data.title}><Link isQuiet><a href={item.data.url} target="_blank">{item.data.title}</a></Link></Cell>
                 : <Cell>{item.data[key]}</Cell>
             }
           </Row>)

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -978,7 +978,7 @@ describe('Table', function () {
         expect(document.activeElement).toBe(tree.getByText('John'));
       });
 
-      it('wraps around when no items past the current one match', function () {
+      it('wraps around when reaching the end of the collection', function () {
         let tree = renderTypeSelect();
         focusCell(tree, 'Sam');
 
@@ -992,6 +992,19 @@ describe('Table', function () {
 
         moveFocus('J');
         expect(document.activeElement).toBe(tree.getByText('Julia'));
+      });
+
+      it('wraps around when no items past the current one match', function () {
+        let tree = renderTypeSelect();
+        focusCell(tree, 'Sam');
+
+        moveFocus('J');
+        expect(document.activeElement).toBe(tree.getByText('Julia'));
+
+        jest.runAllTimers();
+
+        moveFocus('S');
+        expect(document.activeElement).toBe(tree.getByText('Sam'));
       });
     });
 

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -46,6 +46,11 @@ let items = [
   {test: 'Test 2', foo: 'Foo 2', bar: 'Bar 2', yay: 'Yay 2', baz: 'Baz 2'}
 ];
 
+let manyItems = [];
+for (let i = 1; i <= 100; i++) {
+  manyItems.push({id: i, foo: 'Foo ' + i, bar: 'Bar ' + i, baz: 'Baz ' + i});
+}
+
 describe('Table', function () {
   let offsetWidth, offsetHeight;
   beforeAll(function () {
@@ -540,6 +545,23 @@ describe('Table', function () {
       </Provider>
     );
 
+    let renderMany = () => render(
+      <Table selectionMode="none">
+        <TableHeader columns={columns} columnKey="key">
+          {column =>
+            <Column>{column.name}</Column>
+          }
+        </TableHeader>
+        <TableBody items={manyItems} itemKey="foo">
+          {item =>
+            (<Row>
+              {key => <Cell>{item[key]}</Cell>}
+            </Row>)
+          }
+        </TableBody>
+      </Table>
+    );
+
     let focusCell = (tree, text) => tree.getByText(text).focus();
     let moveFocus = (key, opts = {}) => fireEvent.keyDown(document.activeElement, {key, ...opts});
 
@@ -835,8 +857,143 @@ describe('Table', function () {
       });
     });
 
-    // TODO: PageUp and PageDown once scrolling is supported
-    // TODO: type to select once that is figured out
+    describe('PageDown', function () {
+      it('should focus the cell a page below', function () {
+        let tree = renderMany();
+        focusCell(tree, 'Foo 1');
+        moveFocus('PageDown');
+        expect(document.activeElement).toBe(tree.getByText('Foo 21'));
+        moveFocus('PageDown');
+        expect(document.activeElement).toBe(tree.getByText('Foo 41'));
+      });
+
+      it('should focus the row a page below', function () {
+        let tree = renderMany();
+        tree.getAllByRole('row')[1].focus();
+        moveFocus('PageDown');
+        expect(document.activeElement).toBe(tree.getAllByRole('row')[21]);
+      });
+    });
+
+    describe('PageUp', function () {
+      it('should focus the cell a page below', function () {
+        let tree = renderMany();
+        focusCell(tree, 'Foo 21');
+        moveFocus('PageUp');
+        expect(document.activeElement).toBe(tree.getByText('Foo 1'));
+      });
+
+      it('should focus the row a page below', function () {
+        let tree = renderMany();
+        tree.getAllByRole('row')[21].focus();
+        moveFocus('PageUp');
+        expect(document.activeElement).toBe(tree.getAllByRole('row')[1]);
+      });
+    });
+
+    describe('type to select', function () {
+      let renderTypeSelect = () => render(
+        <Table selectionMode="none">
+          <TableHeader>
+            <Column isRowHeader>First Name</Column>
+            <Column isRowHeader>Last Name</Column>
+            <Column>Birthday</Column>
+          </TableHeader>
+          <TableBody>
+            <Row>
+              <Cell>Sam</Cell>
+              <Cell>Smith</Cell>
+              <Cell>May 3</Cell>
+            </Row>
+            <Row>
+              <Cell>Julia</Cell>
+              <Cell>Jones</Cell>
+              <Cell>February 10</Cell>
+            </Row>
+            <Row>
+              <Cell>John</Cell>
+              <Cell>Doe</Cell>
+              <Cell>December 12</Cell>
+            </Row>
+          </TableBody>
+        </Table>
+      );
+
+      it('focuses cell by typing letters in rapid succession', function () {
+        let tree = renderTypeSelect();
+        focusCell(tree, 'Sam');
+
+        moveFocus('J');
+        expect(document.activeElement).toBe(tree.getByText('Julia'));
+
+        moveFocus('o');
+        expect(document.activeElement).toBe(tree.getByText('John'));
+      });
+
+      it('matches against all row header cells', function () {
+        let tree = renderTypeSelect();
+        focusCell(tree, 'Sam');
+
+        moveFocus('D');
+        expect(document.activeElement).toBe(tree.getByText('Doe'));
+      });
+
+      it('non row header columns don\'t match', function () {
+        let tree = renderTypeSelect();
+        focusCell(tree, 'Sam');
+
+        moveFocus('F');
+        expect(document.activeElement).toBe(tree.getByText('Sam'));
+      });
+
+      it('focuses row by typing letters in rapid succession', function () {
+        let tree = renderTypeSelect();
+        tree.getAllByRole('row')[1].focus();
+
+        moveFocus('J');
+        expect(document.activeElement).toBe(tree.getAllByRole('row')[2]);
+
+        moveFocus('o');
+        expect(document.activeElement).toBe(tree.getAllByRole('row')[3]);
+      });
+
+      it('matches row against all row header cells', function () {
+        let tree = renderTypeSelect();
+        tree.getAllByRole('row')[1].focus();
+
+        moveFocus('D');
+        expect(document.activeElement).toBe(tree.getAllByRole('row')[3]);
+      });
+
+      it('resets the search text after a timeout', function () {
+        let tree = renderTypeSelect();
+        focusCell(tree, 'Sam');
+
+        moveFocus('J');
+        expect(document.activeElement).toBe(tree.getByText('Julia'));
+
+        jest.runAllTimers();
+        
+        moveFocus('J');
+        expect(document.activeElement).toBe(tree.getByText('John'));
+      });
+
+      it('wraps around when no items past the current one match', function () {
+        let tree = renderTypeSelect();
+        focusCell(tree, 'Sam');
+
+        moveFocus('J');
+        expect(document.activeElement).toBe(tree.getByText('Julia'));
+
+        moveFocus('o');
+        expect(document.activeElement).toBe(tree.getByText('John'));
+
+        jest.runAllTimers();
+
+        moveFocus('J');
+        expect(document.activeElement).toBe(tree.getByText('Julia'));
+      });
+    });
 
     describe('focus marshalling', function () {
       let renderFocusable = () => render(


### PR DESCRIPTION
This implements page up and page down support for Table, along with typeahead.

Page up/page down are implemented by passing the layout to GridKeyboardDelegate. If available, this will be used to get layout information instead of the DOM, so it works with virtualization. When starting from a cell, focus ends on a cell in the corresponding column. When starting on a row, it ends on a row.

Typeahead is implemented by looking at the text contents or `textValue` prop of the cells in columns marked as row headers. When starting from a cell, focus is moved to the row header cell with the matching text. When starting from a row, focus is moved to the row with the matching text.