### PR TITLE
Support adding and removing columns in Table

### DIFF
--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -162,8 +162,7 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
           return <TableCheckboxCell cell={item} />;
         }
 
-        let column = state.collection.columns[item.index];
-        if (state.collection.rowHeaderColumnKeys.has(column.key)) {
+        if (state.collection.rowHeaderColumnKeys.has(item.column.key)) {
           return <TableRowHeader cell={item} />;
         }
 
@@ -282,7 +281,8 @@ function TableCollectionView({layout, collection, focusedKey, renderView, render
           height: headerHeight,
           overflow: 'hidden',
           position: 'relative',
-          willChange: collectionState.isScrolling ? 'scroll-position' : ''
+          willChange: collectionState.isScrolling ? 'scroll-position' : '',
+          transition: collectionState.isAnimating ? `none ${collectionState.collectionManager.transitionDuration}ms` : undefined
         }}
         ref={headerRef}>
         {collectionState.visibleViews[0]}
@@ -475,8 +475,7 @@ function TableCell({cell}) {
     ref,
     isVirtualized: true
   }, state);
-  let column = state.collection.columns[cell.index];
-  let columnProps = column.props as SpectrumColumnProps<unknown>;
+  let columnProps = cell.column.props as SpectrumColumnProps<unknown>;
 
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
@@ -514,8 +513,7 @@ function TableRowHeader({cell}) {
     ref,
     isVirtualized: true
   }, state);
-  let column = state.collection.columns[cell.index];
-  let columnProps = column.props as SpectrumColumnProps<unknown>;
+  let columnProps = cell.column.props as SpectrumColumnProps<unknown>;
 
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>

--- a/packages/@react-spectrum/table/src/TableLayout.ts
+++ b/packages/@react-spectrum/table/src/TableLayout.ts
@@ -17,10 +17,20 @@ import {SpectrumColumnProps} from '@react-types/table';
 
 export class TableLayout<T> extends ListLayout<T> {
   collection: GridCollection<T>;
+  lastCollection: GridCollection<T>;
   columnWidths: Map<Key, number>;
   stickyColumnIndices: number[];
 
   buildCollection(): LayoutNode[] {
+    // If columns changed, clear layout cache.
+    if (
+      !this.lastCollection ||
+      this.collection.columns.length !== this.lastCollection.columns.length ||
+      this.collection.columns.some((c, i) => c.key !== this.lastCollection.columns[i].key)
+    ) {
+      this.cache = new WeakMap();
+    }
+
     this.buildColumnWidths();
     let header = this.buildHeader();
     let body = this.buildBody(0);

--- a/packages/@react-spectrum/table/stories/HidingColumns.tsx
+++ b/packages/@react-spectrum/table/stories/HidingColumns.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
+import {Checkbox} from '@react-spectrum/checkbox';
+import {Flex} from '@react-spectrum/layout';
+import {Form} from '@react-spectrum/form';
+import React from 'react';
+
+let columns = [
+  {key: 'planName', title: 'Plan Name'},
+  {key: 'audienceType', title: 'Audience Type'},
+  {key: 'netBudget', title: 'Net Budget'},
+  {key: 'targetOTP', title: 'Target OTP'},
+  {key: 'reach', title: 'Reach'}
+];
+
+let data = [
+  {id: 1, planName: 'Plan 1: $300k, digital', audienceType: 'Strategic', netBudget: '$300,000', targetOTP: '7.4%', reach: '11.52%'},
+  {id: 2, planName: 'Plan 2: $500k, digital', audienceType: 'Strategic', netBudget: '$500,000', targetOTP: '22.5%', reach: '11.5%'},
+  {id: 3, planName: 'Plan 3: $800k, digital', audienceType: 'Strategic', netBudget: '$800,000', targetOTP: '22.5%', reach: '11.5%'},
+  {id: 4, planName: 'Plan 4: $300k, MRI', audienceType: 'Demo+strategic', netBudget: '$300,000', targetOTP: '22.5%', reach: '11.5%'},
+  {id: 5, planName: 'Plan 5: $500k, MRI', audienceType: 'Demo+strategic', netBudget: '$500,000', targetOTP: '22.5%', reach: '11.5%'},
+  {id: 6, planName: 'Plan 6: $800k, MRI', audienceType: 'Demo+strategic', netBudget: '$800,000', targetOTP: '22.5%', reach: '11.5%'}
+];
+
+export function HidingColumns() {
+  let [visibleColumns, setVisibleColumns] = React.useState(new Set(columns.map(c => c.key)));
+  let toggleColumn = (key) => {
+    let columns = new Set(visibleColumns);
+    if (columns.has(key)) {
+      columns.delete(key);
+    } else {
+      columns.add(key);
+    }
+
+    setVisibleColumns(columns);
+  };
+
+  return (
+    <Flex>
+      <Form>
+        {columns.slice(1).map(c => 
+          <Checkbox isSelected={visibleColumns.has(c.key)} onChange={() => toggleColumn(c.key)}>{c.title}</Checkbox>
+        )}
+      </Form>
+      <Table width={900} height={500} isQuiet>
+        <TableHeader columns={columns.filter(c => visibleColumns.has(c.key))}>
+          {column => <Column>{column.title}</Column>}
+        </TableHeader>
+        <TableBody items={data}>
+          {item => (
+            <Row>
+              {key => <Cell>{item[key]}</Cell>}
+            </Row>
+          )}
+        </TableBody>
+      </Table>
+    </Flex>
+  );
+}

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -15,6 +15,7 @@ import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
 import {Content} from '@react-spectrum/view';
 import {CRUDExample} from './CRUDExample';
 import {Heading} from '@react-spectrum/typography';
+import {HidingColumns} from './HidingColumns';
 import {IllustratedMessage} from '@react-spectrum/illustratedmessage';
 import {Link} from '@react-spectrum/link';
 import React from 'react';
@@ -126,7 +127,7 @@ storiesOf('Table', module)
   .add(
     'static with nested columns',
     () => (
-      <Table width={300} height={200} onSelectionChange={s => onSelectionChange([...s])}>
+      <Table width={500} height={200} onSelectionChange={s => onSelectionChange([...s])}>
         <TableHeader>
           <Column key="test">Test</Column>
           <Column title="Group 1">
@@ -362,6 +363,12 @@ storiesOf('Table', module)
     )
   )
   .add(
+    'hiding columns',
+    () => (
+      <HidingColumns />
+    )
+  )
+  .add(
     'isLoading',
     () => (
       <Table width={700} height={200} onSelectionChange={s => onSelectionChange([...s])}>
@@ -454,7 +461,7 @@ function AsyncLoadingExample() {
 
   return (
     <Table width={1000} height={500} isQuiet selectionMode="none" sortDescriptor={list.sortDescriptor} onSortChange={list.sort}>
-      <TableHeader columns={columns} columnKey="key">
+      <TableHeader>
         <Column uniqueKey="score" width={100} allowsSorting>Score</Column>
         <Column uniqueKey="title" isRowHeader allowsSorting>Title</Column>
         <Column uniqueKey="author" width={200} allowsSorting>Author</Column>

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -13,6 +13,7 @@
 import {act, cleanup, fireEvent, render as renderComponent, within} from '@testing-library/react';
 import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
 import {CRUDExample} from '../stories/CRUDExample';
+import {HidingColumns} from '../stories/HidingColumns';
 import {Link} from '@react-spectrum/link';
 import {Provider} from '@react-spectrum/provider';
 import React from 'react';
@@ -2076,6 +2077,82 @@ describe('Table', function () {
           expect(row.childNodes[5].style.width).toBe('189px');
         }
       });
+    });
+  });
+
+  describe('updating columns', function () {
+    it('should support removing columns', function () {
+      let tree = render(<HidingColumns />);
+      let form = tree.getByRole('form');
+
+      let checkbox = within(form).getByLabelText('Net Budget');
+      expect(checkbox.checked).toBe(true);
+
+      let table = tree.getByRole('grid');
+      let columns = within(table).getAllByRole('columnheader');
+      expect(columns).toHaveLength(6);
+      expect(columns[1]).toHaveTextContent('Plan Name');
+      expect(columns[2]).toHaveTextContent('Audience Type');
+      expect(columns[3]).toHaveTextContent('Net Budget');
+      expect(columns[4]).toHaveTextContent('Target OTP');
+      expect(columns[5]).toHaveTextContent('Reach');
+
+      for (let row of within(table).getAllByRole('row').slice(1)) {
+        expect(within(row).getAllByRole('rowheader')).toHaveLength(1);
+        expect(within(row).getAllByRole('gridcell')).toHaveLength(5);
+      }
+      
+      act(() => {userEvent.click(checkbox);});
+      expect(checkbox.checked).toBe(false);
+
+      act(() => jest.runAllTimers());
+
+      columns = within(table).getAllByRole('columnheader');
+      expect(columns).toHaveLength(5);
+      expect(columns[1]).toHaveTextContent('Plan Name');
+      expect(columns[2]).toHaveTextContent('Audience Type');
+      expect(columns[3]).toHaveTextContent('Target OTP');
+      expect(columns[4]).toHaveTextContent('Reach');
+
+      for (let row of within(table).getAllByRole('row').slice(1)) {
+        expect(within(row).getAllByRole('rowheader')).toHaveLength(1);
+        expect(within(row).getAllByRole('gridcell')).toHaveLength(4);
+      }
+    });
+
+    it('should support adding columns', function () {
+      let tree = render(<HidingColumns />);
+      let form = tree.getByRole('form');
+
+      let checkbox = within(form).getByLabelText('Net Budget');
+      expect(checkbox.checked).toBe(true);
+
+      act(() => {userEvent.click(checkbox);});
+      expect(checkbox.checked).toBe(false);
+
+      act(() => jest.runAllTimers());
+
+      let table = tree.getByRole('grid');
+      let columns = within(table).getAllByRole('columnheader');
+      expect(columns).toHaveLength(5);
+
+      act(() => {userEvent.click(checkbox);});
+      expect(checkbox.checked).toBe(true);
+
+      act(() => jest.runAllTimers());
+
+      columns = within(table).getAllByRole('columnheader');
+      expect(columns).toHaveLength(6);
+      expect(columns[1]).toHaveTextContent('Plan Name');
+      expect(columns[2]).toHaveTextContent('Audience Type');
+      expect(columns[3]).toHaveTextContent('Net Budget');
+      expect(columns[4]).toHaveTextContent('Target OTP');
+      expect(columns[5]).toHaveTextContent('Reach');
+
+      for (let row of within(table).getAllByRole('row').slice(1)) {
+        expect(within(row).getAllByRole('rowheader')).toHaveLength(1);
+        expect(within(row).getAllByRole('gridcell')).toHaveLength(5);
+      }
     });
   });
 });

--- a/packages/@react-stately/collections/src/CollectionBuilder.ts
+++ b/packages/@react-stately/collections/src/CollectionBuilder.ts
@@ -95,7 +95,7 @@ export class CollectionBuilder<T extends object> {
     let element = partialNode.element;
     if (!element && partialNode.value && state && state.renderer) {
       let cached = this.cache.get(partialNode.value);
-      if (cached) {
+      if (cached && (!cached.shouldInvalidate || !cached.shouldInvalidate(this.context))) {
         yield cached;
         return;
       }
@@ -128,15 +128,6 @@ export class CollectionBuilder<T extends object> {
           // Cache the node based on its value
           node.value = childNode.value || partialNode.value;
           if (node.value) {
-            // If there was a previous cached node for this value,
-            // we can reuse the child nodes. This happens when item
-            // states like selection/focus change, which only affects
-            // the node itself, not its children.
-            let prevCached = this.cache.get(node.value);
-            if (prevCached) {
-              node.childNodes = prevCached.childNodes;
-            }
-
             this.cache.set(node.value, node);
           }
 
@@ -169,6 +160,7 @@ export class CollectionBuilder<T extends object> {
       textValue: partialNode.textValue,
       'aria-label': partialNode['aria-label'],
       wrapper: partialNode.wrapper,
+      shouldInvalidate: partialNode.shouldInvalidate,
       hasChildNodes: partialNode.hasChildNodes,
       childNodes: iterable(function *() {
         if (!partialNode.hasChildNodes) {

--- a/packages/@react-stately/collections/src/ListLayout.ts
+++ b/packages/@react-stately/collections/src/ListLayout.ts
@@ -65,8 +65,8 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   protected lastWidth: number;
   protected lastCollection: Collection<Node<T>>;
   protected rootNodes: LayoutNode[];
-  private collator: Intl.Collator;
-  private cache: WeakMap<Node<T>, LayoutNode> = new WeakMap();
+  protected collator: Intl.Collator;
+  protected cache: WeakMap<Node<T>, LayoutNode> = new WeakMap();
 
   /**
    * Creates a new ListLayout with options. See the list of properties below for a description

--- a/packages/@react-stately/collections/src/types.ts
+++ b/packages/@react-stately/collections/src/types.ts
@@ -47,7 +47,9 @@ export interface Node<T> {
   /** The key of the node after this node. */
   nextKey?: Key,
   /** Additional properties specific to a particular node type. */
-  props?: any
+  props?: any,
+  /** @private */
+  shouldInvalidate?: (context: unknown) => boolean
 }
 
 export interface PartialNode<T> {
@@ -64,7 +66,8 @@ export interface PartialNode<T> {
   childKey?: string,
   hasChildNodes?: boolean,
   childNodes?: () => IterableIterator<PartialNode<T>>,
-  props?: any
+  props?: any,
+  shouldInvalidate?: (context: unknown) => boolean
 }
 
 /** 

--- a/packages/@react-stately/grid/src/Column.ts
+++ b/packages/@react-stately/grid/src/Column.ts
@@ -43,15 +43,26 @@ Column.getCollectionNode = function* getCollectionNode<T>(props: ColumnProps<T>,
           };
         }
       }
+    },
+    shouldInvalidate(newContext: CollectionBuilderContext<T>) {
+      // This is a bit of a hack, but it works.
+      // If this method is called, then there's a cached version of this node available.
+      // But, we need to keep the list of columns in the new context up to date.
+      updateContext(newContext);
+      return false;
     }
   };
 
-  // register leaf columns on the context so that <Row> can access them
-  for (let node of fullNodes) {
-    if (!node.hasChildNodes) {
-      context.columns.push(node);
+  let updateContext = (context: CollectionBuilderContext<T>) => {
+    // register leaf columns on the context so that <Row> can access them
+    for (let node of fullNodes) {
+      if (!node.hasChildNodes) {
+        context.columns.push(node);
+      }
     }
-  }
+  };
+
+  updateContext(context);
 };
 
 // We don't want getCollectionNode to show up in the type definition

--- a/packages/@react-stately/grid/src/Row.ts
+++ b/packages/@react-stately/grid/src/Row.ts
@@ -76,6 +76,13 @@ Row.getCollectionNode = function* getCollectionNode<T>(props: RowProps<T>, conte
           };
         }
       }
+    },
+    shouldInvalidate(newContext: CollectionBuilderContext<T>) {
+      // Invalidate all rows if the columns changed.
+      return newContext.columns.length !== context.columns.length ||
+        newContext.columns.some((c, i) => c.key !== context.columns[i].key) ||
+        newContext.showSelectionCheckboxes !== context.showSelectionCheckboxes ||
+        newContext.selectionMode !== context.selectionMode;
     }
   };
 };


### PR DESCRIPTION
This adds an example of adding and removing columns from a Table to storybook and tests, and fixes a bunch of issues that caused it to be broken. Mostly due to over-aggressive caching.