### PR TITLE
Followup Dialog fixes

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -223,7 +223,7 @@ governing permissions and limitations under the License.
   }
 }
 
-.spectrum-Dialog-closeButton {
+.spectrum-Dialog.spectrum-Dialog--dismissable .spectrum-Dialog-closeButton {
   grid-area: closeButton;
   /* align and justify so it doesn't do the default 'stretch' and end up with forced height/width */
   align-self: start;

--- a/packages/@adobe/spectrum-css-temp/components/overlay/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/overlay/index.css
@@ -26,7 +26,7 @@ governing permissions and limitations under the License.
   visibility: visible;
   /* In Edge (pre chromium), a stacking context is formed for opacity less then 1, and then its removed for 1. 
      It causes a rendering flicker that is visible when css transition is applied. */
-  opacity: 0.99;
+  opacity: 0.9999;
 
   transition-delay: 0ms;
 


### PR DESCRIPTION
Bumps opacity to .9999 so background content isn't visible through Modals
Also will try to fix the dialog close button css (import order issue?) here

Opacity .99 (notice the faded black vertical line aka the scroll bar that bleeds through the middleish of the screenshot) :
![image](https://user-images.githubusercontent.com/9661127/81737273-b860d300-944c-11ea-9b2f-537cbc01851a.png)

vs

Opacity .9999
![image](https://user-images.githubusercontent.com/9661127/81737370-d8909200-944c-11ea-85fc-7fbe31efa86d.png)



## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
