### PR TITLE
Add focus ring to table rows and fix hover/focus color

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -187,9 +187,27 @@ governing permissions and limitations under the License.
     outline: 0;
   }
 
+  /* The focus ring must be on top of the first cell, so needs to be absolutely positioned. */
+  &:focus-ring {
+    &:before {
+      content: '';
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      width: var(--spectrum-selectlist-border-size-key-focus);
+      z-index: 3;
+    }
+  }
+
   &.is-drop-target {
     @inherit: %drop-target;
   }
+}
+
+/* the CSS logical properties postcss plugin doesn't seem to work with :focus-ring. */
+[dir="rtl"] .spectrum-Table-row:focus-ring:before {
+  right: 0;
 }
 
 .spectrum-Table > .spectrum-Table-body > .spectrum-Table-row:last-of-type {

--- a/packages/@adobe/spectrum-css-temp/components/table/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/skin.css
@@ -128,6 +128,12 @@ tbody.spectrum-Table-body {
     background-color: var(--spectrum-table-row-background-color-hover);
   }
 
+  &:focus-ring {
+    &:before {
+      background: var(--spectrum-selectlist-option-focus-indicator-color);
+    }
+  }
+
   &:active .spectrum-Table-cell {
     background-color: var(--spectrum-table-row-background-color-down);
   }
@@ -181,7 +187,7 @@ tbody.spectrum-Table-body {
   }
 
   .spectrum-Table-row {
-    .spectrum-Table-cell {
+    .spectrum-Table-cellWrapper {
       background-color: var(--spectrum-alias-background-color-default);
     }
 

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -15,7 +15,7 @@ import {Checkbox} from '@react-spectrum/checkbox';
 import {classNames, filterDOMProps, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {CollectionItem, layoutInfoToStyle, ScrollView, setScrollLeft, useCollectionView} from '@react-aria/collections';
 import {DOMRef} from '@react-types/shared';
-import {FocusRing} from '@react-aria/focus';
+import {FocusRing, useFocusRing} from '@react-aria/focus';
 import {GridState, useGridState} from '@react-stately/grid';
 import {mergeProps} from '@react-aria/utils';
 import {Node, Rect, ReusableView, useCollectionState} from '@react-stately/collections';
@@ -410,12 +410,41 @@ function TableRow({item, children, ...otherProps}) {
     isVirtualized: true
   }, state);
 
+  // The row should show the focus background style when any cell inside it is focused.
+  // If the row itself is focused, then it should have a blue focus indicator on the left.
+  let {
+    isFocusVisible: isFocusVisibleWithin,
+    focusProps: focusWithinProps
+  } = useFocusRing({within: true});
+  let {isFocusVisible, focusProps} = useFocusRing();
+  let props = mergeProps(
+    mergeProps(
+      rowProps,
+      otherProps
+    ),
+    mergeProps(
+      focusWithinProps,
+      focusProps
+    )
+  );
+
   return (
-    <FocusRing focusRingClass={classNames(styles, 'focus-ring')}>
-      <div {...rowProps} {...otherProps} ref={ref} className={classNames(styles, 'spectrum-Table-row', {'is-selected': isSelected})}>
-        {children}
-      </div>
-    </FocusRing>
+    <div 
+      {...props}
+      ref={ref}
+      className={
+        classNames(
+          styles,
+          'spectrum-Table-row',
+          {
+            'is-selected': isSelected,
+            'is-focused': isFocusVisibleWithin,
+            'focus-ring': isFocusVisible
+          }
+        )
+      }>
+      {children}
+    </div>
   );
 }
 


### PR DESCRIPTION
This adds a focus ring to table rows so that users can tell which row is focused, and also adds a background color to the row when a cell within it are focused. It also fixes the hover/focus background colors so they have better contrast.