### PR TITLE
indeterminate checkbox should trigger false always

### DIFF
--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -27,6 +27,7 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState, ref
     isDisabled = false,
     isRequired,
     isReadOnly,
+    isIndeterminate,
     value,
     name,
     children,
@@ -39,7 +40,11 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState, ref
     // since we spread props on label, onChange will end up there as well as in here.
     // so we have to stop propagation at the lowest level that we care about
     e.stopPropagation();
-    state.setSelected(e.target.checked);
+    if (isIndeterminate) {
+      state.setSelected(false);
+    } else {
+      state.setSelected(e.target.checked);
+    }
   };
 
   let hasChildren = children != null;

--- a/packages/@react-spectrum/checkbox/test/Checkbox.test.js
+++ b/packages/@react-spectrum/checkbox/test/Checkbox.test.js
@@ -138,8 +138,6 @@ describe('Checkbox', function () {
     Name                       | Component      | props
     ${'Checkbox'}              | ${Checkbox}    | ${{onChange: onChangeSpy, isIndeterminate: true}}
     ${'Checkbox isEmphasized'} | ${Checkbox}    | ${{onChange: onChangeSpy, isIndeterminate: true, isEmphasized: true}}
-    ${'V2Checkbox'}            | ${V2Checkbox}  | ${{onChange: onChangeSpy, indeterminate: true}}
-    ${'V2Checkbox quiet'}      | ${V2Checkbox}  | ${{onChange: onChangeSpy, indeterminate: true, quiet: true}}
   `('$Name can be indeterminate (this one is weird) it is controlled, but not via isSelected', function ({Component, props}) {
     let {getByLabelText} = render(<Component {...props}>Click Me</Component>);
 
@@ -148,9 +146,9 @@ describe('Checkbox', function () {
     expect(checkbox.checked).toBeFalsy();
 
     userEvent.click(checkbox);
-    expect(checkbox.checked).toBeTruthy();
+    expect(checkbox.checked).toBeFalsy();
     expect(onChangeSpy).toHaveBeenCalled();
-    expect(onChangeSpy.mock.calls[0][0]).toBe(true);
+    expect(onChangeSpy.mock.calls[0][0]).toBe(false);
 
     userEvent.click(checkbox);
     expect(checkbox.checked).toBeFalsy();

--- a/packages/@react-stately/toggle/src/useToggleState.ts
+++ b/packages/@react-stately/toggle/src/useToggleState.ts
@@ -18,7 +18,9 @@ export interface ToggleState {
   isSelected: boolean,
 
   /** Updates selection state. */
-  setSelected: (isSelected: boolean) => void
+  setSelected: (isSelected: boolean) => void,
+
+
 }
 
 /**

--- a/packages/@react-types/checkbox/src/index.d.ts
+++ b/packages/@react-types/checkbox/src/index.d.ts
@@ -24,8 +24,9 @@ export interface CheckboxBase extends InputBase {
 
 export interface CheckboxProps extends CheckboxBase {
   /**
-   * Indeterminism is presentational, when a checkbox is indeterminate, it overrides the selection state.
+   * When a checkbox is indeterminate, it overrides the selection state.
    * The indeterminate visual representation remains even after subsequent clicks.
+   * It will also emit a change event to go to false because this is a controlled state and we want it to be .
    */
   isIndeterminate?: boolean
 }


### PR DESCRIPTION
When indeterminate, the next click of the checkbox should move to false. Not sure if i should do this in aria or do it in stately. It's more part of checkboxes than toggle in general, which switch also uses.


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
