### PR TITLE
Make table behave as a single tab stop

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/table/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/table/index.css
@@ -15,6 +15,7 @@ governing permissions and limitations under the License.
 .spectrum-Table {
   border-collapse: separate;
   border-spacing: 0;
+  outline: none;
 }
 
 .spectrum-Table-sortedIcon {

--- a/packages/@react-aria/actiongroup/src/useActionGroup.ts
+++ b/packages/@react-aria/actiongroup/src/useActionGroup.ts
@@ -13,7 +13,7 @@
 import {ActionGroupKeyboardDelegate} from './ActionGroupKeyboardDelegate';
 import {ActionGroupProps} from '@react-types/actiongroup';
 import {ActionGroupState} from '@react-stately/actiongroup';
-import {HTMLAttributes, useMemo, useState} from 'react';
+import {HTMLAttributes, RefObject, useMemo, useState} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {Orientation} from '@react-types/shared';
 import {useFocusWithin} from '@react-aria/interactions';
@@ -37,7 +37,8 @@ export interface ActionGroupAria {
   actionGroupProps: HTMLAttributes<HTMLElement>,
   buttonProps: HTMLAttributes<HTMLElement>,
 }
-export function useActionGroup<T>(props: ActionGroupProps<T>, state: ActionGroupState<T>): ActionGroupAria {
+
+export function useActionGroup<T>(props: ActionGroupProps<T>, state: ActionGroupState<T>, ref: RefObject<HTMLElement>): ActionGroupAria {
   let {
     id,
     selectionMode = 'single',
@@ -50,6 +51,7 @@ export function useActionGroup<T>(props: ActionGroupProps<T>, state: ActionGroup
   let keyboardDelegate = useMemo(() => new ActionGroupKeyboardDelegate(state.collection, direction, orientation), [state.collection, direction, orientation]);
 
   let {collectionProps} = useSelectableCollection({
+    ref,
     selectionManager: state.selectionManager,
     keyboardDelegate,
     disallowSelectAll: true

--- a/packages/@react-aria/grid/src/useGridCell.ts
+++ b/packages/@react-aria/grid/src/useGridCell.ts
@@ -16,6 +16,7 @@ import {HTMLAttributes, RefObject} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {usePress} from '@react-aria/interactions';
 import {useSelectableItem} from '@react-aria/selection';
+import {useTabKey} from './useTabKey';
 
 interface GridCellProps {
   node: GridNode<unknown>,
@@ -44,6 +45,7 @@ export function useGridCell<T>(props: GridCellProps, state: GridState<T>): GridC
   // TODO: move into useSelectableItem?
   let {pressProps} = usePress(itemProps);
   let interactions = mergeProps(itemProps, pressProps);
+  let tabKey = useTabKey();
 
   // Grid cells can have focusable elements inside them. In this case, focus should
   // be marshalled to that element rather than focusing the cell itself.
@@ -52,7 +54,12 @@ export function useGridCell<T>(props: GridCellProps, state: GridState<T>): GridC
       // useSelectableItem only handles setting the focused key when
       // the focused element is the gridcell itself. We also want to
       // set the focused key when a child element receives focus.
-      state.selectionManager.setFocusedKey(node.key);
+      // If the tab key is currently pressed, then skip this. We want
+      // to restore focus to the previously focused row/cell in that case
+      // since the table should act like a single tab stop.
+      if (!tabKey.isDown()) {
+        state.selectionManager.setFocusedKey(node.key);
+      }
       return;
     }
 

--- a/packages/@react-aria/grid/src/useSelectionCheckbox.ts
+++ b/packages/@react-aria/grid/src/useSelectionCheckbox.ts
@@ -39,7 +39,8 @@ export function useSelectionCheckbox<T>(props: SelectionCheckboxProps, state: Gr
       'aria-label': 'Select',
       'aria-labelledby': `${checkboxId} ${getRowLabelledBy(state, key)}`,
       isSelected,
-      onChange: () => state.selectionManager.toggleSelection(key)
+      onChange: () => state.selectionManager.toggleSelection(key),
+      tabIndex: -1
     }
   };
 }
@@ -51,7 +52,8 @@ export function useSelectAllCheckbox<T>(state: GridState<T>): SelectionCheckboxA
       'aria-label': 'Select All',
       isSelected: isSelectAll,
       isIndeterminate: !isEmpty && !isSelectAll,
-      onChange: () => state.selectionManager.toggleSelectAll()
+      onChange: () => state.selectionManager.toggleSelectAll(),
+      tabIndex: -1
     }
   };
 }

--- a/packages/@react-aria/grid/src/useTabKey.ts
+++ b/packages/@react-aria/grid/src/useTabKey.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import {useEffect} from 'react';
+
+let isTabKeyDown = false;
+function onKeyDown(e: globalThis.KeyboardEvent) {
+  isTabKeyDown = e.key === 'Tab';
+}
+
+function onKeyUp() {
+  isTabKeyDown = false;
+}
+
+let listenerCount = 0;
+function setupGlobalTabListener() {
+  listenerCount++;
+  if (listenerCount === 1) {
+    document.addEventListener('keydown', onKeyDown, false);
+    document.addEventListener('keyup', onKeyUp, false);  
+  }
+
+  return teardownGlobalTabListener;
+}
+
+function teardownGlobalTabListener() {
+  if (listenerCount === 0) {
+    return;
+  }
+
+  listenerCount--;
+  if (listenerCount === 0) {
+    document.removeEventListener('keydown', onKeyDown, false);
+    document.removeEventListener('keyup', onKeyUp, false);  
+  }
+}
+
+// A helper hook that registers a global listener to track whether the Tab key is currently pressed.
+// Can be used to determine if a focus event came from tabbing or other means.
+export function useTabKey() {
+  useEffect(setupGlobalTabListener, []);
+  return {
+    isDown() {
+      return isTabKeyDown;
+    }
+  };
+}

--- a/packages/@react-aria/selection/package.json
+++ b/packages/@react-aria/selection/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-aria/i18n": "^3.0.0-rc.2",
+    "@react-aria/focus": "^3.0.0-rc.2",
     "@react-aria/interactions": "^3.0.0-rc.2",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-stately/collections": "^3.0.0-alpha.1",

--- a/packages/@react-aria/selection/src/useSelectableCollection.ts
+++ b/packages/@react-aria/selection/src/useSelectableCollection.ts
@@ -12,6 +12,7 @@
 
 import {FocusEvent, HTMLAttributes, KeyboardEvent, RefObject, useEffect} from 'react';
 import {focusWithoutScrolling} from '@react-aria/utils';
+import {getFocusableTreeWalker} from '@react-aria/focus';
 import {KeyboardDelegate} from '@react-types/shared';
 import {mergeProps} from '@react-aria/utils';
 import {MultipleSelectionManager} from '@react-stately/selection';
@@ -35,7 +36,7 @@ function isCtrlKeyPressed(e: KeyboardEvent) {
 interface SelectableCollectionOptions {
   selectionManager: MultipleSelectionManager,
   keyboardDelegate: KeyboardDelegate,
-  ref?: RefObject<HTMLElement>,
+  ref: RefObject<HTMLElement>,
   autoFocus?: boolean | FocusStrategy,
   shouldFocusWrap?: boolean,
   disallowEmptySelection?: boolean,
@@ -179,6 +180,19 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
           manager.clearSelection();
         }
         break;
+      case 'Tab': {
+        // There may be elements that are "tabbable" inside a collection (e.g. in a grid cell).
+        // However, collections should be treated as a single tab stop, with arrow key navigation internally.
+        // We don't control the rendering of these, so we can't override the tabIndex to prevent tabbing.
+        // Instead, we handle the Tab key, and move focus manually to the next/previous tabbable element from the collection.
+        e.preventDefault();
+        let walker = getFocusableTreeWalker(document.body, {tabbable: true, from: ref.current});
+        let next = (e.shiftKey ? walker.previousNode() : walker.nextNode()) as HTMLElement;
+        if (next) {
+          next.focus();
+        }
+        break;
+      }
     }
   };
 
@@ -199,7 +213,7 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
 
     manager.setFocused(true);
 
-    if (manager.focusedKey == null && e.target === e.currentTarget) {
+    if (manager.focusedKey == null) {
       // If the user hasn't yet interacted with the collection, there will be no focusedKey set.
       // Attempt to detect whether the user is tabbing forward or backward into the collection
       // and either focus the first or last item accordingly.
@@ -212,8 +226,11 @@ export function useSelectableCollection(options: SelectableCollectionOptions): S
     }
   };
 
-  let onBlur = () => {
-    manager.setFocused(false);
+  let onBlur = (e) => {
+    // Don't set blurred and then focused again if moving focus within the collection.
+    if (!e.currentTarget.contains(e.relatedTarget as HTMLElement)) {
+      manager.setFocused(false);
+    }
   };
 
   useEffect(() => {

--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -11,7 +11,7 @@
  */
 
 import {focusWithoutScrolling} from '@react-aria/utils';
-import {HTMLAttributes, Key, RefObject, useEffect} from 'react';
+import {HTMLAttributes, Key, RefObject, useLayoutEffect} from 'react';
 import {MultipleSelectionManager} from '@react-stately/selection';
 import {PressEvent} from '@react-types/shared';
 import {PressProps} from '@react-aria/interactions';
@@ -57,7 +57,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
 
   // Focus the associated DOM node when this item becomes the focusedKey
   let isFocused = itemKey === manager.focusedKey;
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (isFocused && manager.isFocused && document.activeElement !== itemRef.current) {
       focusWithoutScrolling(itemRef.current);
     }

--- a/packages/@react-aria/sidenav/src/useSideNav.ts
+++ b/packages/@react-aria/sidenav/src/useSideNav.ts
@@ -10,29 +10,35 @@
  * governing permissions and limitations under the License.
  */
 
-import {HTMLAttributes} from 'react';
+import {HTMLAttributes, RefObject} from 'react';
 import {ListLayout} from '@react-stately/collections';
 import {SideNavProps} from '@react-types/sidenav';
 import {TreeState} from '@react-stately/tree';
 import {useId} from '@react-aria/utils';
 import {useSelectableCollection} from '@react-aria/selection';
 
+interface SideNavAriaProps<T> extends SideNavProps<T> {
+  layout?: ListLayout<T>
+}
+
 interface SideNavAria {
   navProps: HTMLAttributes<HTMLDivElement>,
   listProps: HTMLAttributes<HTMLUListElement>
 }
 
-export function useSideNav<T>(props: SideNavProps<T>, state: TreeState<T>, layout: ListLayout<T>): SideNavAria {
+export function useSideNav<T>(props: SideNavAriaProps<T>, state: TreeState<T>, ref: RefObject<HTMLElement>): SideNavAria {
   let {
     id,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabeldBy,
-    shouldFocusWrap
+    shouldFocusWrap,
+    layout
   } = props;
 
   id = useId(id);
 
   let {collectionProps} = useSelectableCollection({
+    ref,
     selectionManager: state.selectionManager,
     keyboardDelegate: layout,
     shouldFocusWrap

--- a/packages/@react-aria/sidenav/test/useSideNav.test.js
+++ b/packages/@react-aria/sidenav/test/useSideNav.test.js
@@ -22,7 +22,7 @@ describe('useSideNav', function () {
   });
 
   let renderSideNavHook = (menuProps) => {
-    let {result} = renderHook(() => useSideNav(menuProps, mockState, mockLayout));
+    let {result} = renderHook(() => useSideNav({...menuProps, layout: mockLayout}, mockState));
     return result.current;
   };
 

--- a/packages/@react-aria/toggle/src/useToggle.ts
+++ b/packages/@react-aria/toggle/src/useToggle.ts
@@ -32,7 +32,8 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState, ref
     children,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledby,
-    validationState = 'valid'
+    validationState = 'valid',
+    tabIndex
   } = props;
 
   let onChange = (e) => {
@@ -69,6 +70,7 @@ export function useToggle(props: SwitchProps & DOMProps, state: ToggleState, ref
       value,
       name,
       type: 'checkbox',
+      tabIndex,
       ...interactions
     }
   };

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -40,12 +40,12 @@ function ActionGroup<T extends object>(props: SpectrumActionGroupProps<T>, ref: 
     ...otherProps
   } = props;
 
+  let domRef = useDOMRef(ref);
   let state = useActionGroupState({...props, selectionMode});
-  let {actionGroupProps, buttonProps} = useActionGroup(props, state);
+  let {actionGroupProps, buttonProps} = useActionGroup(props, state, domRef);
   let isVertical = orientation === 'vertical';
   let providerProps = {isEmphasized, isDisabled, isQuiet};
   let {styleProps} = useStyleProps(props);
-  let domRef = useDOMRef(ref);
 
   return (
     <div

--- a/packages/@react-spectrum/checkbox/src/Checkbox.tsx
+++ b/packages/@react-spectrum/checkbox/src/Checkbox.tsx
@@ -50,7 +50,8 @@ function Checkbox(props: SpectrumCheckboxProps, ref: FocusableRef<HTMLLabelEleme
         {
           id: false,
           'aria-label': false,
-          'aria-labelledby': false
+          'aria-labelledby': false,
+          tabIndex: false
         }
       )}
       {...styleProps}

--- a/packages/@react-spectrum/sidenav/src/SideNav.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNav.tsx
@@ -13,7 +13,7 @@
 import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {CollectionItem, CollectionView} from '@react-aria/collections';
 import {ListLayout, Node} from '@react-stately/collections';
-import React, {ReactElement, useMemo} from 'react';
+import React, {ReactElement, useMemo, useRef} from 'react';
 import {ReusableView} from '@react-stately/collections';
 import {SideNavContext} from './SideNavContext';
 import {SideNavItem} from './SideNavItem';
@@ -28,7 +28,8 @@ export function SideNav<T extends object>(props: SpectrumSideNavProps<T>) {
   let state = useTreeState({...props, selectionMode: 'single', disallowEmptySelection: true});
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let layout = useMemo(() => new ListLayout({rowHeight: 40, collator}), [collator]);
-  let {navProps, listProps} = useSideNav(props, state, layout);
+  let ref = useRef();
+  let {navProps, listProps} = useSideNav({...props, layout}, state, ref);
   let {styleProps} = useStyleProps(props);
 
   layout.collection = state.collection;
@@ -65,6 +66,7 @@ export function SideNav<T extends object>(props: SpectrumSideNavProps<T>) {
       <SideNavContext.Provider value={state}>
         <CollectionView
           {...listProps}
+          ref={ref}
           focusedKey={state.selectionManager.focusedKey}
           className={classNames(styles, 'spectrum-SideNav')}
           layout={layout}

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -14,6 +14,7 @@ import {action} from '@storybook/addon-actions';
 import {Cell, Column, Row, Table, TableBody, TableHeader} from '../';
 import {Content} from '@react-spectrum/view';
 import {CRUDExample} from './CRUDExample';
+import {Flex} from '@react-spectrum/layout';
 import {Heading} from '@react-spectrum/typography';
 import {HidingColumns} from './HidingColumns';
 import {IllustratedMessage} from '@react-spectrum/illustratedmessage';
@@ -177,25 +178,29 @@ storiesOf('Table', module)
   .add(
     'focusable cells',
     () => (
-      <Table width={300} height={200} onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader>
-          <Column key="foo">Foo</Column>
-          <Column key="bar">Bar</Column>
-          <Column key="baz">baz</Column>
-        </TableHeader>
-        <TableBody>
-          <Row>
-            <Cell><Switch aria-label="Foo" /></Cell>
-            <Cell><Link><a href="https://google.com" target="_blank">Google</a></Link></Cell>
-            <Cell>Three</Cell>
-          </Row>
-          <Row>
-            <Cell><Switch aria-label="Foo" /></Cell>
-            <Cell><Link><a href="https://yahoo.com" target="_blank">Yahoo</a></Link></Cell>
-            <Cell>Three</Cell>
-          </Row>
-        </TableBody>
-      </Table>
+      <Flex flexDirection="column">
+        <input placeholder="Focusable before" />
+        <Table width={300} height={200} onSelectionChange={s => onSelectionChange([...s])}>
+          <TableHeader>
+            <Column key="foo">Foo</Column>
+            <Column key="bar">Bar</Column>
+            <Column key="baz">baz</Column>
+          </TableHeader>
+          <TableBody>
+            <Row>
+              <Cell><Switch aria-label="Foo" /></Cell>
+              <Cell><Link><a href="https://google.com" target="_blank">Google</a></Link></Cell>
+              <Cell>Three</Cell>
+            </Row>
+            <Row>
+              <Cell><Switch aria-label="Foo" /></Cell>
+              <Cell><Link><a href="https://yahoo.com" target="_blank">Yahoo</a></Link></Cell>
+              <Cell>Three</Cell>
+            </Row>
+          </TableBody>
+        </Table>
+        <input placeholder="Focusable after" />
+      </Flex>
     )
   )
   .add(

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -1011,25 +1011,29 @@ describe('Table', function () {
 
     describe('focus marshalling', function () {
       let renderFocusable = () => render(
-        <Table>
-          <TableHeader>
-            <Column>Foo</Column>
-            <Column>Bar</Column>
-            <Column>baz</Column>
-          </TableHeader>
-          <TableBody>
-            <Row>
-              <Cell textValue="Foo 1"><Switch aria-label="Foo 1" /></Cell>
-              <Cell textValue="Google"><Link><a href="https://google.com" target="_blank">Google</a></Link></Cell>
-              <Cell>Baz 1</Cell>
-            </Row>
-            <Row>
-              <Cell textValue="Foo 2"><Switch aria-label="Foo 2" /></Cell>
-              <Cell textValue="Yahoo"><Link><a href="https://yahoo.com" target="_blank">Yahoo</a></Link></Cell>
-              <Cell>Baz 2</Cell>
-            </Row>
-          </TableBody>
-        </Table>
+        <>
+          <input data-testid="before" />
+          <Table>
+            <TableHeader>
+              <Column>Foo</Column>
+              <Column>Bar</Column>
+              <Column>baz</Column>
+            </TableHeader>
+            <TableBody>
+              <Row>
+                <Cell textValue="Foo 1"><Switch aria-label="Foo 1" /></Cell>
+                <Cell textValue="Google"><Link><a href="https://google.com" target="_blank">Google</a></Link></Cell>
+                <Cell>Baz 1</Cell>
+              </Row>
+              <Row>
+                <Cell textValue="Foo 2"><Switch aria-label="Foo 2" /></Cell>
+                <Cell textValue="Yahoo"><Link><a href="https://yahoo.com" target="_blank">Yahoo</a></Link></Cell>
+                <Cell>Baz 2</Cell>
+              </Row>
+            </TableBody>
+          </Table>
+          <input data-testid="after" />
+        </>
       );
 
       it('should marshall focus to the focusable element inside a cell', function () {
@@ -1052,6 +1056,110 @@ describe('Table', function () {
 
         moveFocus('ArrowUp');
         expect(document.activeElement).toBe(tree.getAllByRole('checkbox')[0]);
+      });
+
+      it('should move focus to the first row when tabbing into the table from the start', function () {
+        let tree = renderFocusable();
+
+        let table = tree.getByRole('grid');
+        expect(table).toHaveAttribute('tabIndex', '0');
+
+        let before = tree.getByTestId('before');
+        before.focus();
+
+        // Simulate tabbing to the first "tabbable" item inside the table
+        fireEvent.keyDown(before, {key: 'Tab'});
+        within(table).getAllByRole('switch')[0].focus();
+        fireEvent.keyUp(before, {key: 'Tab'});
+
+        expect(document.activeElement).toBe(within(table).getAllByRole('row')[1]);
+      });
+
+      it('should move focus to the last row when tabbing into the table from the end', function () {
+        let tree = renderFocusable();
+
+        let table = tree.getByRole('grid');
+        expect(table).toHaveAttribute('tabIndex', '0');
+
+        let after = tree.getByTestId('after');
+        after.focus();
+
+        // Simulate tabbing to the last "tabbable" item inside the table
+        fireEvent.keyDown(after, {key: 'Tab', shiftKey: true});
+        within(table).getAllByRole('link')[1].focus();
+        fireEvent.keyUp(after, {key: 'Tab', shiftKey: true});
+
+        expect(document.activeElement).toBe(within(table).getAllByRole('row')[2]);
+      });
+
+      it('should move focus to the last focused cell when tabbing into the table from the start', function () {
+        let tree = renderFocusable();
+
+        let table = tree.getByRole('grid');
+        expect(table).toHaveAttribute('tabIndex', '0');
+
+        let baz1 = tree.getByText('Baz 1');
+        baz1.focus();
+
+        expect(table).toHaveAttribute('tabIndex', '-1');
+
+        let before = tree.getByTestId('before');
+        before.focus();
+
+        // Simulate tabbing to the first "tabbable" item inside the table
+        fireEvent.keyDown(before, {key: 'Tab'});
+        within(table).getAllByRole('switch')[0].focus();
+        fireEvent.keyUp(before, {key: 'Tab'});
+
+        expect(document.activeElement).toBe(baz1);
+      });
+
+      it('should move focus to the last focused cell when tabbing into the table from the end', function () {
+        let tree = renderFocusable();
+
+        let table = tree.getByRole('grid');
+        expect(table).toHaveAttribute('tabIndex', '0');
+
+        let baz1 = tree.getByText('Baz 1');
+        baz1.focus();
+
+        expect(table).toHaveAttribute('tabIndex', '-1');
+
+        let after = tree.getByTestId('after');
+        after.focus();
+
+        // Simulate tabbing to the last "tabbable" item inside the table
+        fireEvent.keyDown(after, {key: 'Tab'});
+        within(table).getAllByRole('link')[1].focus();
+        fireEvent.keyUp(after, {key: 'Tab'});
+
+        expect(document.activeElement).toBe(baz1);
+      });
+
+      it('should move focus after the table when tabbing', function () {
+        let tree = renderFocusable();
+
+        tree.getAllByRole('switch')[1].focus();
+
+        // Simulate tabbing within the table
+        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
+        fireEvent.keyUp(document.activeElement, {key: 'Tab'});
+
+        let after = tree.getByTestId('after');
+        expect(document.activeElement).toBe(after);
+      });
+
+      it('should move focus before the table when shift tabbing', function () {
+        let tree = renderFocusable();
+
+        tree.getAllByRole('switch')[1].focus();
+
+        // Simulate shift tabbing within the table
+        fireEvent.keyDown(document.activeElement, {key: 'Tab', shiftKey: true});
+        fireEvent.keyUp(document.activeElement, {key: 'Tab', shiftKey: true});
+
+        let before = tree.getByTestId('before');
+        expect(document.activeElement).toBe(before);
       });
     });
   });

--- a/packages/@react-spectrum/tree/src/Tree.tsx
+++ b/packages/@react-spectrum/tree/src/Tree.tsx
@@ -37,7 +37,9 @@ export function Tree<T extends object>(props: CollectionBase<T> & Expandable & M
     })
   , []);
 
+  let ref = useRef();
   let {collectionProps} = useSelectableCollection({
+    ref,
     selectionManager: state.selectionManager,
     keyboardDelegate: layout
   });
@@ -45,6 +47,7 @@ export function Tree<T extends object>(props: CollectionBase<T> & Expandable & M
   return (
     <CollectionView
       {...collectionProps}
+      ref={ref}
       focusedKey={state.selectionManager.focusedKey}
       className={classNames(styles, 'spectrum-TreeView')}
       layout={layout}

--- a/packages/@react-stately/selection/src/useMultipleSelectionState.ts
+++ b/packages/@react-stately/selection/src/useMultipleSelectionState.ts
@@ -25,8 +25,12 @@ export function useMultipleSelectionState(props: MultipleSelection): MultipleSel
     disallowEmptySelection
   } = props;
 
-  let isFocused = useRef(false);
-  let [focusedKey, setFocusedKey] = useState(null);
+  // We want synchronous updates to `isFocused` and `focusedKey` after their setters are called.
+  // But we also need to trigger a react re-render. So, we have both a ref (sync) and state (async).
+  let isFocusedRef = useRef(false);
+  let [, setFocused] = useState(false);
+  let focusedKeyRef = useRef(null);
+  let [, setFocusedKey] = useState(null);
   let selectedKeysProp = useMemo(() => props.selectedKeys ? new Selection(props.selectedKeys) : undefined, [props.selectedKeys]);
   let defaultSelectedKeys = useMemo(() => props.defaultSelectedKeys ? new Selection(props.defaultSelectedKeys) : new Selection(), [props.defaultSelectedKeys]);
   let [selectedKeys, setSelectedKeys] = useControlledState(
@@ -39,13 +43,19 @@ export function useMultipleSelectionState(props: MultipleSelection): MultipleSel
     selectionMode,
     disallowEmptySelection,
     get isFocused() {
-      return isFocused.current;
+      return isFocusedRef.current;
     },
     setFocused(f) {
-      isFocused.current = f;
+      isFocusedRef.current = f;
+      setFocused(f);
     },
-    focusedKey,
-    setFocusedKey,
+    get focusedKey() {
+      return focusedKeyRef.current;
+    },
+    setFocusedKey(k) {
+      focusedKeyRef.current = k;
+      setFocusedKey(k);
+    },
     selectedKeys,
     setSelectedKeys
   };


### PR DESCRIPTION
This makes tables behave as a single tab stop, even though they may contain tabbable elements inside their cells. To navigate between cells, users must use the arrow keys. The tab key should navigate them in or out of the entire table.

This is slightly complicated to implement because we don't control the rendering of cell contents, so there's no good way for us to enforce `tabIndex={-1}`. So instead, we need to handle events and marshal focus to the correct element. However, we only want to do this when tabbing, not when focus moves in other ways (e.g. mouse, screen reader).

To accomplish this, we handle the Tab key ourselves for events within the table, and manually move focus to the next tabbable element before/after the table. This overrides the default browser behavior which would be to tab to the next tabbable element, which might be inside the table.

In addition, we need to handle tabbing into and out of the table from outside. In this case, the browser will focus the first/last tabbable element within the table, but we want to restore focus to the last focused row/cell, or the first/last row if nothing has ever been focused before. To handle this, we just need to skip setting the focused key to the cell containing the focused element if the focus came from a tab key event. This is detected by using a global keyboard listener that tracks whether the Tab key is currently pressed.

This mostly works, except in the case where the table is the first/last item element the page and you're tabbing in from outside the window. In this case, there's no preceding keyboard event to capture, so we won't know if the Tab key is pressed. Unfortunately, it seems there is nothing we can do in this case, but this doesn't seem too terrible to me.

This is pretty hacky, I admit. But as far as I can tell, it's the only way to implement this, short of traversing through the DOM in every cell and mutating the `tabIndex` property (which would be unsafe when react renders updates anyway), or some context to tell children to be non-tabbable (wouldn't work with non-RSP elements).