### PR TITLE
Implement select all behavior for infinite scrolling

### DIFF
--- a/packages/@react-aria/selection/src/useSelectableItem.ts
+++ b/packages/@react-aria/selection/src/useSelectableItem.ts
@@ -43,7 +43,7 @@ export function useSelectableItem(options: SelectableItemOptions): SelectableIte
     }
 
     if (manager.selectionMode === 'single') {
-      if (manager.selectedKeys.has(itemKey) && !manager.disallowEmptySelection) {
+      if (manager.isSelected(itemKey) && !manager.disallowEmptySelection) {
         manager.toggleSelection(itemKey);
       } else {
         manager.replaceSelection(itemKey);

--- a/packages/@react-spectrum/table/stories/CRUDExample.tsx
+++ b/packages/@react-spectrum/table/stories/CRUDExample.tsx
@@ -69,6 +69,8 @@ export function CRUDExample() {
     }
   };
 
+  let selectedCount = list.selectedKeys === 'all' ? list.items.length : list.selectedKeys.size;
+
   return (
     <Flex flexDirection="column">
       <ActionGroup selectionMode="none" marginBottom={8}>
@@ -76,11 +78,11 @@ export function CRUDExample() {
           <Item aria-label="Add item"><Add /></Item>
           {onClose => <EditDialog item={null} onClose={onClose} onConfirm={createItem} />}
         </DialogTrigger>
-        {list.selectedKeys.size > 0 &&
+        {selectedCount > 0 &&
           <DialogTrigger>
             <Item aria-label="Delete selected items"><Delete /></Item>
             <AlertDialog title="Delete" variant="destructive" primaryActionLabel="Delete" onPrimaryAction={deleteSelectedItems}>
-              Are you sure you want to delete {list.selectedKeys.size === 1 ? '1 item' : `${list.selectedKeys.size} items`}?
+              Are you sure you want to delete {selectedCount === 1 ? '1 item' : `${selectedCount} items`}?
             </AlertDialog>
           </DialogTrigger>
         }

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -460,7 +460,7 @@ function AsyncLoadingExample() {
   });
 
   return (
-    <Table width={1000} height={500} isQuiet selectionMode="none" sortDescriptor={list.sortDescriptor} onSortChange={list.sort}>
+    <Table width={1000} height={500} isQuiet sortDescriptor={list.sortDescriptor} onSortChange={list.sort}>
       <TableHeader>
         <Column uniqueKey="score" width={100} allowsSorting>Score</Column>
         <Column uniqueKey="title" isRowHeader allowsSorting>Title</Column>

--- a/packages/@react-spectrum/test-utils/src/triggerPress.js
+++ b/packages/@react-spectrum/test-utils/src/triggerPress.js
@@ -14,8 +14,8 @@ import {fireEvent} from '@testing-library/react';
 
 // Triggers a "press" event on an element.
 // TODO: move to somewhere more common
-export function triggerPress(element) {
-  fireEvent.mouseDown(element, {detail: 1});
-  fireEvent.mouseUp(element, {detail: 1});
-  fireEvent.click(element, {detail: 1});
+export function triggerPress(element, opts = {}) {
+  fireEvent.mouseDown(element, {detail: 1, ...opts});
+  fireEvent.mouseUp(element, {detail: 1, ...opts});
+  fireEvent.click(element, {detail: 1, ...opts});
 }

--- a/packages/@react-stately/data/src/useAsyncList.ts
+++ b/packages/@react-stately/data/src/useAsyncList.ts
@@ -12,7 +12,7 @@
 
 import {createListActions, ListData, ListState} from './useListData';
 import {Key, Reducer, useEffect, useReducer} from 'react';
-import {SortDescriptor} from '@react-types/shared';
+import {Selection, SortDescriptor} from '@react-types/shared';
 
 interface AsyncListOptions<T, C> {
   initialSelectedKeys?: Iterable<Key>,
@@ -25,7 +25,7 @@ interface AsyncListOptions<T, C> {
 type AsyncListLoadFunction<T, C> = (state: AsyncListLoadOptions<T, C>) => Promise<AsyncListStateUpdate<T, C>>;
 interface AsyncListLoadOptions<T, C> {
   items: T[],
-  selectedKeys: Set<Key>,
+  selectedKeys: Selection,
   sortDescriptor: SortDescriptor,
   signal: AbortSignal,
   cursor?: C
@@ -42,7 +42,7 @@ interface AsyncListState<T, C> extends ListState<T> {
   state: 'loading' | 'sorting' | 'loadingMore' | 'error' | 'idle'
   items: T[],
   // disabledKeys?: Iterable<Key>,
-  selectedKeys: Set<Key>,
+  selectedKeys: Selection,
   // selectedKey?: Key,
   // expandedKeys?: Iterable<Key>,
   sortDescriptor?: SortDescriptor,

--- a/packages/@react-stately/data/test/useListData.test.js
+++ b/packages/@react-stately/data/test/useListData.test.js
@@ -245,6 +245,20 @@ describe('useListData', function () {
     expect(result.current.selectedKeys).toEqual(new Set());
   });
 
+  it('should remove the selected items with select all', function () {
+    let {result} = renderHook(() => useListData({initialItems: initial, getKey, initialSelectedKeys: 'all'}));
+    let initialResult = result.current;
+
+    act(() => {
+      result.current.removeSelectedItems();
+    });
+
+    expect(result.current.items).not.toBe(initialResult.items);
+    expect(result.current.items).toHaveLength(0);
+    expect(result.current.selectedKeys).not.toBe(initialResult.selectedKeys);
+    expect(result.current.selectedKeys).toEqual(new Set());
+  });
+
   it('should update an item', function () {
     let {result} = renderHook(() => useListData({initialItems: initial, getKey}));
     let initialResult = result.current;

--- a/packages/@react-stately/select/src/useSelectState.ts
+++ b/packages/@react-stately/select/src/useSelectState.ts
@@ -47,7 +47,7 @@ export function useSelectState<T extends object>(props: SelectProps<T>): SelectS
     ...props,
     selectionMode: 'single',
     selectedKeys,
-    onSelectionChange: (keys) => {
+    onSelectionChange: (keys: Set<Key>) => {
       setSelectedKey(keys.values().next().value);
       triggerState.setOpen(false);
     }

--- a/packages/@react-stately/selection/src/types.ts
+++ b/packages/@react-stately/selection/src/types.ts
@@ -11,7 +11,7 @@
  */
 
 import {Key} from 'react';
-import {SelectionMode} from '@react-types/shared';
+import {Selection, SelectionMode} from '@react-types/shared';
 
 export interface FocusState {
   isFocused: boolean,
@@ -29,14 +29,18 @@ export interface SingleSelectionState extends FocusState {
 export interface MultipleSelectionState extends FocusState {
   selectionMode: SelectionMode,
   disallowEmptySelection?: boolean,
-  selectedKeys: Set<Key>,
-  setSelectedKeys(keys: Set<Key> | ((v: Set<Key>) => Set<Key>)): void
+  selectedKeys: Selection,
+  setSelectedKeys(keys: Selection | ((v: Selection) => Selection)): void
 }
 
-export interface MultipleSelectionManager extends MultipleSelectionState {
+export interface MultipleSelectionManager extends FocusState {
+  selectionMode: SelectionMode,
+  disallowEmptySelection?: boolean,
+  selectedKeys: Set<Key>,
   extendSelection(toKey: Key): void,
   toggleSelection(key: Key): void,
   replaceSelection(key: Key): void,
   selectAll(): void,
-  clearSelection(): void
+  clearSelection(): void,
+  isSelected(key: Key): boolean
 }

--- a/packages/@react-stately/selection/src/useMultipleSelectionState.ts
+++ b/packages/@react-stately/selection/src/useMultipleSelectionState.ts
@@ -10,11 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
+import {Key, useMemo, useRef, useState} from 'react';
 import {MultipleSelection, SelectionMode} from '@react-types/shared';
 import {MultipleSelectionState} from './types';
 import {Selection} from './Selection';
 import {useControlledState} from '@react-stately/utils';
-import {useMemo, useRef, useState} from 'react';
 
 /**
  * Manages state for multiple selection and focus in a collection.
@@ -27,8 +27,8 @@ export function useMultipleSelectionState(props: MultipleSelection): MultipleSel
 
   let isFocused = useRef(false);
   let [focusedKey, setFocusedKey] = useState(null);
-  let selectedKeysProp = useMemo(() => props.selectedKeys ? new Selection(props.selectedKeys) : undefined, [props.selectedKeys]);
-  let defaultSelectedKeys = useMemo(() => props.defaultSelectedKeys ? new Selection(props.defaultSelectedKeys) : new Selection(), [props.defaultSelectedKeys]);
+  let selectedKeysProp = useMemo(() => convertSelection(props.selectedKeys), [props.selectedKeys]);
+  let defaultSelectedKeys = useMemo(() => convertSelection(props.defaultSelectedKeys, new Selection()), [props.defaultSelectedKeys]);
   let [selectedKeys, setSelectedKeys] = useControlledState(
     selectedKeysProp,
     defaultSelectedKeys,
@@ -49,4 +49,14 @@ export function useMultipleSelectionState(props: MultipleSelection): MultipleSel
     selectedKeys,
     setSelectedKeys
   };
+}
+
+function convertSelection(selection: 'all' | Iterable<Key>, defaultValue?: Selection): 'all' | Selection {
+  if (!selection) {
+    return defaultValue;
+  }
+
+  return selection === 'all'
+    ? 'all'
+    : new Selection(selection);
 }

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -77,17 +77,18 @@ export interface SingleSelection {
 }
 
 export type SelectionMode = 'none' | 'single' | 'multiple';
+export type Selection = 'all' | Set<Key>;
 export interface MultipleSelection {
   /** The type of selection that is allowed in the collection. */
   selectionMode?: SelectionMode,
   /** Whether the collection allows empty selection. */
   disallowEmptySelection?: boolean,
   /** The currently selected keys in the collection (controlled). */
-  selectedKeys?: Iterable<Key>,
+  selectedKeys?: 'all' | Iterable<Key>,
   /** The initial selected keys in the collection (uncontrolled). */
-  defaultSelectedKeys?: Iterable<Key>,
+  defaultSelectedKeys?: 'all' | Iterable<Key>,
   /** Handler that is called when the selection changes. */
-  onSelectionChange?: (keys: Set<Key>) => any
+  onSelectionChange?: (keys: Selection) => any
 }
 
 export interface Expandable {


### PR DESCRIPTION
When select all is active, new items that are added to the table (e.g. when infinite scrolling) are automatically shown as selected. This is true when users click the select all checkbox or use Ctrl + A. If they manually select each item in the table, then new items will not be automatically selected.

This is implemented by adding a special selection type. `selectedKeys` can now be the string `"all"` or a list of keys, and `onSelectionChange` also reflects this. This allows bulk actions that operate on the selection to change their behavior when everything is selected (e.g. a different API call), so that if affects all items rather than just loaded ones.

This PR also adds a bunch of tests for various selection behavior including select all, range selection, etc.