### PR TITLE
Add async loading support for Picker and ListBox

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -123,6 +123,12 @@ governing permissions and limitations under the License.
   }
 }
 
+.spectrum-Dropdown-trigger {
+  .spectrum-Dropdown-progressCircle {
+    margin-inline-start: var(--spectrum-dropdown-icon-margin-left);
+  }
+}
+
 .spectrum-Icon + .spectrum-Dropdown-chevron {
   margin-inline-start: var(--spectrum-dropdown-icon-gap);
 }

--- a/packages/@react-aria/collections/src/CollectionView.tsx
+++ b/packages/@react-aria/collections/src/CollectionView.tsx
@@ -94,10 +94,10 @@ export function useCollectionView<T extends object, V, W>(props: CollectionViewO
   // is up to the implementation using CollectionView since we don't have refs
   // to all of the item DOM nodes.
   useEffect(() => {
-    if (focusedKey) {
+    if (focusedKey && collectionManager.visibleRect.height > 0) {
       collectionManager.scrollToItem(focusedKey, 0);
     }
-  }, [focusedKey, collectionManager]);
+  }, [focusedKey, collectionManager.visibleRect.height, collectionManager]);
 
   let isFocusWithin = useRef(false);
   let onFocus = useCallback((e: FocusEvent) => {

--- a/packages/@react-aria/collections/src/CollectionView.tsx
+++ b/packages/@react-aria/collections/src/CollectionView.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {Collection, Layout} from '@react-stately/collections';
+import {Collection, Layout, Rect} from '@react-stately/collections';
 import {CollectionItem} from './CollectionItem';
 import {CollectionState, useCollectionState} from '@react-stately/collections';
 import {focusWithoutScrolling, mergeProps} from '@react-aria/utils';
@@ -30,7 +30,9 @@ interface CollectionViewProps<T extends object, V> extends HTMLAttributes<HTMLEl
   collection: Collection<T>,
   focusedKey?: Key,
   sizeToFit?: 'width' | 'height',
-  scrollDirection?: 'horizontal' | 'vertical' | 'both'
+  scrollDirection?: 'horizontal' | 'vertical' | 'both',
+  isLoading?: boolean,
+  onLoadMore?: () => void
 }
 
 function CollectionView<T extends object, V>(props: CollectionViewProps<T, V>, ref: RefObject<HTMLDivElement>) {
@@ -51,6 +53,18 @@ function CollectionView<T extends object, V>(props: CollectionViewProps<T, V>, r
   });
 
   let {collectionViewProps} = useCollectionView(props, state, ref);
+
+  // Handle scrolling, and call onLoadMore when nearing the bottom.
+  let onVisibleRectChange = useCallback((rect: Rect) => {
+    state.setVisibleRect(rect);
+
+    if (!props.isLoading && props.onLoadMore) {
+      let scrollOffset = state.collectionManager.contentSize.height - rect.height * 2;
+      if (rect.y > scrollOffset) {
+        props.onLoadMore();
+      }
+    }
+  }, [props.isLoading, props.onLoadMore, state]);
   
   return (
     <ScrollView 
@@ -58,7 +72,7 @@ function CollectionView<T extends object, V>(props: CollectionViewProps<T, V>, r
       ref={ref}
       innerStyle={state.isAnimating ? {transition: `none ${state.collectionManager.transitionDuration}ms`} : undefined}
       contentSize={state.contentSize}
-      onVisibleRectChange={state.setVisibleRect}
+      onVisibleRectChange={onVisibleRectChange}
       onScrollStart={state.startScrolling}
       onScrollEnd={state.endScrolling}
       sizeToFit={sizeToFit}

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -92,4 +92,6 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
         value={state.selectedKey} />
     );
   }
+
+  return null;
 }

--- a/packages/@react-spectrum/listbox/intl/en-US.json
+++ b/packages/@react-spectrum/listbox/intl/en-US.json
@@ -1,0 +1,4 @@
+{
+  "loading": "Loading…",
+  "loadingMore": "Loading more…"
+}

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -36,6 +36,7 @@
     "@react-aria/separator": "^3.0.0-rc.2",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-spectrum/layout": "^3.0.0-alpha.1",
+    "@react-spectrum/progress": "^3.0.0-rc.2",
     "@react-spectrum/provider": "^3.0.0-rc.2",
     "@react-spectrum/typography": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-rc.2",

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -14,16 +14,19 @@ import {classNames, filterDOMProps, useStyleProps} from '@react-spectrum/utils';
 import {CollectionItem, CollectionView} from '@react-aria/collections';
 import {DOMProps, StyleProps} from '@react-types/shared';
 import {FocusStrategy} from '@react-types/menu';
+// @ts-ignore
+import intlMessages from '../intl/*.json';
 import {ListBoxContext} from './ListBoxContext';
 import {ListBoxOption} from './ListBoxOption';
 import {ListBoxSection} from './ListBoxSection';
 import {ListLayout, Node} from '@react-stately/collections';
 import {ListState} from '@react-stately/list';
 import {mergeProps} from '@react-aria/utils';
+import {ProgressCircle} from '@react-spectrum/progress';
 import React, {HTMLAttributes, ReactElement, RefObject, useMemo} from 'react';
 import {ReusableView} from '@react-stately/collections';
 import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
-import {useCollator} from '@react-aria/i18n';
+import {useCollator, useMessageFormatter} from '@react-aria/i18n';
 import {useListBox} from '@react-aria/listbox';
 import {useProvider} from '@react-spectrum/provider';
 
@@ -35,7 +38,9 @@ interface ListBoxBaseProps<T> extends DOMProps, StyleProps {
   shouldSelectOnPressUp?: boolean,
   focusOnPointerEnter?: boolean,
   domProps?: HTMLAttributes<HTMLElement>,
-  disallowEmptySelection?: boolean
+  disallowEmptySelection?: boolean,
+  isLoading?: boolean,
+  onLoadMore?: () => void
 }
 
 /** @private */
@@ -67,6 +72,10 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
     isVirtualized: true
   }, state);
   let {styleProps} = useStyleProps(props);
+  let formatMessage = useMessageFormatter(intlMessages);
+
+  // Sync loading state into the layout.
+  layout.isLoading = props.isLoading;
 
   // This overrides collection view's renderWrapper to support heirarchy of items in sections.
   // The header is extracted from the children so it can receive ARIA labeling properties.
@@ -110,7 +119,9 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
         }
         layout={layout}
         collection={state.collection}
-        renderWrapper={renderWrapper}>
+        renderWrapper={renderWrapper}
+        isLoading={props.isLoading}
+        onLoadMore={props.onLoadMore}>
         {(type, item) => {
           if (type === 'item') {
             return (
@@ -118,6 +129,17 @@ function ListBoxBase<T>(props: ListBoxBaseProps<T>, ref: RefObject<HTMLDivElemen
                 item={item}
                 shouldSelectOnPressUp={shouldSelectOnPressUp}
                 shouldFocusOnHover={focusOnPointerEnter} />
+            );
+          } else if (type === 'loader') {
+            return (
+              // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
+              <div role="option" style={{display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%'}}>
+                <ProgressCircle 
+                  isIndeterminate
+                  size="S"
+                  aria-label={state.collection.size > 0 ? formatMessage('loadingMore') : formatMessage('loading')}
+                  UNSAFE_className={classNames(styles, 'spectrum-Dropdown-progressCircle')} />
+              </div>
             );
           }
         }}

--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -24,6 +24,7 @@ import Paste from '@spectrum-icons/workflow/Paste';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/typography';
+import {useAsyncList} from '@react-stately/data';
 
 let iconMap = {
   AlignCenter,
@@ -473,13 +474,35 @@ storiesOf('ListBox', module)
   .add(
     'with semantic elements (generative)',
     () => (
-      <ListBox width={200} aria-labelledby="label"items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
+      <ListBox width={200} aria-labelledby="label" items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
         {item => (
           <Section items={item.children} title={item.name}>
             {item => customOption(item)}
           </Section>
         )}
       </ListBox>
+    )
+  )
+  .add(
+    'isLoading',
+    () => (
+      <ListBox aria-labelledby="label" width={200} items={[]} isLoading>
+        {item => <Item>{item.name}</Item>}
+      </ListBox>
+    )
+  )
+  .add(
+    'isLoading more',
+    () => (
+      <ListBox aria-labelledby="label" width={200} items={flatOptions} isLoading>
+        {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+      </ListBox>
+    )
+  )
+  .add(
+    'async loading',
+    () => (
+      <AsyncLoadingExample />
     )
   );
 
@@ -492,3 +515,27 @@ let customOption = (item) => {
     </Item>
   );
 };
+
+function AsyncLoadingExample() {
+  interface Pokemon {
+    name: string,
+    url: string
+  }
+
+  let list = useAsyncList<Pokemon>({
+    async load({signal, cursor}) {
+      let res = await fetch(cursor || 'https://pokeapi.co/api/v2/pokemon', {signal});
+      let json = await res.json();
+      return {
+        items: json.results,
+        cursor: json.next
+      };
+    }
+  });
+
+  return (
+    <ListBox aria-labelledby="label" width={200} items={list.items} isLoading={list.isLoading} onLoadMore={list.loadMore}>
+      {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+    </ListBox>
+  );
+}

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -52,12 +52,13 @@ function renderComponent(props) {
 }
 
 describe('ListBox', function () {
-  let offsetWidth, offsetHeight;
+  let offsetWidth, offsetHeight, scrollHeight;
   let onSelectionChange = jest.fn();
 
   beforeAll(function () {
     offsetWidth = jest.spyOn(window.HTMLElement.prototype, 'clientWidth', 'get').mockImplementation(() => 1000);
     offsetHeight = jest.spyOn(window.HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(() => 1000);
+    scrollHeight = jest.spyOn(window.HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(() => 48);
     jest.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
     jest.useFakeTimers();
   });
@@ -69,6 +70,7 @@ describe('ListBox', function () {
   afterAll(function () {
     offsetWidth.mockReset();
     offsetHeight.mockReset();
+    scrollHeight.mockReset();
   });
 
   it('renders properly', function () {
@@ -564,5 +566,97 @@ describe('ListBox', function () {
     expect(option).toHaveAttribute('aria-label', 'Item');
     expect(option).not.toHaveAttribute('aria-labelledby');
     expect(option).not.toHaveAttribute('aria-describedby');
+  });
+
+  describe('async loading', function () {
+    it('should display a spinner while loading', function () {
+      let {getByRole, rerender} = render(
+        <Provider theme={theme}>
+          <ListBox items={[]} isLoading>
+            {item => <Item>{item.name}</Item>}
+          </ListBox>
+        </Provider>
+      );
+
+      let listbox = getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(options.length).toBe(1);
+
+      let progressbar = within(options[0]).getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-label', 'Loading…');
+      expect(progressbar).not.toHaveAttribute('aria-valuenow');
+
+      rerender(
+        <Provider theme={theme}>
+          <ListBox items={[]}>
+            {item => <Item>{item.name}</Item>}
+          </ListBox>
+        </Provider>
+      );
+
+      expect(progressbar).not.toBeInTheDocument();
+    });
+
+    it('should display a spinner inside the listbox when loading more', function () {
+      let items = [{name: 'Foo'}, {name: 'Bar'}];
+      let {getByRole, rerender} = render(
+        <Provider theme={theme}>
+          <ListBox items={items} isLoading>
+            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+          </ListBox>
+        </Provider>
+      );
+
+      let listbox = getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(options.length).toBe(3);
+
+      let progressbar = within(options[2]).getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-label', 'Loading more…');
+      expect(progressbar).not.toHaveAttribute('aria-valuenow');
+
+      rerender(
+        <Provider theme={theme}>
+          <ListBox items={items}>
+            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+          </ListBox>
+        </Provider>
+      );
+
+      options = within(listbox).getAllByRole('option');
+      expect(options.length).toBe(2);
+      expect(progressbar).not.toBeInTheDocument();
+    });
+
+    it('should fire onLoadMore when scrolling near the bottom', function () {
+      let onLoadMore = jest.fn();
+      let items = [];
+      for (let i = 1; i <= 100; i++) {
+        items.push({name: 'Test ' + i});
+      }
+
+      let {getByRole} = render(
+        <Provider theme={theme}>
+          <ListBox items={items} maxHeight={200} onLoadMore={onLoadMore}>
+            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+          </ListBox>
+        </Provider>
+      );
+
+      let listbox = getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(options.length).toBe(5); // each row is 48px tall, listbox is 200px. 5 rows fit.
+
+      listbox.scrollTop = 250;
+      fireEvent.scroll(listbox);
+
+      listbox.scrollTop = 1500;
+      fireEvent.scroll(listbox);
+
+      listbox.scrollTop = 4000;
+      fireEvent.scroll(listbox);
+
+      expect(onLoadMore).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/@react-spectrum/picker/intl/en-US.json
+++ b/packages/@react-spectrum/picker/intl/en-US.json
@@ -1,3 +1,4 @@
 {
-  "placeholder": "Select an option…"
+  "placeholder": "Select an option…",
+  "loading": "Loading…"
 }

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -39,6 +39,7 @@
     "@react-spectrum/label": "^3.0.0-rc.2",
     "@react-spectrum/listbox": "^3.0.0-alpha.1",
     "@react-spectrum/overlays": "^3.0.0-alpha.1",
+    "@react-spectrum/progress": "^3.0.0-rc.2",
     "@react-spectrum/provider": "^3.0.0-rc.2",
     "@react-spectrum/typography": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-rc.2",

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -26,6 +26,7 @@ import {ListBoxBase, useListBoxLayout} from '@react-spectrum/listbox';
 import {mergeProps} from '@react-aria/utils';
 import {Placement} from '@react-types/overlays';
 import {Popover, Tray} from '@react-spectrum/overlays';
+import {ProgressCircle} from '@react-spectrum/progress';
 import React, {ReactElement, useLayoutEffect, useRef, useState} from 'react';
 import {SpectrumPickerProps} from '@react-types/select';
 import styles from '@adobe/spectrum-css-temp/components/dropdown/vars.css';
@@ -83,6 +84,9 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
     isOpen: state.isOpen
   });
 
+  let isLoadingInitial = props.isLoading && state.collection.size === 0;
+  let isLoadingMore = props.isLoading && state.collection.size > 0;
+
   // On small screen devices, the listbox is rendered in a tray, otherwise a popover.
   let isMobile = useMediaQuery('(max-width: 700px)');
   let listbox = (
@@ -97,7 +101,9 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         focusOnPointerEnter
         layout={layout}
         state={state}
-        width={isMobile ? '100%' : undefined} />
+        width={isMobile ? '100%' : undefined}
+        isLoading={isLoadingMore}
+        onLoadMore={props.onLoadMore} />
       <DismissButton onDismiss={() => state.setOpen(false)} />
     </FocusScope>
   );
@@ -194,12 +200,19 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
           }}>
           {contents}
         </SlotProvider>
-        {validationState === 'invalid' &&
+        {isLoadingInitial &&
+          <ProgressCircle 
+            isIndeterminate
+            size="S"
+            aria-label={formatMessage('loading')}
+            UNSAFE_className={classNames(styles, 'spectrum-Dropdown-progressCircle')} />
+        }
+        {validationState === 'invalid' && !isLoadingInitial &&
           <AlertMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-invalidIcon')} />
         }
         <ChevronDownMedium UNSAFE_className={classNames(styles, 'spectrum-Dropdown-chevron')} />
       </FieldButton>
-      {overlay}
+      {state.collection.size === 0 ? null : overlay}
     </div>
   );
 

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -22,6 +22,7 @@ import Paste from '@spectrum-icons/workflow/Paste';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/typography';
+import {useAsyncList} from '@react-stately/data';
 
 let flatOptions = [
   {id: 1, name: 'Aardvark'},
@@ -446,4 +447,60 @@ storiesOf('Picker', module)
         </div>
       </>
     )
+  )
+  .add(
+    'isLoading',
+    () => (
+      <Picker label="Test" isLoading items={[]}>
+        {item => <Item>{item.name}</Item>}
+      </Picker>
+    )
+  )
+  .add(
+    'isLoading, isQuiet',
+    () => (
+      <Picker label="Test" isLoading isQuiet items={[]}>
+        {item => <Item>{item.name}</Item>}
+      </Picker>
+    )
+  )
+  .add(
+    'isLoading more',
+    () => (
+      <Picker label="Test" isLoading items={flatOptions}>
+        {item => <Item>{item.name}</Item>}
+      </Picker>
+    )
+  )
+  .add(
+    'async loading',
+    () => (
+      <AsyncLoadingExample />
+    )
   );
+
+function AsyncLoadingExample() {
+  interface Pokemon {
+    name: string,
+    url: string
+  }
+
+  let list = useAsyncList<Pokemon>({
+    async load({signal, cursor}) {
+      let res = await fetch(cursor || 'https://pokeapi.co/api/v2/pokemon', {signal});
+      let json = await res.json();
+      // The API is too fast sometimes, so make it take longer so we can see the spinner
+      await new Promise(resolve => setTimeout(resolve, cursor ? 500 : 1000));
+      return {
+        items: json.results,
+        cursor: json.next
+      };
+    }
+  });
+
+  return (
+    <Picker label="Pick a Pokemon" items={list.items} isLoading={list.isLoading} onLoadMore={list.loadMore}>
+      {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+    </Picker>
+  );
+}

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -1464,4 +1464,66 @@ describe('Picker', function () {
       expect(hiddenInput).toHaveAttribute('tabIndex', '0');
     });
   });
+
+  describe('async loading', function () {
+    it('should display a spinner while loading', function () {
+      let {getByRole, rerender} = render(
+        <Provider theme={theme}>
+          <Picker label="Test" items={[]} isLoading>
+            {item => <Item>{item.name}</Item>}
+          </Picker>
+        </Provider>
+      );
+
+      let picker = getByRole('button');
+      let progressbar = within(picker).getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-label', 'Loading…');
+      expect(progressbar).not.toHaveAttribute('aria-valuenow');
+
+      rerender(
+        <Provider theme={theme}>
+          <Picker label="Test" items={[]}>
+            {item => <Item>{item.name}</Item>}
+          </Picker>
+        </Provider>
+      );
+
+      expect(progressbar).not.toBeInTheDocument();
+    });
+
+    it('should display a spinner inside the listbox when loading more', function () {
+      let items = [{name: 'Foo'}, {name: 'Bar'}];
+      let {getByRole, rerender} = render(
+        <Provider theme={theme}>
+          <Picker label="Test" items={items} isLoading>
+            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+          </Picker>
+        </Provider>
+      );
+
+      let picker = getByRole('button');
+      act(() => triggerPress(picker));
+      act(() => jest.runAllTimers());
+
+      let listbox = getByRole('listbox');
+      let options = within(listbox).getAllByRole('option');
+      expect(options.length).toBe(3);
+
+      let progressbar = within(options[2]).getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-label', 'Loading more…');
+      expect(progressbar).not.toHaveAttribute('aria-valuenow');
+
+      rerender(
+        <Provider theme={theme}>
+          <Picker label="Test" items={items}>
+            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+          </Picker>
+        </Provider>
+      );
+
+      options = within(listbox).getAllByRole('option');
+      expect(options.length).toBe(2);
+      expect(progressbar).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/@react-spectrum/table/intl/en-US.json
+++ b/packages/@react-spectrum/table/intl/en-US.json
@@ -1,0 +1,4 @@
+{
+  "loading": "Loading…",
+  "loadingMore": "Loading more…"
+}

--- a/packages/@react-spectrum/table/src/Table.tsx
+++ b/packages/@react-spectrum/table/src/Table.tsx
@@ -17,6 +17,8 @@ import {CollectionItem, layoutInfoToStyle, ScrollView, setScrollLeft, useCollect
 import {DOMRef} from '@react-types/shared';
 import {FocusRing, useFocusRing} from '@react-aria/focus';
 import {GridState, useGridState} from '@react-stately/grid';
+// @ts-ignore
+import intlMessages from '../intl/*.json';
 import {mergeProps} from '@react-aria/utils';
 import {Node, Rect, ReusableView, useCollectionState} from '@react-stately/collections';
 import {ProgressCircle} from '@react-spectrum/progress';
@@ -26,7 +28,7 @@ import styles from '@adobe/spectrum-css-temp/components/table/vars.css';
 import stylesOverrides from './table.css';
 import {TableLayout} from './TableLayout';
 import {useColumnHeader, useGrid, useGridCell, useRow, useRowGroup, useRowHeader, useSelectAllCheckbox, useSelectionCheckbox} from '@react-aria/grid';
-import {useLocale} from '@react-aria/i18n';
+import {useLocale, useMessageFormatter} from '@react-aria/i18n';
 import {useProvider, useProviderProps} from '@react-spectrum/provider';
 
 const MIN_ROW_HEIGHT = 48;
@@ -52,6 +54,7 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
   let {styleProps} = useStyleProps(props);
   let state = useGridState({...props, showSelectionCheckboxes: true});
   let domRef = useDOMRef(ref);
+  let formatMessage = useMessageFormatter(intlMessages);
 
   let {scale} = useProvider();
   let layout = useMemo(() => new TableLayout({
@@ -187,7 +190,7 @@ function Table<T>(props: SpectrumTableProps<T>, ref: DOMRef<HTMLDivElement>) {
           <CenteredWrapper>
             <ProgressCircle 
               isIndeterminate 
-              aria-label={state.collection.size > 0 ? 'Loading more...' : 'Loading...'} />
+              aria-label={state.collection.size > 0 ? formatMessage('loadingMore') : formatMessage('loading')} />
           </CenteredWrapper>
         );
       case 'empty': {

--- a/packages/@react-spectrum/table/test/Table.test.js
+++ b/packages/@react-spectrum/table/test/Table.test.js
@@ -1432,7 +1432,7 @@ describe('Table', function () {
 
       let spinner = within(cell).getByRole('progressbar');
       expect(spinner).toBeVisible();
-      expect(spinner).toHaveAttribute('aria-label', 'Loading...');
+      expect(spinner).toHaveAttribute('aria-label', 'Loading…');
       expect(spinner).not.toHaveAttribute('aria-valuenow');
 
       rerender(tree, defaultTable);
@@ -1473,7 +1473,7 @@ describe('Table', function () {
 
       let spinner = within(cell).getByRole('progressbar');
       expect(spinner).toBeVisible();
-      expect(spinner).toHaveAttribute('aria-label', 'Loading more...');
+      expect(spinner).toHaveAttribute('aria-label', 'Loading more…');
       expect(spinner).not.toHaveAttribute('aria-valuenow');
 
       rerender(tree, defaultTable);

--- a/packages/@react-stately/collections/src/ListLayout.ts
+++ b/packages/@react-stately/collections/src/ListLayout.ts
@@ -62,6 +62,7 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
   protected contentSize: Size;
   collection: Collection<Node<T>>;
   disabledKeys: Set<Key> = new Set();
+  isLoading: boolean;
   protected lastWidth: number;
   protected lastCollection: Collection<Node<T>>;
   protected rootNodes: LayoutNode[];
@@ -139,6 +140,14 @@ export class ListLayout<T> extends Layout<Node<T>> implements KeyboardDelegate {
       let layoutNode = this.buildChild(node, 0, y);
       y = layoutNode.layoutInfo.rect.maxY;
       nodes.push(layoutNode);
+    }
+
+    if (this.isLoading) {
+      let rect = new Rect(0, y, this.collectionManager.visibleRect.width, 40);
+      let loader = new LayoutInfo('loader', 'loader', rect);
+      this.layoutInfos.set('loader', loader);
+      nodes.push({layoutInfo: loader});
+      y = loader.rect.maxY;
     }
 
     this.contentSize = new Size(this.collectionManager.visibleRect.width, y + this.padding);

--- a/packages/@react-stately/collections/src/TreeCollection.ts
+++ b/packages/@react-stately/collections/src/TreeCollection.ts
@@ -53,7 +53,9 @@ export class TreeCollection<T> implements Collection<Node<T>> {
       last = node;
     }
 
-    this.lastKey = last.key;
+    if (last) {
+      this.lastKey = last.key;
+    }
   }
 
   *[Symbol.iterator]() {

--- a/packages/@react-stately/select/src/useSelectState.ts
+++ b/packages/@react-stately/select/src/useSelectState.ts
@@ -61,6 +61,17 @@ export function useSelectState<T extends object>(props: SelectProps<T>): SelectS
 
   return {
     ...triggerState,
+    open() {
+      // Don't open if the collection is empty.
+      if (collection.size !== 0) {
+        triggerState.open();
+      }
+    },
+    toggle(focusStrategy) {
+      if (collection.size !== 0) {
+        triggerState.toggle(focusStrategy);
+      }
+    },
     collection,
     disabledKeys,
     selectionManager,


### PR DESCRIPTION
This adds async loading and infinite scrolling support to ListBox and Picker. I needed an example of this for the docs that wasn't Table. Plus people have been asking for it and it's relatively simple to add.