### PR TITLE
Add rel="noreferrer" to external links

### DIFF
--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -14,6 +14,7 @@ import ChevronLeft from '@spectrum-icons/ui/ChevronLeftLarge';
 import classNames from 'classnames';
 import {Divider} from '@react-spectrum/divider';
 import docStyles from './docs.css';
+import {getAnchorProps} from './utils';
 import highlightCss from './syntax-highlight.css';
 import {ImageContext} from './Image';
 import {LinkProvider} from './types';
@@ -55,20 +56,8 @@ const mdxComponents = {
   ul: ({children, ...props}) => <ul {...props} className={typographyStyles['spectrum-Body3']}>{children}</ul>,
   code: ({children, ...props}) => <code {...props} className={typographyStyles['spectrum-Code4']}>{children}</code>,
   inlineCode: ({children, ...props}) => <code {...props} className={typographyStyles['spectrum-Code4']}>{children}</code>,
-  a: ({children, ...props}) => <a {...props} className={linkStyle['spectrum-Link']} target={getTarget(props.href)}>{children}</a>
+  a: ({children, ...props}) => <a {...props} className={linkStyle['spectrum-Link']} {...getAnchorProps(props.href)}>{children}</a>
 };
-
-function getTarget(href) {
-  if (!/^http/.test(href) || /localhost|reactspectrum\.blob\.core\.windows\.net|react-spectrum\.(corp\.)?adobe\.com|#/.test(href)) {
-    return null;
-  }
-
-  if (/^\//.test(href)) {
-    return null;
-  }
-
-  return '_blank';
-}
 
 function Page({children, title, styles, scripts}) {
   return (

--- a/packages/dev/docs/src/ResourceCard.js
+++ b/packages/dev/docs/src/ResourceCard.js
@@ -56,7 +56,7 @@ export function ResourceCard(props) {
   }
 
   return (
-    <a href={url} target="_blank" title={cardContent.title} className={styles['resourceCard']}>
+    <a href={url} rel="noreferrer" target="_blank" title={cardContent.title} className={styles['resourceCard']}>
       <div>
         {cardContent.svg}
       </div>

--- a/packages/dev/docs/src/types.js
+++ b/packages/dev/docs/src/types.js
@@ -12,7 +12,8 @@
 
 import Asterisk from '@spectrum-icons/workflow/Asterisk';
 import {getDoc} from 'globals-docs';
-import {getUsedLinks} from './utils';
+import {getAnchorProps, getUsedLinks} from './utils';
+import linkStyle from '@adobe/spectrum-css-temp/components/link/vars.css';
 import Lowlight from 'react-lowlight';
 import Markdown from 'markdown-to-jsx';
 import React, {useContext} from 'react';
@@ -125,7 +126,7 @@ function BooleanLiteral({value}) {
 function Keyword({type}) {
   let link = getDoc(type);
   if (link) {
-    return <a href={link} className={`${styles.colorLink} token hljs-keyword`} target="_blank">{type}</a>;
+    return <a href={link} className={`${styles.colorLink} token hljs-keyword`} rel="noreferrer" target="_blank">{type}</a>;
   }
 
   return <span className="token hljs-keyword">{type}</span>;
@@ -134,7 +135,7 @@ function Keyword({type}) {
 function Identifier({name}) {
   let link = getDoc(name) || DOC_LINKS[name];
   if (link) {
-    return <a href={link} className={`${styles.colorLink} token hljs-name`} target="_blank">{name}</a>;
+    return <a href={link} className={`${styles.colorLink} token hljs-name`} rel="noreferrer" target="_blank">{name}</a>;
   }
 
   return <span className="token hljs-name">{name}</span>;
@@ -277,12 +278,16 @@ export function LinkType({id}) {
   return <a href={'#' + id} data-link={id} className={`${styles.colorLink} token hljs-name`}>{value.name}</a>;
 }
 
+function SpectrumLink({href, children, title}) {
+  return <a className={linkStyle['spectrum-Link']} href={href} title={title} {...getAnchorProps(href)}>{children}</a>;
+}
+
 export function renderHTMLfromMarkdown(description) {
   if (description) {
-    return <Markdown options={{forceInline: true}}>{description}</Markdown>;
-  } else {
-    return '';
+    const options = {forceInline: true, overrides: {a: {component: SpectrumLink}}};
+    return <Markdown options={options}>{description}</Markdown>;
   }
+  return '';
 }
 
 export function InterfaceType({description, properties: props, showRequired, showDefault}) {

--- a/packages/dev/docs/src/types.js
+++ b/packages/dev/docs/src/types.js
@@ -11,8 +11,8 @@
  */
 
 import Asterisk from '@spectrum-icons/workflow/Asterisk';
-import {getDoc} from 'globals-docs';
 import {getAnchorProps, getUsedLinks} from './utils';
+import {getDoc} from 'globals-docs';
 import linkStyle from '@adobe/spectrum-css-temp/components/link/vars.css';
 import Lowlight from 'react-lowlight';
 import Markdown from 'markdown-to-jsx';

--- a/packages/dev/docs/src/utils.js
+++ b/packages/dev/docs/src/utils.js
@@ -39,3 +39,15 @@ export function getUsedLinks(obj, links, usedLinks = {}) {
 
   return usedLinks;
 }
+
+export function getAnchorProps(href) {
+  if (!/^http/.test(href) || /localhost|reactspectrum\.blob\.core\.windows\.net|react-spectrum\.(corp\.)?adobe\.com|^#/.test(href)) {
+    return {};
+  }
+
+  if (/^\//.test(href)) {
+    return {};
+  }
+
+  return {target: '_blank', rel: 'noreferrer'};
+}


### PR DESCRIPTION
Fixes a privacy issue.

While this issue was being fixed, it was useful to add spectrum styling to links in the description of the props table.

Before:
![Screen Shot 2020-05-19 at 11 57 17 AM](https://user-images.githubusercontent.com/1123335/82366972-ec497480-99c7-11ea-9866-51a1b878b53f.png)

After:
![Screen Shot 2020-05-19 at 11 57 25 AM](https://user-images.githubusercontent.com/1123335/82366980-f0759200-99c7-11ea-9bca-1bce024b6416.png)

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

React spectrum
