### PR TITLE
(RSP-1760) Stop passing press event to onClear 

### DIFF
--- a/packages/@react-aria/searchfield/src/useSearchField.ts
+++ b/packages/@react-aria/searchfield/src/useSearchField.ts
@@ -11,7 +11,6 @@
  */
 
 import {ButtonHTMLAttributes, InputHTMLAttributes, LabelHTMLAttributes, RefObject} from 'react';
-import {chain} from '@react-aria/utils';
 // @ts-ignore
 import intlMessages from '../intl/*.json';
 import {PressProps} from '@react-aria/interactions';
@@ -76,6 +75,10 @@ export function useSearchField(
   let onClearButtonClick = () => {
     state.setValue('');
     inputRef.current.focus();
+   
+    if (onClear) {
+      onClear();
+    }
   };
 
   let {labelProps, inputProps} = useTextField({
@@ -92,7 +95,7 @@ export function useSearchField(
     clearButtonProps: {
       'aria-label': formatMessage('Clear search'),
       tabIndex: -1,
-      onPress: chain(onClearButtonClick, props.onClear)
+      onPress: onClearButtonClick
     }
   };
 }

--- a/packages/@react-aria/searchfield/test/useSearchField.test.js
+++ b/packages/@react-aria/searchfield/test/useSearchField.test.js
@@ -134,7 +134,7 @@ describe('useSearchField hook', () => {
         expect(ref.current.focus).toHaveBeenCalledTimes(1);
         // Verify that props.onClear is triggered as well with the same event
         expect(onClear).toHaveBeenCalledTimes(1);
-        expect(onClear).not.toHaveBeenCalledWith(mockEvent);
+        expect(onClear).toHaveBeenCalledWith();
       });
     });
   });

--- a/packages/@react-aria/searchfield/test/useSearchField.test.js
+++ b/packages/@react-aria/searchfield/test/useSearchField.test.js
@@ -27,7 +27,7 @@ describe('useSearchField hook', () => {
   let onClear = jest.fn();
 
   let renderSearchHook = (props, wrapper) => {
-    let {result} = renderHook(() => useSearchField(props, state, ref), {wrapper});
+    let {result} = renderHook(() => useSearchField({...props, 'aria-label': 'testLabel'}, state, ref), {wrapper});
     return result.current;
   };
 
@@ -134,6 +134,7 @@ describe('useSearchField hook', () => {
         expect(ref.current.focus).toHaveBeenCalledTimes(1);
         // Verify that props.onClear is triggered as well with the same event
         expect(onClear).toHaveBeenCalledTimes(1);
+        expect(onClear).not.toHaveBeenCalledWith(mockEvent);
       });
     });
   });

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -61,6 +61,8 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
     if (!dirty) {
       setDirty(true);
     }
+  // Don't add dirty to dep array since it will cause infinite loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [children, scale]);
 
   // Check for overflow on window resize


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1760

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Go to SearchField onClear story. Test clearing the field with ESC key and by clicking the 'x' button in the field. Verify that the clear action in the storybook action panel is called with `[ ]` meaning it is passed nothing
