### PR TITLE
(RSP-1742) Updating aria-posinset in useOption so it is index origin 1

### DIFF
--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -83,7 +83,7 @@ export function useOption<T>(props: OptionProps, state: ListState<T>): OptionAri
   };
 
   if (isVirtualized) {
-    optionProps['aria-posinset'] = state.collection.getItem(key).index;
+    optionProps['aria-posinset'] = state.collection.getItem(key).index + 1;
     optionProps['aria-setsize'] = state.collection.size;
   }
 

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -93,7 +93,7 @@ describe('ListBox', function () {
 
     let items = within(listbox).getAllByRole('option');
     expect(items.length).toBe(5);
-    let i = 0;
+    let i = 1;
     for (let item of items) {
       expect(item).toHaveAttribute('tabindex');
       expect(item).toHaveAttribute('aria-selected');


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1742

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:
Go to default ListBox story with voiceover on and navigate through the list. The first item should say "1 of 9" instead of "0 of 9"

<!--- Which product/company is this pull request for? -->
