### PR TITLE
(Picker) "isQuiet, labelPosition=side" story has label on top

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -165,4 +165,8 @@ governing permissions and limitations under the License.
       inline-size: auto;
     }
   }
+
+  &.spectrum-Dropdown-fieldWrapper--positionSide {
+    flex-direction: row;
+  }
 }

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -201,7 +201,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
           {contents}
         </SlotProvider>
         {isLoadingInitial &&
-          <ProgressCircle 
+          <ProgressCircle
             isIndeterminate
             size="S"
             aria-label={formatMessage('loading')}
@@ -227,7 +227,10 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
       classNames(
         styles,
         'spectrum-Field',
-        {'spectrum-Dropdown-fieldWrapper--quiet': isQuiet}
+        {
+          'spectrum-Dropdown-fieldWrapper--quiet': isQuiet,
+          'spectrum-Dropdown-fieldWrapper--positionSide': labelPosition === 'side'
+        }
       ),
       styleProps.className
     );


### PR DESCRIPTION
this file set it to always flex column, so needed to override that
Closes https://jira.corp.adobe.com/browse/RSP-1767

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
