### PR TITLE
Skip the V2 package installation when NPM_PASSWORD isn't set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,10 @@ jobs:
 
       - run:
           name: comment on pr
-          command: node .circleci/comment.js
+          command: |
+            if [ $GITHUB_TOKEN ]; then
+              node .circleci/comment.js
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,9 @@ jobs:
       - run:
           name: build
           command: |
-            make adobe_setup
+            if [ $NPM_PASSWORD ]; then
+              make adobe_setup
+            fi
             yarn --pure-lockfile
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,10 @@ jobs:
           at: /tmp/dist
       - run:
           name: deploy
-          command: az storage blob upload-batch -d reactspectrum -s /tmp/dist --account-name reactspectrum
+          command: |
+            if [ $AZURE_STORAGE_SAS_TOKEN ]; then
+              az storage blob upload-batch -d reactspectrum -s /tmp/dist --account-name reactspectrum
+            fi
 
   deploy-master:
     executor: azure-cli/azure-docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
       - run:
           name: Write npmrc
           command: |
-            cp .circleci/.npmrc .npmrc
+            if [ $NPM_PASSWORD ]; then
+              cp .circleci/.npmrc .npmrc
+            fi
 
       - run:
           name: build


### PR DESCRIPTION
Skip the V2 package installation when NPM_PASSWORD isn't set so that builds pass for open source pull requests.