### PR TITLE
Fix storybook console warnings

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -28,13 +28,8 @@
   justify-content: center;
   width: 100%;
 
-  /* On mobile browsers, vh units are fixed based on the maximum height of the screen.
-   * However, when you scroll, the toolbar and address bar shrink, making the viewport resize.
-   * We use the fill-available value to counteract this where supported. */
   height: 100vh;
-  height: -moz-available;
-  height: -webkit-fill-available;
-  height: fill-available;
+  height: stretch;
 
   /* Appear above underlay */
   z-index: 2;

--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -28,6 +28,9 @@
   justify-content: center;
   width: 100%;
 
+  /* On mobile browsers, vh units are fixed based on the maximum height of the screen.
+   * However, when you scroll, the toolbar and address bar shrink, making the viewport resize.
+   * We use the stretch value to counteract this where supported. */
   height: 100vh;
   height: stretch;
 

--- a/patches/@spectrum-css+component-builder++autoprefixer+6.7.7.patch
+++ b/patches/@spectrum-css+component-builder++autoprefixer+6.7.7.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@spectrum-css/component-builder/node_modules/autoprefixer/lib/processor.js b/node_modules/@spectrum-css/component-builder/node_modules/autoprefixer/lib/processor.js
+index d72a8ec..15a3fcb 100644
+--- a/node_modules/@spectrum-css/component-builder/node_modules/autoprefixer/lib/processor.js
++++ b/node_modules/@spectrum-css/component-builder/node_modules/autoprefixer/lib/processor.js
+@@ -89,10 +89,16 @@
+               result.warn('Replace fill-available to stretch, ' + 'because spec had been changed', {
+                 node: decl
+               });
+-            } else if (decl.value.indexOf('fill') !== -1) {
+-              result.warn('Replace fill to stretch, because spec had been changed', {
+-                node: decl
+-              });
++            } else if (decl.value.includes('fill')) {
++              var _ast = parser(value);
++
++              if (_ast.nodes.some(function (i) {
++                return i.type === 'word' && i.value === 'fill';
++              })) {
++                result.warn('Replace fill to stretch, because spec had been changed', {
++                  node: decl
++                });
++              }
+             }
+           }
+           if (_this.prefixes.options.flexbox !== false) {


### PR DESCRIPTION
Autoprefixer should take care of the transformation of height stretch
newer autoprefixer doesn't get upset if the variable name has 'fill' in it, patching it from their update


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
