### PR TITLE
Cleanup use of style prop in Alert Dialog

### DIFF
--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -70,7 +70,7 @@ describe('Breadcrumbs', function () {
 
   it('Handles multiple items', () => {
     let {getByText} = render(
-      <Breadcrumbs className="test-class">
+      <Breadcrumbs UNSAFE_className="test-class">
         <Item>Folder 1</Item>
         <Item>Folder 2</Item>
         <Item>Folder 3</Item>

--- a/packages/@react-spectrum/dialog/src/AlertDialog.tsx
+++ b/packages/@react-spectrum/dialog/src/AlertDialog.tsx
@@ -66,8 +66,9 @@ function AlertDialog(props: SpectrumAlertDialogProps, ref: DOMRef) {
 
   return (
     <Dialog
-      {...styleProps}
+      UNSAFE_style={styleProps.style}
       UNSAFE_className={classNames(styles, {[`spectrum-Dialog--${variant}`]: variant}, styleProps.className)}
+      isHidden={styleProps.hidden}
       size="M"
       role="alertdialog"
       ref={ref}>

--- a/packages/@react-spectrum/dialog/src/Dialog.tsx
+++ b/packages/@react-spectrum/dialog/src/Dialog.tsx
@@ -123,7 +123,7 @@ function Dialog(props: SpectrumDialogProps, ref: DOMRef) {
 }
 
 /**
- * Dialogs are windows containing contextual information, tasks, or workflows that appear over the user interface. 
+ * Dialogs are windows containing contextual information, tasks, or workflows that appear over the user interface.
  * Depending on the kind of Dialog, further interactions may be blocked until the Dialog is acknowledged.
  */
 let _Dialog = React.forwardRef(Dialog);

--- a/packages/@react-spectrum/illustratedmessage/src/IllustratedMessage.tsx
+++ b/packages/@react-spectrum/illustratedmessage/src/IllustratedMessage.tsx
@@ -35,7 +35,8 @@ function IllustratedMessage(props: SpectrumIllustratedMessageProps, ref: DOMRef<
   return (
     <Flex
       {...filterDOMProps(otherProps)}
-      {...styleProps}
+      UNSAFE_style={styleProps.style}
+      isHidden={styleProps.hidden}
       UNSAFE_className={classNames(
         styles,
         'spectrum-IllustratedMessage',


### PR DESCRIPTION
we shouldn't spread styleprops directly on a react spectrum component, only on dom elements. as a result, unpack it and pass it through the appropriate way


Closes https://jira.corp.adobe.com/browse/RSP-1725

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
