### PR TITLE
WIP fix error of class React does not recognize the `%s` prop on a DOM element

### DIFF
--- a/packages/@react-aria/collections/src/ScrollView.tsx
+++ b/packages/@react-aria/collections/src/ScrollView.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {DOMEventPropNames, filterDOMProps} from '@react-spectrum/utils';
 // @ts-ignore
 import {flushSync} from 'react-dom';
 import {getScrollLeft} from './utils';
@@ -165,8 +166,9 @@ function ScrollView(props: ScrollViewProps, ref: RefObject<HTMLDivElement>) {
     style.overflow = 'auto';
   }
 
+  let {focusedKey, isLoading, ...otherotherProps} = otherProps;
   return (
-    <div {...otherProps} style={style} ref={ref} onScroll={onScroll}>
+    <div {...otherotherProps} style={style} ref={ref} onScroll={onScroll}>
       <div role="presentation" style={{width: contentSize.width, height: contentSize.height, pointerEvents: isScrolling ? 'none' : 'auto', position: 'relative', ...innerStyle}}>
         {children}
       </div>

--- a/packages/@react-aria/interactions/src/usePress.ts
+++ b/packages/@react-aria/interactions/src/usePress.ts
@@ -14,6 +14,7 @@ import {DOMProps, PointerType, PressEvents} from '@react-types/shared';
 import {focusWithoutScrolling, mergeProps} from '@react-aria/utils';
 import {HTMLAttributes, RefObject, useContext, useEffect, useMemo, useRef, useState} from 'react';
 import {PressResponderContext} from './context';
+import {DOMEventPropNames, filterDOMProps} from "@react-spectrum/utils";
 
 export interface PressProps extends PressEvents {
   /** Whether the target is in a controlled press state (e.g. an overlay it triggers is open). */
@@ -236,7 +237,7 @@ export function usePress(props: PressHookProps): PressResult {
       if (state.isPressed && isValidKeyboardEvent(e)) {
         e.preventDefault();
         e.stopPropagation();
-        
+
         state.isPressed = false;
         triggerPressEnd(createEvent(state.target, e), 'keyboard', e.target === state.target);
         document.removeEventListener('keyup', onKeyUp, false);
@@ -259,7 +260,7 @@ export function usePress(props: PressHookProps): PressResult {
     };
 
     let restoreTextSelection = () => {
-      // There appears to be a delay on iOS where selection still might occur 
+      // There appears to be a delay on iOS where selection still might occur
       // after pointer up, so wait a bit before removing user-select.
       setTimeout(() => {
         // Avoid race conditions
@@ -426,7 +427,7 @@ export function usePress(props: PressHookProps): PressResult {
         if (e.button !== 0) {
           return;
         }
-        
+
         state.isPressed = false;
         document.removeEventListener('mouseup', onMouseUp, false);
 
@@ -545,7 +546,7 @@ export function usePress(props: PressHookProps): PressResult {
 
   return {
     isPressed: isPressedProp || isPressed,
-    pressProps: mergeProps(domProps, pressProps)
+    pressProps: mergeProps(filterDOMProps(domProps, DOMEventPropNames), pressProps)
   };
 }
 
@@ -627,8 +628,8 @@ interface EventPoint {
 
 function isOverTarget(point: EventPoint, target: HTMLElement) {
   let rect = target.getBoundingClientRect();
-  return (point.clientX || 0) >= (rect.left || 0) && 
-    (point.clientX || 0) <= (rect.right || 0) && 
-    (point.clientY || 0) >= (rect.top || 0) && 
+  return (point.clientX || 0) >= (rect.left || 0) &&
+    (point.clientX || 0) <= (rect.right || 0) &&
+    (point.clientY || 0) >= (rect.top || 0) &&
     (point.clientY || 0) <= (rect.bottom || 0);
 }

--- a/packages/@react-aria/overlays/src/useOverlayTrigger.ts
+++ b/packages/@react-aria/overlays/src/useOverlayTrigger.ts
@@ -41,7 +41,7 @@ interface OverlayTriggerAria {
  */
 export function useOverlayTrigger(props: OverlayTriggerProps): OverlayTriggerAria {
   let {ref, type, onClose, isOpen} = props;
-  
+
   // When scrolling a parent scrollable region of the trigger (other than the body),
   // we hide the popover. Otherwise, its position would be incorrect.
   useEffect(() => {
@@ -69,7 +69,7 @@ export function useOverlayTrigger(props: OverlayTriggerProps): OverlayTriggerAri
 
   // Aria 1.1 supports multiple values for aria-haspopup other than just menus.
   // https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup
-  // However, we only add it for menus for now because screen readers often 
+  // However, we only add it for menus for now because screen readers often
   // announce it as a menu even for other values.
   let ariaHasPopup = undefined;
   if (type === 'menu') {

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -370,7 +370,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -407,7 +407,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -442,7 +442,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -479,7 +479,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -519,7 +519,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -556,7 +556,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -593,7 +593,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -635,7 +635,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(2);
       expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -701,7 +701,7 @@ describe('Picker', function () {
       act(() => jest.runAllTimers());
 
       expect(listbox).not.toBeInTheDocument();
-      expect(picker).not.toHaveAttribute('aria-expanded');
+      expect(picker).toHaveAttribute('aria-expanded', 'false');
       expect(picker).not.toHaveAttribute('aria-controls');
       expect(onOpenChange).toBeCalledTimes(1);
       expect(onOpenChange).toHaveBeenCalledWith(false);

--- a/packages/@react-spectrum/sidenav/src/SideNav.tsx
+++ b/packages/@react-spectrum/sidenav/src/SideNav.tsx
@@ -51,7 +51,7 @@ export function SideNav<T extends object>(props: SpectrumSideNavProps<T>) {
     }
 
     return (
-      <CollectionItem 
+      <CollectionItem
         key={reusableView.key}
         reusableView={reusableView}
         parent={parent} />

--- a/packages/@react-spectrum/utils/src/filterDOMProps.ts
+++ b/packages/@react-spectrum/utils/src/filterDOMProps.ts
@@ -22,11 +22,13 @@ const DOMPropNames = {
   'aria-describedby': 1,
   'aria-controls': 1,
   'aria-owns': 1,
-  'aria-hidden': 1
+  'aria-hidden': 1,
+  'aria-haspopup': 1,
+  'aria-expanded': 1
 };
 
 // Based on DOMAttributes from react types
-export const DOMEventPropNames = {  
+export const DOMEventPropNames = {
   // Focus events
   onFocus: 1,
   onBlur: 1,


### PR DESCRIPTION
usePress will pass through its props that aren't destructured out
filtering dom props on that passthrough isn't quite right, because it would filter out onClick, so we include dom events, it would also filter out aria-haspopup and aria-expanded which are both valid, so include those in the dom props we filter as well, but in the default set because i can't think of what the new set might be called, should talk that point over with devon, i suspect they should be elsewhere

i think that if there is a possibility that aria-expanded should be true, then false is more appropriate for the opposing state and it should only be undefined when it can't be aria-expanded ever

found in https://github.com/adobe-private/react-spectrum-v3/pull/502
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
