### PR TITLE
fix error of class Not implemented: navigation

### DIFF
--- a/packages/@react-spectrum/button/test/Button.test.js
+++ b/packages/@react-spectrum/button/test/Button.test.js
@@ -119,16 +119,16 @@ describe('Button', function () {
 
   it.each`
     Name              | Component      | props
-    ${'ActionButton'} | ${ActionButton}| ${{onPress: onPressSpy, elementType: 'a', href: 'https://adobe.com'}}
-    ${'Button'}       | ${Button}      | ${{onPress: onPressSpy, elementType: 'a', href: 'https://adobe.com'}}
-    ${'LogicButton'}  | ${LogicButton} | ${{onPress: onPressSpy, elementType: 'a', href: 'https://adobe.com'}}
-    ${'V2Button'}     | ${V2Button}    | ${{onClick: onPressSpy, element: 'a', href: 'https://adobe.com'}}
+    ${'ActionButton'} | ${ActionButton}| ${{onPress: onPressSpy, elementType: 'a', href: '#only-hash-in-jsdom'}}
+    ${'Button'}       | ${Button}      | ${{onPress: onPressSpy, elementType: 'a', href: '#only-hash-in-jsdom'}}
+    ${'LogicButton'}  | ${LogicButton} | ${{onPress: onPressSpy, elementType: 'a', href: '#only-hash-in-jsdom'}}
+    ${'V2Button'}     | ${V2Button}    | ${{onClick: onPressSpy, element: 'a', href: '#only-hash-in-jsdom'}}
   `('$Name can have elementType=a with an href', function ({Component, props}) {
     let {getByRole} = render(<Component {...props}>Click Me</Component>);
 
     let button = getByRole('button');
     expect(button).toHaveAttribute('tabindex', '0');
-    expect(button).toHaveAttribute('href', 'https://adobe.com');
+    expect(button).toHaveAttribute('href', '#only-hash-in-jsdom');
     triggerPress(button);
     expect(onPressSpy).toHaveBeenCalledTimes(1);
   });

--- a/packages/@react-spectrum/link/test/Link.test.js
+++ b/packages/@react-spectrum/link/test/Link.test.js
@@ -66,13 +66,14 @@ describe('Link', function () {
   it('Wraps custom child element', () => {
     let {getByRole} = render(
       <Link UNSAFE_className="test-class" onPress={onPressSpy} >
-        <a href="http://example.com" >Click me </a>
+        <a href="#only-hash-in-jsdom" >Click me </a>
       </Link>
     );
     let link = getByRole('link');
     expect(link).toBeDefined();
     expect(link.nodeName).toBe('A');
     expect(link).toHaveAttribute('class', expect.stringContaining('test-class'));
+    expect(link).toHaveAttribute('href', '#only-hash-in-jsdom');
     triggerPress(link);
     expect(onPressSpy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
jsdom has only implemented hash changes to navigation

as noted https://github.com/adobe-private/react-spectrum-v3/pull/502
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
