### PR TITLE
Remove z-index from checkbox, radio, and switch

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/checkbox/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/checkbox/index.css
@@ -63,7 +63,6 @@ governing permissions and limitations under the License.
   block-size: 100%;
 
   opacity: .0001;
-  z-index: 1;
 
   cursor: default;
 

--- a/packages/@adobe/spectrum-css-temp/components/radio/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/radio/index.css
@@ -68,7 +68,6 @@ governing permissions and limitations under the License.
   block-size: 100%;
 
   opacity: .0001;
-  z-index: 1;
 
   cursor: default;
 

--- a/packages/@adobe/spectrum-css-temp/components/toggle/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/toggle/index.css
@@ -52,7 +52,6 @@ governing permissions and limitations under the License.
   inset-block-start: 0;
   inset-inline-start: 0;
   opacity: .0001;
-  z-index: 1;
 
   cursor: default;
 


### PR DESCRIPTION
This was causing it to eat mouse events from a picker opened over the top of it due to `isolation: isolate`. It's also unnecessary, because the label wraps the entire radio and causes a click on the actual input.