### PR TITLE
Fix Picker height with window scrollbars

### DIFF
--- a/packages/@react-aria/overlays/src/calculatePosition.ts
+++ b/packages/@react-aria/overlays/src/calculatePosition.ts
@@ -100,8 +100,8 @@ function getContainerDimensions(containerNode: Element): Dimensions {
   let scroll: Position = {};
 
   if (containerNode.tagName === 'BODY') {
-    width = window.innerWidth;
-    height = window.innerHeight;
+    width = document.documentElement.clientWidth;
+    height = document.documentElement.clientHeight;
 
     scroll.top =
       getScrollTop(ownerDocument(containerNode).documentElement) ||

--- a/packages/@react-aria/overlays/test/useOverlayPosition.test.js
+++ b/packages/@react-aria/overlays/test/useOverlayPosition.test.js
@@ -43,6 +43,11 @@ HTMLElement.prototype.getBoundingClientRect = function () {
 };
 
 describe('useOverlayPosition', function () {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {configurable: true, value: 768});
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {configurable: true, value: 500});
+  });
+
   it('should position the overlay relative to the trigger', function () {
     let res = render(<Example />);
     let overlay = res.getByTestId('overlay');
@@ -74,8 +79,7 @@ describe('useOverlayPosition', function () {
 
     expect(overlay).toHaveTextContent('placement: bottom');
 
-    let innerHeight = window.innerHeight;
-    window.innerHeight = 1000;
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {configurable: true, value: 1000});
     fireEvent(window, new Event('resize'));
 
     expect(overlay).toHaveStyle(`
@@ -85,7 +89,6 @@ describe('useOverlayPosition', function () {
     `);
 
     expect(overlay).toHaveTextContent('placement: bottom');
-    window.innerHeight = innerHeight;
   });
 
   it('should update the position on props change', function () {


### PR DESCRIPTION
use clientHeight instead of innerHeight to fix Picker height with window scrollbars


Closes https://jira.corp.adobe.com/browse/RSP-1791

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
