### PR TITLE
Fix picker closing on blur on Chrome Android

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/tray/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/tray/index.css
@@ -36,6 +36,9 @@
   height: -webkit-fill-available;
   height: fill-available;
 
+  /* Don't catch clicks */
+  pointer-events: none;
+
   /* Appear above underlay */
   z-index: 2;
 }


### PR DESCRIPTION
The tray backdrop seems to have been catching the click and somehow sending focus to the body when in an iframe. Not entirely sure why. Adding `pointer-events: none` fixes it. This was already in `.spectrum-Modal-wrapper`.