### PR TITLE
Fix focus ring on first click in iframe in Firefox

### DIFF
--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -71,6 +71,12 @@ function handlePointerEvent(e: PointerEvent | MouseEvent) {
 }
 
 function handleFocusEvent(e: FocusEvent) {
+  // Firefox fires a focus event with the document as the target when the user first clicks into
+  // an iframe. We ignore this event so it doesn't cause keyboard focus rings to appear.
+  if (e.target === document) {
+    return;
+  }
+
   // If a focus event occurs without a preceding keyboard or pointer event, switch to keyboard modality.
   // This occurs, for example, when navigating a form with the next/previous buttons on iOS.
   if (!hasEventBeforeFocus) {


### PR DESCRIPTION
This fixes the issue where a focus ring is visible on the first click of a component inside an iframe in Firefox. This was due to an extra focus event that Firefox fires where the target is `document`. No other browser fires this event, and it was messing up our internal focus visibility state. This event is now ignored.