### PR TITLE
Fix menu item padding in large scale

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -22,7 +22,9 @@ governing permissions and limitations under the License.
   --spectrum-selectlist-heading-padding-left: var(--spectrum-global-dimension-size-150);
   --spectrum-selectlist-heading-padding-right: var(--spectrum-global-dimension-size-450);
 
-
+  /* OVERRIDE: DNA uses a static size which doesn't properly adjust on large scale */
+  /* Remove once https://git.corp.adobe.com/Spectrum/spectrum-dna/pull/409 is released. */
+  --spectrum-selectlist-option-padding: var(--spectrum-global-dimension-size-150);
   --spectrum-selectlist-option-padding-y: var(--spectrum-global-dimension-size-85);
 
   --spectrum-selectlist-option-selectable-padding-right: calc(var(--spectrum-global-dimension-size-100) + var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-selectlist-option-icon-padding-x));


### PR DESCRIPTION
Overriding DNA for now. Sent a PR also: https://git.corp.adobe.com/Spectrum/spectrum-dna/pull/409.

Before:
<img width="164" src="https://user-images.githubusercontent.com/19409/83311551-6ea21780-a1c4-11ea-83df-e66bd16eaee3.png">

After:
<img width="164" src="https://user-images.githubusercontent.com/19409/83311561-73ff6200-a1c4-11ea-8869-a393fc2738fd.png">
