### PR TITLE
Update max width and alignment for menu items

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -150,6 +150,10 @@ governing permissions and limitations under the License.
   margin-inline-start: calc(var(--spectrum-dropdown-quiet-offset) * -1);
 }
 
+.spectrum-Dropdown-popover .spectrum-Dropdown-menu {
+  max-width: initial;
+}
+
 /* When used with a label or inside a Form, we need to override some things from .spectrum-Field
  * so quiet dropdowns still collapse properly. */
 .spectrum-Field.spectrum-Dropdown-fieldWrapper--quiet {

--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -25,7 +25,7 @@ governing permissions and limitations under the License.
   /* OVERRIDE: DNA uses a static size which doesn't properly adjust on large scale */
   /* Remove once https://git.corp.adobe.com/Spectrum/spectrum-dna/pull/409 is released. */
   --spectrum-selectlist-option-padding: var(--spectrum-global-dimension-size-150);
-  --spectrum-selectlist-option-padding-y: var(--spectrum-global-dimension-size-85);
+  --spectrum-selectlist-option-padding-y: var(--spectrum-global-dimension-size-75);
 
   --spectrum-selectlist-option-selectable-padding-right: calc(var(--spectrum-global-dimension-size-100) + var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-selectlist-option-icon-padding-x));
 
@@ -33,6 +33,9 @@ governing permissions and limitations under the License.
 
   /* Hardcoded for wrapping study */
   --spectrum-selectlist-option-label-line-height: 1.3;
+
+  /* From spectrum: this value should be the same for both medium and large scale. */
+  --spectrum-menu-max-width: 320px;
 }
 
 .spectrum-Menu {
@@ -50,6 +53,7 @@ governing permissions and limitations under the License.
   user-select: none;
 
   max-height: inherit; /* inherit from parent popover */
+  max-width: var(--spectrum-menu-max-width);
 
   & .spectrum-Menu-sectionHeading {
     /* Support headings as LI */
@@ -65,6 +69,8 @@ governing permissions and limitations under the License.
 .spectrum-Menu-checkmark {
   transform: scale(1);
   opacity: 1;
+  /* Should be 10px from the top according to XD. Margin around whole menu item is 6px in medium scale, so 4px left. */
+  padding-block-start: var(--spectrum-global-dimension-size-50);
 }
 
 .spectrum-Menu-item {
@@ -76,8 +82,6 @@ governing permissions and limitations under the License.
   margin: 0;
 
   border-inline-start: var(--spectrum-selectlist-border-size-key-focus) solid transparent;
-
-  min-block-size: var(--spectrum-selectlist-option-height);
 
   font-size: var(--spectrum-selectlist-option-text-size);
   font-weight: var(--spectrum-selectlist-option-text-font-weight);
@@ -102,7 +106,6 @@ governing permissions and limitations under the License.
 
 .spectrum-Menu-itemLabel {
   grid-area: text;
-  align-self: center;
 }
 
 .spectrum-Menu-itemLabel--wrapping {
@@ -113,7 +116,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Menu-checkmark {
   display: none;
-  align-self: center;
+  align-self: start;
   justify-self: end;
   grid-area: checkmark;
 }
@@ -173,26 +176,23 @@ governing permissions and limitations under the License.
 .spectrum-Menu .spectrum-Menu-end {
   grid-area: end;
   justify-self: end;
-  align-self: center;
+  align-self: start;
   padding-inline-start: var(--spectrum-global-dimension-size-125);
 }
 .spectrum-Menu-icon {
   grid-area: icon;
-  /* This is a bandaid fix to align the icons with the top of multiline text items. */
-  /* It will need to be revisited when we actually pull in typography. */
-  vertical-align: top;
-  padding-block-start: 2px;
-  padding-inline-end: 5px;
+  /* Margin around the whole menu item is 6px. Icon should be 7px from the top according to XD. */
+  padding-block-start: var(--spectrum-global-dimension-size-10);
+  padding-inline-end: var(--spectrum-global-dimension-size-100);
 }
 .spectrum-Menu-description {
   grid-area: description;
-  align-self: center;
   line-height: 1.3;
   font-size: var(--spectrum-global-dimension-size-150);
 }
 .spectrum-Menu-keyboard {
   grid-area: keyboard;
-  align-self: center;
+  align-self: start;
   padding-inline-start: var(--spectrum-global-dimension-size-125);
   /* override default browser styling. */
   /* keyboard shortcuts are always ASCII, so use base font */

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -15,7 +15,6 @@ import {ActionButton} from '@react-spectrum/button';
 import AlignCenter from '@spectrum-icons/workflow/AlignCenter';
 import AlignLeft from '@spectrum-icons/workflow/AlignLeft';
 import AlignRight from '@spectrum-icons/workflow/AlignRight';
-import ChevronRightMedium from '@spectrum-icons/ui/ChevronRightMedium';
 import Copy from '@spectrum-icons/workflow/Copy';
 import Cut from '@spectrum-icons/workflow/Cut';
 import {Item, Menu, MenuTrigger, Section} from '../';

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -137,7 +137,6 @@ storiesOf('MenuTrigger', module)
                 <AlignCenter size="S" />
                 <Text>Doggo with really really really long long long text</Text>
                 <Text slot="end">Value</Text>
-                <ChevronRightMedium slot="keyboard" />
               </Item>
               <Item>
                 <AlignRight size="S" />

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -102,6 +102,7 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         layout={layout}
         state={state}
         width={isMobile ? '100%' : undefined}
+        UNSAFE_className={classNames(styles, 'spectrum-Dropdown-menu')}
         isLoading={isLoadingMore}
         onLoadMore={props.onLoadMore} />
       <DismissButton onDismiss={() => state.setOpen(false)} />


### PR DESCRIPTION
Max width for menus set to 320px as per spectrum. Icons, keyboard shortcuts, checkmark, key/value, etc. all now top aligned.