### PR TITLE
Removing isEmphasized and isSelected example from ActionButton docs

### DIFF
--- a/packages/@react-spectrum/button/docs/ActionButton.mdx
+++ b/packages/@react-spectrum/button/docs/ActionButton.mdx
@@ -103,22 +103,6 @@ function Example() {
 <ActionButton isQuiet>Action!</ActionButton>
 ```
 
-### Selected
-[View guidelines](https://spectrum.adobe.com/page/action-button/#Selected)
-
-```tsx example
-<ActionButton isSelected>Action!</ActionButton>
-```
-
-### Emphasis
-[View guidelines](https://spectrum.adobe.com/page/action-button/#Emphasis)
-
-Note that the styling provided by the `isEmphasized` prop is only applied when the `isSelected` prop is true.
-
-```tsx example
-<ActionButton isEmphasized isSelected>Action!</ActionButton>
-```
-
 ### Hold affordance
 [View guidelines](https://spectrum.adobe.com/page/action-button/#Hold-icon)
 


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
