### PR TITLE
Fix to Menu max width so it doesn't apply on Menu Trays

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dropdown/index.css
@@ -150,10 +150,6 @@ governing permissions and limitations under the License.
   margin-inline-start: calc(var(--spectrum-dropdown-quiet-offset) * -1);
 }
 
-.spectrum-Dropdown-popover .spectrum-Dropdown-menu {
-  max-width: initial;
-}
-
 /* When used with a label or inside a Form, we need to override some things from .spectrum-Field
  * so quiet dropdowns still collapse properly. */
 .spectrum-Field.spectrum-Dropdown-fieldWrapper--quiet {

--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -38,6 +38,10 @@ governing permissions and limitations under the License.
   --spectrum-menu-max-width: 320px;
 }
 
+.spectrum-Menu-Popover {
+  max-width: var(--spectrum-menu-max-width);
+}
+
 .spectrum-Menu {
   text-align: start;
   display: block;
@@ -53,7 +57,6 @@ governing permissions and limitations under the License.
   user-select: none;
 
   max-height: inherit; /* inherit from parent popover */
-  max-width: var(--spectrum-menu-max-width);
 
   & .spectrum-Menu-sectionHeading {
     /* Support headings as LI */

--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -38,7 +38,7 @@ governing permissions and limitations under the License.
   --spectrum-menu-max-width: 320px;
 }
 
-.spectrum-Menu-Popover {
+.spectrum-Menu-popover {
   max-width: var(--spectrum-menu-max-width);
 }
 

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import {classNames, unwrapDOMRef, useMediaQuery} from '@react-spectrum/utils';
 import {DismissButton, useOverlayPosition} from '@react-aria/overlays';
 import {DOMRefValue} from '@react-types/shared';
 import {FocusScope} from '@react-aria/focus';
@@ -19,7 +20,7 @@ import {Popover, Tray} from '@react-spectrum/overlays';
 import {PressResponder} from '@react-aria/interactions';
 import React, {Fragment, useRef} from 'react';
 import {SpectrumMenuTriggerProps} from '@react-types/menu';
-import {unwrapDOMRef, useMediaQuery} from '@react-spectrum/utils';
+import styles from '@adobe/spectrum-css-temp/components/menu/vars.css';
 import {useMenuTrigger} from '@react-aria/menu';
 import {useMenuTriggerState} from '@react-stately/menu';
 
@@ -67,7 +68,8 @@ export function MenuTrigger(props: SpectrumMenuTriggerProps) {
     autoFocus: state.focusStrategy || true,
     UNSAFE_style: {
       width: isMobile ? '100%' : undefined
-    }
+    },
+    UNSAFE_className: classNames(styles, {'spectrum-Menu-Popover': !isMobile})
   };
 
   let contents = (

--- a/packages/@react-spectrum/menu/src/MenuTrigger.tsx
+++ b/packages/@react-spectrum/menu/src/MenuTrigger.tsx
@@ -69,7 +69,7 @@ export function MenuTrigger(props: SpectrumMenuTriggerProps) {
     UNSAFE_style: {
       width: isMobile ? '100%' : undefined
     },
-    UNSAFE_className: classNames(styles, {'spectrum-Menu-Popover': !isMobile})
+    UNSAFE_className: classNames(styles, {'spectrum-Menu-popover': !isMobile})
   };
 
   let contents = (

--- a/packages/@react-spectrum/picker/src/Picker.tsx
+++ b/packages/@react-spectrum/picker/src/Picker.tsx
@@ -102,7 +102,6 @@ function Picker<T extends object>(props: SpectrumPickerProps<T>, ref: DOMRef<HTM
         layout={layout}
         state={state}
         width={isMobile ? '100%' : undefined}
-        UNSAFE_className={classNames(styles, 'spectrum-Dropdown-menu')}
         isLoading={isLoadingMore}
         onLoadMore={props.onLoadMore} />
       <DismissButton onDismiss={() => state.setOpen(false)} />


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
