### PR TITLE
Fix menu item heights

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/menu/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/index.css
@@ -25,7 +25,6 @@ governing permissions and limitations under the License.
   /* OVERRIDE: DNA uses a static size which doesn't properly adjust on large scale */
   /* Remove once https://git.corp.adobe.com/Spectrum/spectrum-dna/pull/409 is released. */
   --spectrum-selectlist-option-padding: var(--spectrum-global-dimension-size-150);
-  --spectrum-selectlist-option-padding-y: var(--spectrum-global-dimension-size-75);
 
   --spectrum-selectlist-option-selectable-padding-right: calc(var(--spectrum-global-dimension-size-100) + var(--spectrum-icon-checkmark-medium-width) + var(--spectrum-selectlist-option-icon-padding-x));
 
@@ -72,8 +71,7 @@ governing permissions and limitations under the License.
 .spectrum-Menu-checkmark {
   transform: scale(1);
   opacity: 1;
-  /* Should be 10px from the top according to XD. Margin around whole menu item is 6px in medium scale, so 4px left. */
-  padding-block-start: var(--spectrum-global-dimension-size-50);
+  padding-block-start: calc(var(--spectrum-selectlist-option-icon-padding-y) - var(--spectrum-selectlist-option-padding-y));
 }
 
 .spectrum-Menu-item {
@@ -109,6 +107,7 @@ governing permissions and limitations under the License.
 
 .spectrum-Menu-itemLabel {
   grid-area: text;
+  line-height: var(--spectrum-global-font-line-height-small);
 }
 
 .spectrum-Menu-itemLabel--wrapping {
@@ -190,7 +189,7 @@ governing permissions and limitations under the License.
 }
 .spectrum-Menu-description {
   grid-area: description;
-  line-height: 1.3;
+  line-height: var(--spectrum-global-font-line-height-small);
   font-size: var(--spectrum-global-dimension-size-150);
 }
 .spectrum-Menu-keyboard {

--- a/packages/@adobe/spectrum-css-temp/components/menu/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/menu/skin.css
@@ -66,3 +66,7 @@ governing permissions and limitations under the License.
 .spectrum-Menu-divider {
   background-color: var(--spectrum-selectlist-divider-color);
 }
+
+.spectrum-Menu-description {
+  color: var(--spectrum-global-color-gray-700);
+}

--- a/packages/@adobe/spectrum-css-temp/vars/spectrum-large.css
+++ b/packages/@adobe/spectrum-css-temp/vars/spectrum-large.css
@@ -228,6 +228,10 @@
   --spectrum-selectlist-option-icon-padding-y: var(--spectrum-global-dimension-static-size-200);
   --spectrum-selectlist-option-icon-margin-top: var(--spectrum-global-dimension-static-size-50);
   --spectrum-selectlist-option-height: var(--spectrum-global-dimension-static-size-600);
+  /* BEGIN RSP PATCH */
+  /* This is not correct in DNA. */
+  --spectrum-selectlist-option-padding-y: var(--spectrum-global-dimension-static-size-160);
+  /* END RSP PATCH */
   --spectrum-selectlist-thumbnail-option-icon-padding-y: var(--spectrum-global-dimension-static-size-200);
   --spectrum-loader-bar-large-border-radius: 4px;
   --spectrum-loader-bar-large-over-background-border-radius: 4px;

--- a/packages/@adobe/spectrum-css-temp/vars/spectrum-medium.css
+++ b/packages/@adobe/spectrum-css-temp/vars/spectrum-medium.css
@@ -228,6 +228,10 @@
   --spectrum-selectlist-option-icon-padding-y: var(--spectrum-global-dimension-static-size-125);
   --spectrum-selectlist-option-icon-margin-top: var(--spectrum-global-dimension-static-size-65);
   --spectrum-selectlist-option-height: var(--spectrum-global-dimension-static-size-400);
+  /* BEGIN RSP PATCH */
+  /* This is not correct in DNA. */
+  --spectrum-selectlist-option-padding-y: var(--spectrum-global-dimension-static-size-75);
+  /* END RSP PATCH */
   --spectrum-selectlist-thumbnail-option-icon-padding-y: var(--spectrum-global-dimension-static-size-125);
   --spectrum-loader-bar-large-border-radius: 3px;
   --spectrum-loader-bar-large-over-background-border-radius: 3px;

--- a/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
+++ b/packages/@react-spectrum/listbox/src/ListBoxBase.tsx
@@ -49,8 +49,8 @@ export function useListBoxLayout<T>(state: ListState<T>) {
   let collator = useCollator({usage: 'search', sensitivity: 'base'});
   let layout = useMemo(() =>
     new ListLayout<T>({
-      estimatedRowHeight: scale === 'large' ? 48 : 35,
-      estimatedHeadingHeight: scale === 'large' ? 37 : 30,
+      estimatedRowHeight: scale === 'large' ? 48 : 32,
+      estimatedHeadingHeight: scale === 'large' ? 33 : 26,
       padding: scale === 'large' ? 5 : 4, // TODO: get from DNA
       collator
     })

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -110,34 +110,34 @@ storiesOf('MenuTrigger', module)
           </ActionButton>
           <Menu onAction={action('action')}>
             <Section title="Section 1">
-              <Item>
+              <Item textValue="Copy">
                 <Copy size="S" />
                 <Text>Copy</Text>
                 <Keyboard>⌘C</Keyboard>
               </Item>
-              <Item>
+              <Item textValue="Cut">
                 <Cut size="S" />
                 <Text>Cut</Text>
                 <Keyboard>⌘X</Keyboard>
               </Item>
-              <Item>
+              <Item textValue="Paste">
                 <Paste size="S" />
                 <Text>Paste</Text>
                 <Keyboard>⌘V</Keyboard>
               </Item>
             </Section>
             <Section title="Section 2">
-              <Item>
+              <Item textValue="Puppy">
                 <AlignLeft size="S" />
                 <Text>Puppy</Text>
                 <Text slot="description">Puppy description super long as well geez</Text>
               </Item>
-              <Item>
+              <Item textValue="Doggo with really really really long long long text">
                 <AlignCenter size="S" />
                 <Text>Doggo with really really really long long long text</Text>
                 <Text slot="end">Value</Text>
               </Item>
-              <Item>
+              <Item textValue="Floof">
                 <AlignRight size="S" />
                 <Text>Floof</Text>
               </Item>


### PR DESCRIPTION
The estimated heights weren't matching the real heights after my last PR, so there was extra "margin" between the items. Also the padding was much too small in large scale. Adjusted to match the XD file, but required an override of DNA for now.

Also fixed typeahead in the complex items example in MenuTrigger, and the color of the menu item description text.