### PR TITLE
Responsive code examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "type": "git",
     "url": "https://github.com/adobe-private/react-spectrum-v3"
   },
-  "browserslist": ["chrome >= 61", "firefox >= 60", "safari >= 11", "edge >= 16"],
+  "browserslist": [
+    "chrome >= 61",
+    "firefox >= 60",
+    "safari >= 11",
+    "edge >= 16"
+  ],
   "scripts": {
     "check-types": "tsc --skipLibCheck",
     "start": "make run",
@@ -62,8 +67,8 @@
     "@storybook/react": "^5.2.1",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/react": "^10.0.3",
-    "@testing-library/user-event": "^10.3.1",
     "@testing-library/react-hooks": "^3.2.1",
+    "@testing-library/user-event": "^10.3.1",
     "@types/react": "^16.8.0",
     "@types/storybook__react": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^2.28.0",

--- a/packages/dev/docs/src/FunctionAPI.js
+++ b/packages/dev/docs/src/FunctionAPI.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {JoinList, Type, TypeContext, TypeParameters} from './types';
+import {Indent, JoinList, Type, TypeContext, TypeParameters} from './types';
 import React from 'react';
 import typographyStyles from '@adobe/spectrum-css-temp/components/typography/vars.css';
 
@@ -22,9 +22,9 @@ export function FunctionAPI({function: func, links}) {
       <code className={`${typographyStyles['spectrum-Code4']}`}>
         <span className="token hljs-function">{name}</span>
         <TypeParameters typeParameters={typeParameters} />
-        <span className="token punctuation">{parameters.length > 2 ? '(\n  ' : '('}</span>
-        <JoinList elements={parameters} joiner={parameters.length > 2 ? ',\n  ' : ', '} />
-        <span className="token punctuation">{parameters.length > 2 ? '\n)' : ')'}</span>
+        <span className="token punctuation"><Indent params={parameters} small={'(\n  '} large="(" /></span>
+        <JoinList elements={parameters} joiner={<Indent params={parameters} small={',\n  '} large=", " />} />
+        <span className="token punctuation">{<Indent params={parameters} small={'\n)'} large=")" />}</span>
         <span className="token punctuation">{': '}</span>
         <Type type={returnType} />
       </code>

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -116,11 +116,11 @@ function Page({children, currentPage, publicUrl, styles, scripts}) {
               }
 
               if (!fine.matches) {
-                classList.remove("${theme.medium['spectrum--medium']}");
-                classList.add("${theme.large['spectrum--large']}");
+                classList.remove("${theme.medium['spectrum--medium']}", "${docStyles.medium}");
+                classList.add("${theme.large['spectrum--large']}", "${docStyles.large}");
               } else {
-                classList.add("${theme.medium['spectrum--medium']}");
-                classList.remove("${theme.large['spectrum--large']}");
+                classList.add("${theme.medium['spectrum--medium']}", "${docStyles.medium}");
+                classList.remove("${theme.large['spectrum--large']}", "${docStyles.large}");
               }
             };
 

--- a/packages/dev/docs/src/docs.css
+++ b/packages/dev/docs/src/docs.css
@@ -61,6 +61,7 @@
 
 html, body {
   margin: 0;
+  text-size-adjust: none;
 }
 
 .provider {
@@ -288,6 +289,7 @@ article pre {
   padding: 18px;
   border-radius: 4px;
   overflow-x: auto;
+  white-space: pre-wrap;
 }
 
 article pre:global(.example) {
@@ -295,12 +297,36 @@ article pre:global(.example) {
   margin-bottom: 0;
 }
 
+/* Display large width code examples by default */
+article pre:global(.small),
+article pre:global(.medium) {
+  display: none;
+}
+
 code {
   white-space: pre-wrap;
 }
 
+/* Override spectrum font size for code in large scale */
+.medium code {
+  font-size: var(--spectrum-global-dimension-static-font-size-100);
+}
+
+.large code {
+  font-size: var(--spectrum-global-dimension-static-font-size-150);
+}
+
 article > code {
   display: block;
+}
+
+/* Display large width API types by default */
+code :global(.small) {
+  display: none;
+}
+
+code :global(.large) {
+  display: inline;
 }
 
 article kbd {
@@ -532,7 +558,38 @@ h2.sectionHeader {
     max-width: initial !important;
   }
 
+  /* Swap to displaying the medium width code examples */
+  article pre:global(.small),
+  article pre:global(.large) {
+    display: none;
+  }
+
+  article pre:global(.medium) {
+    display: block;
+  }
+
   @mixin small-propTable;
+}
+
+@media (max-width: 500px) {
+  /* Swap to displaying the small width code examples */
+  article pre:global(.medium),
+  article pre:global(.large) {
+    display: none;
+  }
+
+  article pre:global(.small) {
+    display: block;
+  }
+
+  /* Swap to displaying the medium width API types. */
+  code :global(.large) {
+    display: none;
+  }
+
+  code :global(.small) {
+    display: inline;
+  }
 }
 
 .popover {

--- a/packages/dev/docs/src/syntax-highlight.css
+++ b/packages/dev/docs/src/syntax-highlight.css
@@ -116,15 +116,13 @@
 
 :global(.source) {
   display: block;
-  overflow-x: auto;
   padding: 0.5em;
   color: var(--hljs-color);
   background: var(--hljs-background);
 
   text-align: left;
-  white-space: pre;
   word-spacing: normal;
-  word-break: normal;
+  word-break: break-all;
   line-height: 1.5;
 
   -moz-tab-size: 4;

--- a/packages/dev/docs/src/types.js
+++ b/packages/dev/docs/src/types.js
@@ -200,14 +200,29 @@ function TypeParameter({name, default: defaultType}) {
   );
 }
 
+export function Indent({params, small, large}) {
+  if (params.length > 2) {
+    return small;
+  }
+
+  return (
+    <>
+      <span className="small">{small}</span>
+      <span className="large">{large}</span>
+    </>
+  );
+}
+
 function FunctionType({name, parameters, return: returnType, typeParameters, rest}) {
   return (
     <>
       {name && <span className="token hljs-function">{name}</span>}
       <TypeParameters typeParameters={typeParameters} />
-      <span className="token punctuation">{parameters.length > 2 ? '(\n  ' : '('}</span>
-      <JoinList elements={parameters} joiner={parameters.length > 2 ? ',\n  ' : ', '} />
-      <span className="token punctuation">{parameters.length > 2 ? '\n)' : ')'}</span>
+      <span className="token punctuation"><Indent params={parameters} small={'(\n  '} large="(" /></span>
+      <JoinList
+        elements={parameters}
+        joiner={<Indent params={parameters} small={',\n  '} large=", " />} />
+      <Indent params={parameters} small={'\n)'} large=")" />
       <span className="token punctuation">{name ? ': ' : ' => '}</span>
       <Type type={returnType} />
     </>
@@ -358,9 +373,9 @@ export function InterfaceType({description, properties: props, showRequired, sho
                   <code className={`${typographyStyles['spectrum-Code4']}`}>
                     <span className="token hljs-function">{prop.name}</span>
                     <TypeParameters typeParameters={prop.value.typeParameters} />
-                    <span className="token punctuation">{prop.value.parameters.length > 2 ? '(\n  ' : '('}</span>
-                    <JoinList elements={prop.value.parameters} joiner={prop.value.parameters.length > 2 ? ',\n  ' : ', '} />
-                    <span className="token punctuation">{prop.value.parameters.length > 2 ? '\n)' : ')'}</span>
+                    <span className="token punctuation"><Indent params={prop.value.parameters} small={'(\n  '} large="(" /></span>
+                    <JoinList elements={prop.value.parameters} joiner={<Indent params={prop.value.parameters} small={',\n  '} large=",  " />} />
+                    <span className="token punctuation"><Indent params={prop.value.parameters} small={'\n)'} large=")" /></span>
                     <span className="token punctuation">{': '}</span>
                     <Type type={prop.value.return} />
                   </code>

--- a/packages/dev/parcel-transformer-mdx-docs/MDXFragments.js
+++ b/packages/dev/parcel-transformer-mdx-docs/MDXFragments.js
@@ -12,13 +12,6 @@
 
 const flatMap = require('unist-util-flatmap');
 
-const openingTag = '<>\n';
-const closingTag = '\n</>';
-
-const get = p => o =>
-  p.reduce((xs, x) =>
-    (xs && xs[x]) ? xs[x] : null, o);
-
 /**
  * Takes example code blocks in mdx files that are just React Tags and wraps all of them into
  * a single Fragment shorthand node. This way syntax trees can parse them and return something meaningful
@@ -26,10 +19,9 @@ const get = p => o =>
 const fragmentWrap = () => (tree, file) => (
   flatMap(tree, node => {
     if (node.type === 'code') {
-      if (node.meta === 'example') {
-        let code = node.value;
-        if (/^<(.|\n)*>$/.test(code)) {
-          node.value = `${openingTag}${code}${closingTag}`;
+      if (/^example/.test(node.meta)) {
+        if (/^<(.|\n)*>$/m.test(node.value)) {
+          node.value = node.value.replace(/^(<(.|\n)*>)$/m, '<WRAPPER>\n$1\n</WRAPPER>');
         }
 
         return [
@@ -42,24 +34,45 @@ const fragmentWrap = () => (tree, file) => (
   })
 );
 
+function match(children, i, ...texts) {
+  if (children.length < i + texts.length) {
+    return false;
+  }
+
+  for (let t = 0; t < texts.length; t++, i++) {
+    let text = texts[t];
+    let child = children[i];
+
+    if (child.type === 'element') {
+      if (child.children && child.children[0] && child.children[0].value !== text) {
+        return false;
+      }
+    } else if (child.type === 'text') {
+      if (child.value !== text) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 /**
  * This undoes the above wrapping for display purposes.
  */
 const fragmentUnWrap = () => (tree, file) => (
   flatMap(tree, node => {
     if (node.type === 'code') {
-      if (node.meta === 'example' && node.data && node.data.hChildren) {
-        if (get(['data', 'hChildren', 0, 'children', 1, 'children', 0, 'value'])(node) === '>') {
-          // unshift the children that make up `<>\n`
-          node.data.hChildren[0].children.shift();
-          node.data.hChildren[0].children.shift();
-          node.data.hChildren[0].children.shift();
+      if (/^example/.test(node.meta) && node.data && node.data.hChildren) {
+        let children = node.data.hChildren[0].children;
+        for (let i = 0; i < children.length; i++) {
+          if (match(children, i, '<', 'WRAPPER', '>', '\n')) {
+            children.splice(i, 4);
+          }
 
-          // remove the last children that make up `\n</>`
-          node.data.hChildren[0].children.length = node.data.hChildren[0].children.length - 4;
-
-          // fix the 'value' field to reflect what we've done getting rid of the wrapping <></>
-          node.value = node.value.slice(3, node.value.length - 4);
+          if (match(children, i, '\n', '<', '/', 'WRAPPER', '>')) {
+            children.splice(i, 5);
+          }
         }
 
         return [

--- a/packages/dev/parcel-transformer-mdx-docs/package.json
+++ b/packages/dev/parcel-transformer-mdx-docs/package.json
@@ -14,6 +14,7 @@
     "@parcel/plugin": "nightly",
     "js-yaml": "^3.13.1",
     "mdast-util-toc": "^5.0.1",
+    "prettier": "^2.0.5",
     "remark-frontmatter": "^2.0.0",
     "remark-slug": "5.1.2",
     "remark-toc": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16879,6 +16879,11 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
 pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"


### PR DESCRIPTION
This makes the code examples in the docs responsive, and ensures they are formatted consistently. It runs each example through prettier at three widths: 25 characters, 60 characters, and 80 characters. These all get placed in the output HTML with separate classes, and we use media queries to switch between them. So on small screens, you'd get more wrapping than large screens, but the wrapping is "smart" and includes proper indentation.

In some cases, e.g. on super small screens, there may still be some overflow, and this has been changed to wrap rather than horizontally scroll as recommended by the accessibility team. But because of the prettier formatting, this should be much more rare.

Also adjusted the API types the same way, and fixed some issues with syntax highlighting of multiple adjacent JSX elements.