### PR TITLE
Switch to `key` instead of `uniqueKey` in collections, and remove `itemKey`

### DIFF
--- a/packages/@react-aria/menu/docs/useMenu.mdx
+++ b/packages/@react-aria/menu/docs/useMenu.mdx
@@ -184,9 +184,9 @@ function MenuItem({item, state, onAction}) {
 }
 
 <Menu onAction={alert} aria-label="Actions">
-  <Item uniqueKey="one">One</Item>
-  <Item uniqueKey="two">Two</Item>
-  <Item uniqueKey="three">Three</Item>
+  <Item key="one">One</Item>
+  <Item key="two">Two</Item>
+  <Item key="three">Three</Item>
 </Menu>
 ```
 
@@ -314,14 +314,14 @@ function MenuItem({item, state, onAction}) {
 
 <Menu onAction={alert} aria-label="Actions">
   <Section title="Section 1">
-    <Item uniqueKey="section1-item1">One</Item>
-    <Item uniqueKey="section1-item2">Two</Item>
-    <Item uniqueKey="section1-item3">Three</Item>
+    <Item key="section1-item1">One</Item>
+    <Item key="section1-item2">Two</Item>
+    <Item key="section1-item3">Three</Item>
   </Section>
   <Section title="Section 2">
-    <Item uniqueKey="section2-item1">One</Item>
-    <Item uniqueKey="section2-item2">Two</Item>
-    <Item uniqueKey="section2-item3">Three</Item>
+    <Item key="section2-item1">One</Item>
+    <Item key="section2-item2">Two</Item>
+    <Item key="section2-item3">Three</Item>
   </Section>
 </Menu>
 ```
@@ -420,17 +420,17 @@ function MenuItem({item, state, onAction}) {
 }
 
 <Menu onAction={alert} aria-label="Actions">
-  <Item textValue="Copy" uniqueKey="copy">
+  <Item textValue="Copy" key="copy">
     <div><strong>Copy</strong></div>
     <div>Copy the selected text</div>
     <kbd>⌘C</kbd>
   </Item>
-  <Item textValue="Cut" uniqueKey="cut">
+  <Item textValue="Cut" key="cut">
     <div><strong>Cut</strong></div>
     <div>Cut the selected text</div>
     <kbd>⌘X</kbd>
   </Item>
-  <Item textValue="Paste" uniqueKey="paste">
+  <Item textValue="Paste" key="paste">
     <div><strong>Paste</strong></div>
     <div>Paste the copied text</div>
     <kbd>⌘V</kbd>

--- a/packages/@react-aria/menu/docs/useMenuTrigger.mdx
+++ b/packages/@react-aria/menu/docs/useMenuTrigger.mdx
@@ -216,9 +216,9 @@ function MenuItem({item, state, onAction, onClose}) {
 }
 
 <MenuButton label="Actions" onAction={alert}>
-  <Item uniqueKey="copy">Copy</Item>
-  <Item uniqueKey="cut">Cut</Item>
-  <Item uniqueKey="paste">Paste</Item>
+  <Item key="copy">Copy</Item>
+  <Item key="cut">Cut</Item>
+  <Item key="paste">Paste</Item>
 </MenuButton>
 ```
 

--- a/packages/@react-spectrum/actiongroup/docs/ActionGroup.mdx
+++ b/packages/@react-spectrum/actiongroup/docs/ActionGroup.mdx
@@ -40,15 +40,15 @@ category: Buttons
 
 ```tsx example
 <ActionGroup>
-  <Item uniqueKey="add">Add</Item>
-  <Item uniqueKey="delete">Delete</Item>
-  <Item uniqueKey="edit">Edit</Item>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
 </ActionGroup>
 ```
 
 ## Content
 
-ActionGroups accepts a list of `children`, each with a `uniqueKey` prop. It is required that the `children` are <TypeLink links={collectionsDocs.links} type={collectionsDocs.exports.Item} /> components from the `@react-stately/collections` library.
+ActionGroups accepts a list of `children`, each with a `key` prop. It is required that the `children` are <TypeLink links={collectionsDocs.links} type={collectionsDocs.exports.Item} /> components from the `@react-stately/collections` library.
 
 However, a function that returns `Item` components is also accepted.
 
@@ -58,13 +58,13 @@ const items = [
   {children: 'Add', name: 'Add'},
   {children: 'Delete', name: 'Delete'}
 ];
-<ActionGroup items={items} itemKey="name">
-  {item => <Item>{item.children}</Item>}
+<ActionGroup items={items}>
+  {item => <Item key={item.name}>{item.children}</Item>}
 </ActionGroup>
 ```
 
 
-Each child needs to have a `uniqueKey` prop so it can be identified when actioned upon by a user. If using a function, an `itemKey` prop is required on the ActionGroup.
+Each item needs to have a `key` prop so it can be identified when actioned upon by a user.
 
 See [Events](#events) for more information.
 
@@ -72,13 +72,13 @@ See [Events](#events) for more information.
 
 ActionGroups are uncontrolled by default. 
 
-Use `defaultSelectedKeys` to provide a default set of selected items. The value of the selected keys must match the `uniqueKey` prop of the items.
+Use `defaultSelectedKeys` to provide a default set of selected items. The value of the selected keys must match the `key` prop of the items.
 
 ```tsx example
 <ActionGroup defaultSelectedKeys={['delete']}>
-  <Item uniqueKey="add">Add</Item>
-  <Item uniqueKey="delete">Delete</Item>
-  <Item uniqueKey="edit">Edit</Item>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
 </ActionGroup>
 ```
 
@@ -86,9 +86,9 @@ The `selectedKeys` prop can be used to make the selected state controlled.
 
 ```tsx example
 <ActionGroup selectedKeys={['delete']}>
-  <Item uniqueKey="add">Add</Item>
-  <Item uniqueKey="delete">Delete</Item>
-  <Item uniqueKey="edit">Edit</Item>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
 </ActionGroup>
 ```
 
@@ -99,9 +99,9 @@ This should be added using the `aria-label` prop to each Item.
 
 ```tsx example
 <ActionGroup>
-  <Item uniqueKey="brush" aria-label="Brush"><Brush /></Item>
-  <Item uniqueKey="select" aria-label="Select"><Select /></Item>
-  <Item uniqueKey="regionSelect" aria-label="Select Region"><RegionSelect /></Item>
+  <Item key="brush" aria-label="Brush"><Brush /></Item>
+  <Item key="select" aria-label="Select"><Select /></Item>
+  <Item key="regionSelect" aria-label="Select Region"><RegionSelect /></Item>
 </ActionGroup>
 ```
 
@@ -112,7 +112,7 @@ In order to internationalize an ActionGroup, the strings of all child items shou
 ## Events
 
 Use the `onSelectionChange` prop as a callback to handle press events on items.
-The `uniqueKey` prop from the selected item will be passed into the callback.
+The `key` prop from the selected item will be passed into the callback.
 
 The following example uses the `onSelectionChange` prop to update a string stored in React state.
 
@@ -122,9 +122,9 @@ function Example() {
   return (
     <div>
       <ActionGroup onSelectionChange={setLastKey}>
-        <Item uniqueKey="add">Add</Item>
-        <Item uniqueKey="delete">Delete</Item>
-        <Item uniqueKey="edit">Edit</Item>
+        <Item key="add">Add</Item>
+        <Item key="delete">Delete</Item>
+        <Item key="edit">Edit</Item>
       </ActionGroup>
       <p>Current selection: {lastKey}</p>
     </div>
@@ -139,9 +139,9 @@ function Example() {
   return (
     <div>
       <ActionGroup selectionMode="multiple" onSelectionChange={setSelectedKeys}>
-        <Item uniqueKey="add">Add</Item>
-        <Item uniqueKey="delete">Delete</Item>
-        <Item uniqueKey="edit">Edit</Item>
+        <Item key="add">Add</Item>
+        <Item key="delete">Delete</Item>
+        <Item key="edit">Edit</Item>
       </ActionGroup>
       <p>Selected: {[...selectedKeys].toString()}</p>
     </div>
@@ -156,9 +156,9 @@ function Example() {
   return (
     <div>
       <ActionGroup selectionMode="none" onAction={setActedKey}>
-        <Item uniqueKey="add">Add</Item>
-        <Item uniqueKey="delete">Delete</Item>
-        <Item uniqueKey="edit">Edit</Item>
+        <Item key="add">Add</Item>
+        <Item key="delete">Delete</Item>
+        <Item key="edit">Edit</Item>
       </ActionGroup>
       <p>Last action: {actedKey}</p>
     </div>
@@ -176,9 +176,9 @@ function Example() {
 
 ```tsx example
 <ActionGroup isQuiet>
-  <Item uniqueKey="add">Add</Item>
-  <Item uniqueKey="delete">Delete</Item>
-  <Item uniqueKey="edit">Edit</Item>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
 </ActionGroup>
 ```
 
@@ -188,9 +188,9 @@ The additional styling provided by the `isEmphasized` prop is only applied when 
 
 ```tsx example
 <ActionGroup isEmphasized defaultSelectedKeys={['add']}>
-  <Item uniqueKey="add">Add</Item>
-  <Item uniqueKey="delete">Delete</Item>
-  <Item uniqueKey="edit">Edit</Item>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
 </ActionGroup>
 ```
 
@@ -200,9 +200,9 @@ To disable the entire ActionGroup, use the `isDisabled` prop on the root.
 
 ```tsx example
 <ActionGroup isDisabled>
-  <Item uniqueKey="add">Add</Item>
-  <Item uniqueKey="delete">Delete</Item>
-  <Item uniqueKey="edit">Edit</Item>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
 </ActionGroup>
 ```
 
@@ -210,9 +210,9 @@ To disable individual items, a list of `disabledKeys` can be provided.
 
 ```tsx example
 <ActionGroup disabledKeys={['add', 'delete']}>
-  <Item uniqueKey="add">Add</Item>
-  <Item uniqueKey="delete">Delete</Item>
-  <Item uniqueKey="edit">Edit</Item>
+  <Item key="add">Add</Item>
+  <Item key="delete">Delete</Item>
+  <Item key="edit">Edit</Item>
 </ActionGroup>
 ```
 
@@ -222,8 +222,8 @@ Using the `orientation` prop with value `vertical` changes the alignment of the 
 
 ```tsx example
 <ActionGroup orientation="vertical" maxWidth="32px">
-  <Item uniqueKey="brush" aria-label="Brush"><Brush /></Item>
-  <Item uniqueKey="select" aria-label="Select"><Select /></Item>
-  <Item uniqueKey="regionSelect" aria-label="Select Region"><RegionSelect /></Item>
+  <Item key="brush" aria-label="Brush"><Brush /></Item>
+  <Item key="select" aria-label="Select"><Select /></Item>
+  <Item key="regionSelect" aria-label="Select Region"><RegionSelect /></Item>
 </ActionGroup>
 ```

--- a/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
+++ b/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
@@ -121,8 +121,8 @@ storiesOf('ActionGroup', module)
   .add(
     'dynamic',
     () => (
-      <ActionGroup onSelectionChange={s => onSelectionChange([...s])} items={items} itemKey="name">
-        {item => <Item textValue={item.name}>{item.children}</Item>}
+      <ActionGroup onSelectionChange={s => onSelectionChange([...s])} items={items}>
+        {item => <Item key={item.name} textValue={item.name}>{item.children}</Item>}
       </ActionGroup>
     )
   );
@@ -149,8 +149,8 @@ function render(props = {}, items: any = itemsWithIcons) {
   return (
     <ActionGroup onSelectionChange={s => onSelectionChange([...s])} {...props}>
       {
-        items.map((itemProps, index) => (
-          <Item uniqueKey={itemProps.name} key={index} textValue={itemProps.name} {...itemProps} />
+        items.map((itemProps) => (
+          <Item key={itemProps.name} textValue={itemProps.name} {...itemProps} />
         ))
       }
     </ActionGroup>

--- a/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
+++ b/packages/@react-spectrum/actiongroup/test/ActionGroup.test.js
@@ -108,8 +108,8 @@ function renderComponent(props) {
   return render(
     <Provider theme={theme} locale="de-DE">
       <ActionGroup {...props}>
-        <Item uniqueKey="1">Click me 1</Item>
-        <Item uniqueKey="2">Click me 2</Item>
+        <Item key="1">Click me 1</Item>
+        <Item key="2">Click me 2</Item>
       </ActionGroup>
     </Provider>
   );
@@ -120,8 +120,8 @@ function renderComponentWithExtraInputs(props) {
     <Provider theme={theme} locale="de-DE">
       <Button variant="primary" aria-label="ButtonBefore" />
       <ActionGroup {...props}>
-        <Item uniqueKey="1">Click me 1</Item>
-        <Item uniqueKey="2">Click me 2</Item>
+        <Item key="1">Click me 1</Item>
+        <Item key="2">Click me 2</Item>
       </ActionGroup>
       <Button variant="primary" aria-label="ButtonAfter" />
     </Provider>
@@ -245,9 +245,9 @@ describe('ActionGroup', function () {
     let tree = render(
       <Provider theme={theme} locale={props.locale}>
         <ActionGroup disabledKeys={disabledKeys}>
-          <Item uniqueKey="0" data-testid="button-1">Click me 1</Item>
-          <Item uniqueKey="1" data-testid="button-2">Click me 2</Item>
-          <Item uniqueKey="2" data-testid="button-3">Click me 3</Item>
+          <Item key="0" data-testid="button-1">Click me 1</Item>
+          <Item key="1" data-testid="button-2">Click me 2</Item>
+          <Item key="2" data-testid="button-3">Click me 3</Item>
         </ActionGroup>
       </Provider>
     );
@@ -270,10 +270,10 @@ describe('ActionGroup', function () {
     let tree = render(
       <Provider theme={theme} locale={props.locale}>
         <ActionGroup disabledKeys={disabledKeys}>
-          <Item uniqueKey="0" data-testid="button-1">Click me 1</Item>
-          <Item uniqueKey="1" data-testid="button-2">Click me 2</Item>
-          <Item uniqueKey="2" data-testid="button-3">Click me 3</Item>
-          <Item uniqueKey="3" data-testid="button-4">Click me 4</Item>
+          <Item key="0" data-testid="button-1">Click me 1</Item>
+          <Item key="1" data-testid="button-2">Click me 2</Item>
+          <Item key="2" data-testid="button-3">Click me 3</Item>
+          <Item key="3" data-testid="button-4">Click me 4</Item>
         </ActionGroup>
       </Provider>
     );
@@ -547,7 +547,7 @@ describe('ActionGroup', function () {
     let tree = render(
       <Provider theme={theme} locale="de-DE">
         <ActionGroup selectionMode="none" onAction={onAction}>
-          <Item uniqueKey="test">Click me</Item>
+          <Item key="test">Click me</Item>
         </ActionGroup>
       </Provider>
     );
@@ -564,7 +564,7 @@ describe('ActionGroup', function () {
     let tree = render(
       <Provider theme={theme} locale="de-DE">
         <ActionGroup selectionMode="none" onAction={onAction} isDisabled>
-          <Item uniqueKey="test">Click me</Item>
+          <Item key="test">Click me</Item>
         </ActionGroup>
       </Provider>
     );
@@ -580,7 +580,7 @@ describe('ActionGroup', function () {
     let tree = render(
       <Provider theme={theme} locale="de-DE">
         <ActionGroup selectionMode="none" onAction={onAction} disabledKeys={['test']}>
-          <Item uniqueKey="test">Click me</Item>
+          <Item key="test">Click me</Item>
         </ActionGroup>
       </Provider>
     );

--- a/packages/@react-spectrum/breadcrumbs/docs/Breadcrumbs.mdx
+++ b/packages/@react-spectrum/breadcrumbs/docs/Breadcrumbs.mdx
@@ -37,15 +37,15 @@ category: Navigation
 
 ```tsx example
 <Breadcrumbs>
-  <Item uniqueKey="Folder 1">Folder 1</Item>
-  <Item uniqueKey="Folder 2">Folder 2</Item>
-  <Item uniqueKey="Folder 3">Folder 3</Item>
+  <Item key="Folder 1">Folder 1</Item>
+  <Item key="Folder 2">Folder 2</Item>
+  <Item key="Folder 3">Folder 3</Item>
 </Breadcrumbs>
 ```
 
 ## Content
 
-Breadcrumbs accept as list of `children`, each with a `uniqueKey` prop.
+Breadcrumbs accept as list of `children`, each with a `key` prop.
 
 It is required that the `children` are <TypeLink links={collectionsDocs.links} type={collectionsDocs.exports.Item} /> components from the `@react-stately/collections` library.
 
@@ -53,16 +53,16 @@ It is required that the `children` are <TypeLink links={collectionsDocs.links} t
 function Example() {
   return (
     <Breadcrumbs>
-      <Item uniqueKey="Folder 1">Folder 1</Item>
-      <Item uniqueKey="Folder 2">Folder 2</Item>
-      <Item uniqueKey="Folder 3">Folder 3</Item>
+      <Item key="Folder 1">Folder 1</Item>
+      <Item key="Folder 2">Folder 2</Item>
+      <Item key="Folder 3">Folder 3</Item>
     </Breadcrumbs>
   );
 }
 ```
 
 In order to identify children when a user takes an action on a item,
-each child needs to have a `uniqueKey` prop. See [Events](#events) for more information.
+each child needs to have a `key` prop. See [Events](#events) for more information.
 
 ### Internationalization
 
@@ -71,7 +71,7 @@ In order to internationalize Breadcrumbs, the strings of all child items should 
 ## Events
 
 Use the `onAction` prop as a callback to handle press events on items.
-The `uniqueKey` prop from the selected item will be passed into the callback.
+The `key` prop from the selected item will be passed into the callback.
 
 ```tsx example
 function Example() {
@@ -84,7 +84,7 @@ function Example() {
   return (
     <div>
       <Breadcrumbs onAction={(a) => setFolderId(a)}>
-        {folders.map(f => <Item key={f.id} uniqueKey={f.id}>{f.label}</Item>)}
+        {folders.map(f => <Item key={f.id} key={f.id}>{f.label}</Item>)}
       </Breadcrumbs>
       <p>Last Selected Folder: {folderId}</p>
     </div>
@@ -104,16 +104,16 @@ The small size is useful when available space is limited.
 
 ```tsx example
 <Breadcrumbs size="S">
-  <Item uniqueKey="Folder 1">Folder 1</Item>
-  <Item uniqueKey="Folder 2">Folder 2</Item>
+  <Item key="Folder 1">Folder 1</Item>
+  <Item key="Folder 2">Folder 2</Item>
 </Breadcrumbs>
 ```
 
 The medium size is the default.
 ```tsx example
 <Breadcrumbs size="M">
-  <Item uniqueKey="Folder 1">Folder 1</Item>
-  <Item uniqueKey="Folder 2">Folder 2</Item>
+  <Item key="Folder 1">Folder 1</Item>
+  <Item key="Folder 2">Folder 2</Item>
 </Breadcrumbs>
 ```
 
@@ -121,8 +121,8 @@ The large size places emphasis on the selected item as a page title or heading.
 
 ```tsx example
 <Breadcrumbs size="L">
-  <Item uniqueKey="Folder 1">Folder 1</Item>
-  <Item uniqueKey="Folder 2">Folder 2</Item>
+  <Item key="Folder 1">Folder 1</Item>
+  <Item key="Folder 2">Folder 2</Item>
 </Breadcrumbs>
 ```
 
@@ -133,9 +133,9 @@ If a change to the aria-level is required, use the `headingAriaLevel` prop.
 
 ```tsx example
 <Breadcrumbs isHeading headingAriaLevel={2}>
-  <Item uniqueKey="Folder 1">Folder 1</Item>
-  <Item uniqueKey="Folder 2">Folder 2</Item>
-  <Item uniqueKey="Folder 3">Folder 3</Item>
+  <Item key="Folder 1">Folder 1</Item>
+  <Item key="Folder 2">Folder 2</Item>
+  <Item key="Folder 3">Folder 3</Item>
 </Breadcrumbs>
 ```
 
@@ -150,9 +150,9 @@ In order to manually control the truncation, use the `maxVisibleItems` prop.
 
 ```tsx example
 <Breadcrumbs maxVisibleItems={2}>
-  <Item uniqueKey="Folder 1">Folder 1</Item>
-  <Item uniqueKey="Folder 2">Folder 2</Item>
-  <Item uniqueKey="Folder 3">Folder 3</Item>
+  <Item key="Folder 1">Folder 1</Item>
+  <Item key="Folder 2">Folder 2</Item>
+  <Item key="Folder 3">Folder 3</Item>
 </Breadcrumbs>
 ```
 
@@ -164,11 +164,11 @@ This variation keeps the root visible when other items are truncated into the me
 ```tsx example
 <View overflow="hidden" width="200px">
   <Breadcrumbs showRoot maxVisibleItems="auto">
-    <Item uniqueKey="Folder 1">Folder 1</Item>
-    <Item uniqueKey="Folder 2">Folder 2</Item>
-    <Item uniqueKey="Folder 3">Folder 3</Item>
-    <Item uniqueKey="Folder 4">Folder 4</Item>
-    <Item uniqueKey="Folder 5">Folder 5</Item>
+    <Item key="Folder 1">Folder 1</Item>
+    <Item key="Folder 2">Folder 2</Item>
+    <Item key="Folder 3">Folder 3</Item>
+    <Item key="Folder 4">Folder 4</Item>
+    <Item key="Folder 5">Folder 5</Item>
   </Breadcrumbs>
 </View>
 ```
@@ -180,8 +180,8 @@ This can be used to maintain layout continuity.
 
 ```tsx example
 <Breadcrumbs isDisabled>
-  <Item uniqueKey="Folder 1">Folder 1</Item>
-  <Item uniqueKey="Folder 2">Folder 2</Item>
-  <Item uniqueKey="Folder 3">Folder 3</Item>
+  <Item key="Folder 1">Folder 1</Item>
+  <Item key="Folder 2">Folder 2</Item>
+  <Item key="Folder 3">Folder 3</Item>
 </Breadcrumbs>
 ```

--- a/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/@react-spectrum/breadcrumbs/src/Breadcrumbs.tsx
@@ -16,7 +16,7 @@ import {classNames, useDOMRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMRef} from '@react-types/shared';
 import FolderBreadcrumb from '@spectrum-icons/ui/FolderBreadcrumb';
 import {Menu, MenuTrigger} from '@react-spectrum/menu';
-import React, {Key, useEffect, useRef, useState} from 'react';
+import React, {Key, ReactElement, useEffect, useRef, useState} from 'react';
 import {SpectrumBreadcrumbsProps} from '@react-types/breadcrumbs';
 import styles from '@adobe/spectrum-css-temp/components/breadcrumb/vars.css';
 import {useBreadcrumbs} from '@react-aria/breadcrumbs';
@@ -45,7 +45,14 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
     ...otherProps
   } = props;
 
-  let childArray = React.Children.toArray(children);
+  // Not using React.Children.toArray because it mutates the key prop.
+  let childArray: ReactElement[] = [];
+  React.Children.forEach(children, child => {
+    if (React.isValidElement(child)) {
+      childArray.push(child);
+    }
+  });
+
   let isCollapsible = maxVisibleItems === 'auto';
 
   let domRef = useDOMRef(ref);
@@ -117,7 +124,7 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
 
   if (childArray.length > visibleItems) {
     let selectedItem = childArray[childArray.length - 1];
-    let selectedKey = selectedItem.props.uniqueKey || selectedItem.key;
+    let selectedKey = selectedItem.key ?? childArray.length - 1;
     let onMenuAction = (key: Key) => {
       // Don't fire onAction when clicking on the last item
       if (key !== selectedKey && onAction) {
@@ -154,7 +161,7 @@ function Breadcrumbs<T>(props: SpectrumBreadcrumbsProps<T>, ref: DOMRef) {
   let lastIndex = childArray.length - 1;
   let breadcrumbItems = childArray.map((child, index) => {
     let isCurrent = index === lastIndex;
-    let key = child.props.uniqueKey || child.key;
+    let key = child.key ?? index;
     let onPress = () => {
       if (onAction) {
         onAction(key);

--- a/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
+++ b/packages/@react-spectrum/breadcrumbs/stories/Breadcrumbs.stories.tsx
@@ -104,9 +104,9 @@ storiesOf('Breadcrumbs', module)
 function render(props = {}) {
   return (
     <Breadcrumbs {...props} onAction={action('onAction')}>
-      <Item uniqueKey="Folder 1">The quick brown fox jumps over</Item>
-      <Item uniqueKey="Folder 2">My Documents</Item>
-      <Item uniqueKey="Folder 3">Kangaroos jump high</Item>
+      <Item key="Folder 1">The quick brown fox jumps over</Item>
+      <Item key="Folder 2">My Documents</Item>
+      <Item key="Folder 3">Kangaroos jump high</Item>
     </Breadcrumbs>
   );
 }
@@ -114,13 +114,13 @@ function render(props = {}) {
 function renderMany(props = {}) {
   return (
     <Breadcrumbs {...props} onAction={action('onAction')}>
-      <Item uniqueKey="Folder 1">The quick brown fox jumps over</Item>
-      <Item uniqueKey="Folder 2">My Documents</Item>
-      <Item uniqueKey="Folder 3">Kangaroos jump high</Item>
-      <Item uniqueKey="Folder 4">Koalas are very cute</Item>
-      <Item uniqueKey="Folder 5">Wombat's noses</Item>
-      <Item uniqueKey="Folder 6">Wattle trees</Item>
-      <Item uniqueKey="Folder 7">April 7</Item>
+      <Item key="Folder 1">The quick brown fox jumps over</Item>
+      <Item key="Folder 2">My Documents</Item>
+      <Item key="Folder 3">Kangaroos jump high</Item>
+      <Item key="Folder 4">Koalas are very cute</Item>
+      <Item key="Folder 5">Wombat's noses</Item>
+      <Item key="Folder 6">Wattle trees</Item>
+      <Item key="Folder 7">April 7</Item>
     </Breadcrumbs>
   );
 }

--- a/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
+++ b/packages/@react-spectrum/breadcrumbs/test/Breadcrumbs.test.js
@@ -249,7 +249,7 @@ describe('Breadcrumbs', function () {
     let {getAllByText, getByRole, getAllByRole} = render(
       <Provider theme={theme}>
         <Breadcrumbs maxVisibleItems="auto" showRoot onAction={onAction}>
-          <Item uniqueKey="Folder 1">Folder 1</Item>
+          <Item key="Folder 1">Folder 1</Item>
           <Item>Folder 2</Item>
           <Item>Folder 3</Item>
           <Item>Folder 4</Item>
@@ -285,11 +285,11 @@ describe('Breadcrumbs', function () {
     let {getByRole, getAllByRole} = render(
       <Provider theme={theme}>
         <Breadcrumbs maxVisibleItems="auto" showRoot onAction={onAction}>
-          <Item uniqueKey="Folder 1">Folder 1</Item>
-          <Item uniqueKey="Folder 2">Folder 2</Item>
-          <Item uniqueKey="Folder 3">Folder 3</Item>
-          <Item uniqueKey="Folder 4">Folder 4</Item>
-          <Item uniqueKey="Folder 5">Folder 5</Item>
+          <Item key="Folder 1">Folder 1</Item>
+          <Item key="Folder 2">Folder 2</Item>
+          <Item key="Folder 3">Folder 3</Item>
+          <Item key="Folder 4">Folder 4</Item>
+          <Item key="Folder 5">Folder 5</Item>
         </Breadcrumbs>
       </Provider>
     );

--- a/packages/@react-spectrum/form/stories/Form.stories.tsx
+++ b/packages/@react-spectrum/form/stories/Form.stories.tsx
@@ -56,8 +56,8 @@ storiesOf('Form', module)
         <TextField label="Street Address" placeholder="123 Any Street" />
         <Flex>
           <TextField label="City" placeholder="San Francisco" marginEnd="size-100" flex={1} />
-          <Picker label="State" placeholder="Select a state" items={states} itemKey="abbr" marginEnd="size-100" flex={1}>
-            {item => <Item>{item.name}</Item>}
+          <Picker label="State" placeholder="Select a state" items={states} marginEnd="size-100" flex={1}>
+            {item => <Item key={item.abbr}>{item.name}</Item>}
           </Picker>
           <TextField label="Zip code" placeholder="12345" flex={1} />
         </Flex>
@@ -108,12 +108,12 @@ function render(props: any = {}) {
       <TextField label="Last Name" placeholder="Smith" />
       <TextField label="Street Address" placeholder="123 Any Street" />
       <TextField label="City" placeholder="San Francisco" />
-      <Picker label="State" placeholder="Select a state" items={states} itemKey="abbr">
-        {item => <Item>{item.name}</Item>}
+      <Picker label="State" placeholder="Select a state" items={states}>
+        {item => <Item key={item.abbr}>{item.name}</Item>}
       </Picker>
       <TextField label="Zip code" placeholder="12345" />
-      <Picker label="Country" placeholder="Select a country" items={countries} itemKey="name">
-        {item => <Item>{item.name}</Item>}
+      <Picker label="Country" placeholder="Select a country" items={countries}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </Picker>
       <RadioGroup label="Favorite pet" name="favorite-pet-group">
         <Radio value="dogs">Dogs</Radio>

--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -97,18 +97,18 @@ storiesOf('ListBox', module)
   .add(
     'Default ListBox',
     () => (
-      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={flatOptions} itemKey="name">
-        {item => <Item>{item.name}</Item>}
+      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={flatOptions}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ListBox>
     )
   )
   .add(
     'ListBox w/ sections',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -117,10 +117,10 @@ storiesOf('ListBox', module)
   .add(
     'ListBox w/ many sections',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={lotsOfSections} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+      <ListBox width={200} aria-labelledby="label" items={lotsOfSections} onSelectionChange={action('onSelectionChange')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {(item: any) => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {(item: any) => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -129,10 +129,10 @@ storiesOf('ListBox', module)
   .add(
     'ListBox w/ sections and no title',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')}>
         {item => (
-          <Section items={item.children} aria-label={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} aria-label={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -185,10 +185,10 @@ storiesOf('ListBox', module)
   .add(
     'with default selected options',
     () => (
-      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
+      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} defaultSelectedKeys={['Kangaroo']}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -199,27 +199,27 @@ storiesOf('ListBox', module)
     () => (
       <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
-          <Item uniqueKey="7">
+          <Item key="7">
             Seven
           </Item>
         </Section>
@@ -229,10 +229,10 @@ storiesOf('ListBox', module)
   .add(
     'with selected options (controlled)',
     () => (
-      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
+      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} selectedKeys={['Kangaroo']}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -243,27 +243,27 @@ storiesOf('ListBox', module)
     () => (
       <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
-          <Item uniqueKey="7">
+          <Item key="7">
             Seven
           </Item>
         </Section>
@@ -273,10 +273,10 @@ storiesOf('ListBox', module)
   .add(
     'with disabled options',
     () => (
-      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']}>
+      <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} items={withSection} disabledKeys={['Kangaroo', 'Ross']}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -287,27 +287,27 @@ storiesOf('ListBox', module)
     () => (
       <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} disabledKeys={['3', '5']}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
-          <Item uniqueKey="7">
+          <Item key="7">
             Seven
           </Item>
         </Section>
@@ -317,10 +317,10 @@ storiesOf('ListBox', module)
   .add(
     'Multiple selection',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -331,24 +331,24 @@ storiesOf('ListBox', module)
     () => (
       <ListBox width={200} aria-labelledby="label" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['2', '5']} disabledKeys={['1', '3']}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
         </Section>
@@ -358,10 +358,10 @@ storiesOf('ListBox', module)
   .add(
     'No selection allowed',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="none">
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')} selectionMode="none">
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -387,10 +387,10 @@ storiesOf('ListBox', module)
   .add(
     'ListBox with autoFocus=true',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus>
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')} autoFocus>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -399,10 +399,10 @@ storiesOf('ListBox', module)
   .add(
     'ListBox with autoFocus="first"',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus="first">
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')} autoFocus="first">
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -411,10 +411,10 @@ storiesOf('ListBox', module)
   .add(
     'ListBox with autoFocus="last"',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} autoFocus="last">
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')} autoFocus="last">
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -423,10 +423,10 @@ storiesOf('ListBox', module)
   .add(
     'ListBox with keyboard selection wrapping',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} shouldFocusWrap>
+      <ListBox width={200} aria-labelledby="label" items={withSection} onSelectionChange={action('onSelectionChange')} shouldFocusWrap>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -474,9 +474,9 @@ storiesOf('ListBox', module)
   .add(
     'with semantic elements (generative)',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={hardModeProgrammatic} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
+      <ListBox width={200} aria-labelledby="label" items={hardModeProgrammatic}onSelectionChange={action('onSelectionChange')} selectionMode="multiple">
         {item => (
-          <Section items={item.children} title={item.name}>
+          <Section key={item.name} items={item.children} title={item.name}>
             {item => customOption(item)}
           </Section>
         )}
@@ -495,7 +495,7 @@ storiesOf('ListBox', module)
     'isLoading more',
     () => (
       <ListBox aria-labelledby="label" width={200} items={flatOptions} isLoading>
-        {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </ListBox>
     )
   )
@@ -509,7 +509,7 @@ storiesOf('ListBox', module)
 let customOption = (item) => {
   let Icon = iconMap[item.icon];
   return (
-    <Item textValue={item.name}>
+    <Item textValue={item.name} key={item.name}>
       {item.icon && <Icon size="S" />}
       <Text>{item.name}</Text>
     </Item>
@@ -535,7 +535,7 @@ function AsyncLoadingExample() {
 
   return (
     <ListBox aria-labelledby="label" width={200} items={list.items} isLoading={list.isLoading} onLoadMore={list.loadMore}>
-      {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+      {item => <Item key={item.name}>{item.name}</Item>}
     </ListBox>
   );
 }

--- a/packages/@react-spectrum/listbox/test/ListBox.test.js
+++ b/packages/@react-spectrum/listbox/test/ListBox.test.js
@@ -35,10 +35,10 @@ function renderComponent(props) {
   return render(
     <Provider theme={theme}>
       <span id="label">Choose an item</span>
-      <ListBox items={withSection} itemKey="name" aria-labelledby="label" {...props}>
+      <ListBox items={withSection} aria-labelledby="label" {...props}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item childItems={item.children}>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
           </Section>
         )}
       </ListBox>
@@ -616,7 +616,7 @@ describe('ListBox', function () {
       let {getByRole, rerender} = render(
         <Provider theme={theme}>
           <ListBox aria-label="listbox" items={items} isLoading>
-            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+            {item => <Item key={item.name}>{item.name}</Item>}
           </ListBox>
         </Provider>
       );
@@ -632,7 +632,7 @@ describe('ListBox', function () {
       rerender(
         <Provider theme={theme}>
           <ListBox aria-label="listbox" items={items}>
-            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+            {item => <Item key={item.name}>{item.name}</Item>}
           </ListBox>
         </Provider>
       );
@@ -652,7 +652,7 @@ describe('ListBox', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <ListBox aria-label="listbox" items={items} maxHeight={200} onLoadMore={onLoadMore}>
-            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+            {item => <Item key={item.name}>{item.name}</Item>}
           </ListBox>
         </Provider>
       );

--- a/packages/@react-spectrum/menu/docs/MenuTrigger.mdx
+++ b/packages/@react-spectrum/menu/docs/MenuTrigger.mdx
@@ -61,19 +61,16 @@ category: Collections
 The Menu accepts Items and [`Sections`](#sections) as children. Items can be
 statically populated (initial example above) or dynamically (below). The dynamic
 method would be better suited to use if the actions within a Menu came from a
-data object such as values returned via an API call. The `uniqueKey` prop needs
-to be set on an Item when statically defining Items and the `itemKey` prop in
-the Menu when its Items are dynamically populated.
+data object such as values returned via an API call. A unique `key` prop must be set
+on each item.
 
 ```tsx example
 <MenuTrigger>
   <ActionButton>
       Edit
   </ActionButton>
-  <Menu
-    items={[{name: 'Cut'}, {name: 'Copy'}, {name: 'Paste'}]}
-    itemKey="name">
-    {item => <Item>{item.name}</Item>}
+  <Menu items={[{name: 'Cut'}, {name: 'Copy'}, {name: 'Paste'}]}>
+    {item => <Item key={item.name}>{item.name}</Item>}
   </Menu>
 </MenuTrigger>
 ```
@@ -99,9 +96,9 @@ controlled state.
       Edit (Controlled)
   </ActionButton>
   <Menu selectionMode="single" selectedKeys={['copy']}>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 <MenuTrigger closeOnSelect={false}>
@@ -109,9 +106,9 @@ controlled state.
       Edit (Uncontrolled)
   </ActionButton>
   <Menu selectionMode="single" defaultSelectedKeys={['paste']}>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 ```
@@ -126,10 +123,10 @@ entirely (default).
       Show (Multiple)
   </ActionButton>
   <Menu selectionMode="multiple" defaultSelectedKeys={['Sidebar', 'Console']}>
-    <Item uniqueKey='Sidebar'>Sidebar</Item>
-    <Item uniqueKey='Searchbar'>Searchbar</Item>
-    <Item uniqueKey='Tools'>Tools</Item>
-    <Item uniqueKey='Console'>Console</Item>
+    <Item key='Sidebar'>Sidebar</Item>
+    <Item key='Searchbar'>Searchbar</Item>
+    <Item key='Tools'>Tools</Item>
+    <Item key='Console'>Console</Item>
   </Menu>
 </MenuTrigger>
 <MenuTrigger closeOnSelect={false}>
@@ -137,9 +134,9 @@ entirely (default).
       Edit (Selection Mode None)
   </ActionButton>
   <Menu selectionMode="none">
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 ```
@@ -147,7 +144,7 @@ entirely (default).
 ### Sections
 
 Menus may have Sections which can be used to wrap groups of Items. Each
-`Section` takes a `title` and `uniqueKey` prop.
+`Section` takes a `title` and `key` prop.
 
 #### Static Items
 
@@ -157,14 +154,14 @@ Menus may have Sections which can be used to wrap groups of Items. Each
       Edit
   </ActionButton>
   <Menu>
-    <Section uniqueKey="rollback" title="Rollback Options">
-      <Item uniqueKey="undo">Undo</Item>
-      <Item uniqueKey="redo">Redo</Item>
+    <Section key="rollback" title="Rollback Options">
+      <Item key="undo">Undo</Item>
+      <Item key="redo">Redo</Item>
     </Section>
-    <Section uniqueKey="select" title="Selected Text Options">
-      <Item uniqueKey="cut">Cut</Item>
-      <Item uniqueKey="copy">Copy</Item>
-      <Item uniqueKey="paste">Paste</Item>
+    <Section key="select" title="Selected Text Options">
+      <Item key="cut">Cut</Item>
+      <Item key="copy">Copy</Item>
+      <Item key="paste">Paste</Item>
     </Section>
   </Menu>
 </MenuTrigger>
@@ -181,11 +178,10 @@ structure. Section takes an array of data using the `items` prop.
       File Types
   </ActionButton>
   <Menu
-    items={[{name: 'Docs', children: [{name: 'PDF'}]}, {name: 'Images', children: [{name: 'jpeg'}, {name: 'png'}, {name: 'tiff'}]}]}
-    itemKey="name">
+    items={[{name: 'Docs', children: [{name: 'PDF'}]}, {name: 'Images', children: [{name: 'jpeg'}, {name: 'png'}, {name: 'tiff'}]}]}>
     {item => (
-      <Section items={item.children} title={item.name}>
-        {item => <Item>{item.name}</Item>}
+      <Section key={item.name} items={item.children} title={item.name}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </Section>
     )}
   </Menu>
@@ -206,7 +202,6 @@ import {Keyboard, Text} from '@react-spectrum/typography';
       Edit
   </ActionButton>
   <Menu
-    itemKey="name"
     items={[
       {name: 'Copy', icon: 'Copy', shortcut: '⌘C'},
       {name: 'Cut', icon: 'Cut', shortcut: '⌘X'},
@@ -220,7 +215,7 @@ import {Keyboard, Text} from '@react-spectrum/typography';
       };
       let Icon = iconMap[item.icon];
       return (
-        <Item childItems={item.children} textValue={item.name}>
+        <Item key={item.name} childItems={item.children} textValue={item.name}>
           <Icon size="S" />
           <Text>{item.name}</Text>
           <Keyboard>{item.shortcut}</Keyboard>
@@ -246,10 +241,10 @@ Titleless Menu Sections must be provided with an `aria-label` for accessibility.
   <ActionButton>
       Edit
   </ActionButton>
-  <Menu items={[{name: 'Rollback Options', children: [{name: 'Undo'}, {name: 'Redo'}]}, {name: 'Selected Text Options', children: [{name: 'Cut'}, {name: 'Copy'}, {name: 'Paste'}]}]} itemKey="name">
+  <Menu items={[{name: 'Rollback Options', children: [{name: 'Undo'}, {name: 'Redo'}]}, {name: 'Selected Text Options', children: [{name: 'Cut'}, {name: 'Copy'}, {name: 'Paste'}]}]}>
     {item => (
-      <Section items={item.children} aria-label={item.name}>
-        {item => <Item>{item.name}</Item>}
+      <Section key={item.name} items={item.children} aria-label={item.name}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </Section>
     )}
   </Menu>
@@ -277,9 +272,9 @@ function Example() {
             Edit
         </ActionButton>
         <Menu>
-          <Item uniqueKey="cut">Cut</Item>
-          <Item uniqueKey="copy">Copy</Item>
-          <Item uniqueKey="paste">Paste</Item>
+          <Item key="cut">Cut</Item>
+          <Item key="copy">Copy</Item>
+          <Item key="paste">Paste</Item>
         </Menu>
       </MenuTrigger>
       <span style={{'margin-left': '8px'}}>Current open state: {state.toString()}</span>
@@ -305,9 +300,9 @@ function Example() {
             Edit
         </ActionButton>
         <Menu onAction={(value) => setState(value)}>
-          <Item uniqueKey="cut">Cut</Item>
-          <Item uniqueKey="copy">Copy</Item>
-          <Item uniqueKey="paste">Paste</Item>
+          <Item key="cut">Cut</Item>
+          <Item key="copy">Copy</Item>
+          <Item key="paste">Paste</Item>
         </Menu>
       </MenuTrigger>
       <span style={{'margin-left': '8px'}}>onAction: {state.toString()}</span>
@@ -338,9 +333,9 @@ function Example() {
     placement align=start
   </ActionButton>
   <Menu>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 <MenuTrigger align="end">
@@ -348,9 +343,9 @@ function Example() {
     placement align=end
   </ActionButton>
   <Menu>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 ```
@@ -365,9 +360,9 @@ function Example() {
     placement direction=bottom
   </ActionButton>
   <Menu>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 <MenuTrigger direction="top" shouldFlip={false}>
@@ -375,9 +370,9 @@ function Example() {
     placement direction=top
   </ActionButton>
   <Menu>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 ```
@@ -399,9 +394,9 @@ selected Menu Item when the Menu is opened.
     selectionMode="single"
     selectedKeys={['copy']}
     autoFocus>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 ```
@@ -415,9 +410,9 @@ first Menu Item or last Menu Item is focused when the Menu is opened.
       autofocus=first
   </ActionButton>
   <Menu autoFocus="first">
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 <MenuTrigger>
@@ -425,9 +420,9 @@ first Menu Item or last Menu Item is focused when the Menu is opened.
     autofocus=last
   </ActionButton>
   <Menu autoFocus="last">
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 ```
@@ -445,9 +440,9 @@ selections at once.
     closeOnSelect=true
   </ActionButton>
   <Menu>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 <MenuTrigger closeOnSelect={false}>
@@ -455,9 +450,9 @@ selections at once.
     closeOnSelect=false
   </ActionButton>
   <Menu selectionMode="multiple">
-    <Item uniqueKey="jpg">jpg</Item>
-    <Item uniqueKey="png">png</Item>
-    <Item uniqueKey="tiff">tiff</Item>
+    <Item key="jpg">jpg</Item>
+    <Item key="png">png</Item>
+    <Item key="tiff">tiff</Item>
   </Menu>
 </MenuTrigger>
 ```
@@ -476,9 +471,8 @@ selections at once.
       {name: 'jpg', dataId: 'p8k3i4'},
       {name: 'PDF', dataId: 'j7i3a0'}
     ]}
-    itemKey="dataId"
     disabledKeys={['a1b2c3', 'p8k3i4']}>
-    {item => <Item>{item.name}</Item>}
+    {item => <Item key={item.dataId}>{item.name}</Item>}
   </Menu>
 </MenuTrigger>
 ```
@@ -494,9 +488,9 @@ main axis in situations where the original placement would cause it to render ou
     shouldFlip=true
   </ActionButton>
   <Menu>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 <MenuTrigger shouldFlip={false}>
@@ -504,9 +498,9 @@ main axis in situations where the original placement would cause it to render ou
     shouldFlip=false
   </ActionButton>
   <Menu>
-    <Item uniqueKey="cut">Cut</Item>
-    <Item uniqueKey="copy">Copy</Item>
-    <Item uniqueKey="paste">Paste</Item>
+    <Item key="cut">Cut</Item>
+    <Item key="copy">Copy</Item>
+    <Item key="paste">Paste</Item>
   </Menu>
 </MenuTrigger>
 ```

--- a/packages/@react-spectrum/menu/stories/Menu.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/Menu.stories.tsx
@@ -91,18 +91,18 @@ storiesOf('Menu', module)
   .add(
     'Default Menu',
     () => (
-      <Menu items={flatMenu} itemKey="name" onAction={action('onAction')}>
-        {item => <Item>{item.name}</Item>}
+      <Menu items={flatMenu} onAction={action('onAction')}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </Menu>
     )
   )
   .add(
     'Menu w/ sections',
     () => (
-      <Menu items={withSection} itemKey="name" onAction={action('onAction')}>
+      <Menu items={withSection} onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -111,10 +111,10 @@ storiesOf('Menu', module)
   .add(
     'Menu w/ sections and no title',
     () => (
-      <Menu items={withSection} itemKey="name" onAction={action('onAction')}>
+      <Menu items={withSection} onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} aria-label={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} aria-label={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -194,10 +194,10 @@ storiesOf('Menu', module)
   .add(
     'with single selection',
     () => (
-      <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name">
+      <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item childItems={item.children}>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -206,10 +206,10 @@ storiesOf('Menu', module)
   .add(
     'with default selected menu items',
     () => (
-      <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" defaultSelectedKeys={['Kangaroo']}>
+      <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} defaultSelectedKeys={['Kangaroo']}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item childItems={item.children}>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -220,27 +220,27 @@ storiesOf('Menu', module)
     () => (
       <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} defaultSelectedKeys={['2']}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
-          <Item uniqueKey="7">
+          <Item key="7">
             Seven
           </Item>
         </Section>
@@ -250,10 +250,10 @@ storiesOf('Menu', module)
   .add(
     'with selected menu items (controlled)',
     () => (
-      <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} itemKey="name" selectedKeys={['Kangaroo']}>
+      <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} items={withSection} selectedKeys={['Kangaroo']}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item childItems={item.children}>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -264,27 +264,27 @@ storiesOf('Menu', module)
     () => (
       <Menu selectionMode="single" onSelectionChange={action('onSelectionChange')} selectedKeys={['2']}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
-          <Item uniqueKey="7">
+          <Item key="7">
             Seven
           </Item>
         </Section>
@@ -294,10 +294,10 @@ storiesOf('Menu', module)
   .add(
     'with disabled menu items',
     () => (
-      <Menu items={withSection} itemKey="name" disabledKeys={['Kangaroo', 'Ross']} onAction={action('onAction')}>
+      <Menu items={withSection} disabledKeys={['Kangaroo', 'Ross']} onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -308,27 +308,27 @@ storiesOf('Menu', module)
     () => (
       <Menu disabledKeys={['3', '5']} onAction={action('onAction')}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
-          <Item uniqueKey="7">
+          <Item key="7">
             Seven
           </Item>
         </Section>
@@ -338,10 +338,10 @@ storiesOf('Menu', module)
   .add(
     'Multiselect menu',
     () => (
-      <Menu items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
+      <Menu items={withSection} onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['Aardvark', 'Snake']} disabledKeys={['Kangaroo', 'Ross']}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item childItems={item.children}>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -352,24 +352,24 @@ storiesOf('Menu', module)
     () => (
       <Menu onSelectionChange={action('onSelectionChange')} selectionMode="multiple" defaultSelectedKeys={['2', '5']} disabledKeys={['1', '3']}>
         <Section title="Section 1">
-          <Item uniqueKey="1">
+          <Item key="1">
             One
           </Item>
-          <Item uniqueKey="2">
+          <Item key="2">
             Two
           </Item>
-          <Item uniqueKey="3">
+          <Item key="3">
             Three
           </Item>
         </Section>
         <Section title="Section 2">
-          <Item uniqueKey="4">
+          <Item key="4">
             Four
           </Item>
-          <Item uniqueKey="5">
+          <Item key="5">
             Five
           </Item>
-          <Item uniqueKey="6">
+          <Item key="6">
             Six
           </Item>
         </Section>
@@ -379,10 +379,10 @@ storiesOf('Menu', module)
   .add(
     'Menu with autoFocus=true',
     () => (
-      <Menu items={withSection} itemKey="name" autoFocus onAction={action('onAction')}>
+      <Menu items={withSection} autoFocus onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -391,10 +391,10 @@ storiesOf('Menu', module)
   .add(
     'Menu with autoFocus="first"',
     () => (
-      <Menu items={withSection} itemKey="name" autoFocus="first" onAction={action('onAction')}>
+      <Menu items={withSection} autoFocus="first" onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -403,10 +403,10 @@ storiesOf('Menu', module)
   .add(
     'Menu with autoFocus="last"',
     () => (
-      <Menu items={withSection} itemKey="name" autoFocus="last" onAction={action('onAction')}>
+      <Menu items={withSection} autoFocus="last" onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -415,10 +415,10 @@ storiesOf('Menu', module)
   .add(
     'Menu with keyboard selection wrapping',
     () => (
-      <Menu items={withSection} itemKey="name" shouldFocusWrap onAction={action('onAction')}>
+      <Menu items={withSection} shouldFocusWrap onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Menu>
@@ -471,9 +471,9 @@ storiesOf('Menu', module)
   .add(
     'with semantic elements (generative)',
     () => (
-      <Menu items={hardModeProgrammatic} itemKey="name" onAction={action('onAction')}>
+      <Menu items={hardModeProgrammatic} onAction={action('onAction')}>
         {item => (
-          <Section items={item.children} title={item.name}>
+          <Section key={item.name} items={item.children} title={item.name}>
             {item => customMenuItem(item)}
           </Section>
         )}
@@ -484,7 +484,7 @@ storiesOf('Menu', module)
 let customMenuItem = (item) => {
   let Icon = iconMap[item.icon];
   return (
-    <Item childItems={item.children} textValue={item.name}>
+    <Item childItems={item.children} textValue={item.name} key={item.name}>
       {item.icon && <Icon size="S" />}
       <Text>{item.name}</Text>
       {item.shortcut && <Keyboard>{item.shortcut}</Keyboard>}

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -164,10 +164,10 @@ storiesOf('MenuTrigger', module)
                 onPressEnd={action('pressend')}>
                   Menu Button
               </ActionButton>
-              <Menu items={withSection} itemKey="name" onAction={action('action')}>
+              <Menu items={withSection} onAction={action('action')}>
                 {item => (
-                  <Section items={item.children} title={item.name}>
-                    {item => <Item childItems={item.children}>{item.name}</Item>}
+                  <Section key={item.name} items={item.children} title={item.name}>
+                    {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
                   </Section>
                 )}
               </Menu>
@@ -195,10 +195,10 @@ storiesOf('MenuTrigger', module)
               onPressEnd={action('pressend')}>
                 Menu Button
             </ActionButton>
-            <Menu items={withSection} itemKey="name" onAction={action('action')} disabledKeys={['Snake', 'Ross']}>
+            <Menu items={withSection} onAction={action('action')} disabledKeys={['Snake', 'Ross']}>
               {item => (
-                <Section items={item.children} title={item.name}>
-                  {item => <Item childItems={item.children}>{item.name}</Item>}
+                <Section key={item.name} items={item.children} title={item.name}>
+                  {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
                 </Section>
               )}
             </Menu>
@@ -220,10 +220,10 @@ function render({isDisabled, ...props}: any = {}, menuProps = {}) {
           onPressEnd={action('pressend')}>
             Menu Button
         </ActionButton>
-        <Menu items={withSection} itemKey="name" onAction={action('action')} disabledKeys={['Snake', 'Ross']} {...menuProps}>
+        <Menu items={withSection} onAction={action('action')} disabledKeys={['Snake', 'Ross']} {...menuProps}>
           {item => (
-            <Section items={item.children} title={item.name}>
-              {item => <Item childItems={item.children}>{item.name}</Item>}
+            <Section key={item.name} items={item.children} title={item.name}>
+              {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
             </Section>
           )}
         </Menu>

--- a/packages/@react-spectrum/menu/test/Menu.test.js
+++ b/packages/@react-spectrum/menu/test/Menu.test.js
@@ -70,10 +70,10 @@ function renderComponent(Component, contextProps = {}, props = {}) {
       <Provider theme={theme}>
         <span id="label">Label</span>
         <MenuContext.Provider value={contextProps}>
-          <Menu id={menuId} items={withSection} itemKey="name" aria-labelledby="label" {...props}>
+          <Menu id={menuId} items={withSection} aria-labelledby="label" {...props}>
             {item => (
-              <Section items={item.children} title={item.name}>
-                {item => <Item childItems={item.children}>{item.name}</Item>}
+              <Section key={item.name} items={item.children} title={item.name}>
+                {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
               </Section>
             )}
           </Menu>
@@ -652,9 +652,9 @@ describe('Menu', function () {
       let tree = render(
         <Provider theme={theme}>
           <Menu aria-label="menu" onSelectionChange={onSelectionChange} onAction={onAction}>
-            <Item uniqueKey="One">One</Item>
-            <Item uniqueKey="Two">Two</Item>
-            <Item uniqueKey="Three">Three</Item>
+            <Item key="One">One</Item>
+            <Item key="Two">Two</Item>
+            <Item key="Three">Three</Item>
           </Menu>
         </Provider>
       );
@@ -692,8 +692,8 @@ describe('Menu', function () {
       ];
       let tree = render(
         <Provider theme={theme}>
-          <Menu aria-label="menu" onSelectionChange={onSelectionChange} items={flatItems} itemKey="name" onAction={onAction}>
-            {item => <Item>{item.name}</Item>}
+          <Menu aria-label="menu" onSelectionChange={onSelectionChange} items={flatItems} onAction={onAction}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Menu>
         </Provider>
       );

--- a/packages/@react-spectrum/menu/test/MenuTrigger.test.js
+++ b/packages/@react-spectrum/menu/test/MenuTrigger.test.js
@@ -54,10 +54,10 @@ function renderComponent(Component, triggerProps = {}, menuProps = {}, buttonPro
             <Button {...buttonProps}>
               {triggerText}
             </Button>
-            <Menu items={withSection} itemKey="name" {...menuProps}>
+            <Menu items={withSection} {...menuProps}>
               {item => (
-                <Section items={item.children} title={item.name}>
-                  {item => <Item childItems={item.children}>{item.name}</Item>}
+                <Section key={item.name} items={item.children} title={item.name}>
+                  {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
                 </Section>
               )}
             </Menu>
@@ -575,10 +575,10 @@ describe('MenuTrigger', function () {
             <Button>
               {triggerText}
             </Button>
-            <Menu items={withSection} itemKey="name">
+            <Menu items={withSection}>
               {item => (
-                <Section items={item.children} title={item.name}>
-                  {item => <Item childItems={item.children}>{item.name}</Item>}
+                <Section key={item.name} items={item.children} title={item.name}>
+                  {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
                 </Section>
               )}
             </Menu>
@@ -613,10 +613,10 @@ describe('MenuTrigger', function () {
             <Button>
               {triggerText}
             </Button>
-            <Menu items={withSection} itemKey="name">
+            <Menu items={withSection}>
               {item => (
-                <Section items={item.children} title={item.name}>
-                  {item => <Item childItems={item.children}>{item.name}</Item>}
+                <Section key={item.name} items={item.children} title={item.name}>
+                  {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
                 </Section>
               )}
             </Menu>

--- a/packages/@react-spectrum/picker/docs/Picker.mdx
+++ b/packages/@react-spectrum/picker/docs/Picker.mdx
@@ -43,18 +43,18 @@ category: Pickers
 ## Example
 ```tsx example
 <Picker label="Choose frequency" onSelectionChange={selected => console.log(selected)}>
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 ```
 
 ## Content
-Picker follows the [Collection Components](../react-stately/collections.html) API, accepting both static and dynamic forms of children. Similar to the Menu, Picker accepts an `<Item>` component, each with a `uniqueKey` prop. Basic usage of the Picker, seen in the example above, shows multiple options populated with a string. This implementation would be used when the list of options is finite and known.
+Picker follows the [Collection Components](../react-stately/collections.html) API, accepting both static and dynamic forms of children. Similar to the Menu, Picker accepts an `<Item>` component, each with a `key` prop. Basic usage of the Picker, seen in the example above, shows multiple options populated with a string. This implementation would be used when the list of options is finite and known.
 
 The dynamic method (shown below) would be better suited to use if the options came from a data object such as values returned from an API call. Providing the data in this way allows for Picker to automatically cache the rendering of each item, which dramatically improves performance.
 
-As seen below, an iterable list of options is passed to the Picker using the `items` prop. Each item accepts a uniqueKey prop, which is passed to the onSelectionChange handler to identify the selected item. Alternatively, if the item objects contain an id property, as shown in the example below, then this is used automatically and a uniqueKey prop is not required. See the <a href="#events" title="Events">events</a> section for more detail on selection.
+As seen below, an iterable list of options is passed to the Picker using the `items` prop. Each item accepts a key prop, which is passed to the onSelectionChange handler to identify the selected item. Alternatively, if the item objects contain an id property, as shown in the example below, then this is used automatically and a key prop is not required. See the <a href="#events" title="Events">events</a> section for more detail on selection.
 
 ```tsx example
 function Example() {
@@ -88,24 +88,24 @@ Picker can be labeled using the `label` prop. If no label is provided, an altern
 
 ```tsx example
 <Picker label="Choose frequency" isRequired necessityIndicator="icon" marginEnd="10px">
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 <Picker label="Choose frequency" isRequired necessityIndicator="label" marginEnd="10px">
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 <Picker label="Choose frequency" necessityIndicator="label">
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 ```
 
 ## Selection
-Setting a selected option can be done by using the `defaultSelectedKey` or `selectedKey` prop. The selected key corresponds to the `uniqueKey` of an item. See <a href="#events" title="Events">Events</a> for more details on selection events.
+Setting a selected option can be done by using the `defaultSelectedKey` or `selectedKey` prop. The selected key corresponds to the `key` of an item. See <a href="#events" title="Events">Events</a> for more details on selection events.
 
 ```tsx example
 function Example() {
@@ -126,7 +126,7 @@ function Example() {
         items={options}
         defaultSelectedKey="Bison"
         marginEnd="20px">
-        {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </Picker>
 
       <Picker
@@ -134,27 +134,27 @@ function Example() {
         items={options}
         selectedKey={animal}
         onSelectionChange={selected => setAnimal(selected)}>
-        {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+        {item => <Item key={item.name}>{item.name}</Item>}
       </Picker>
     </>
   );
 }
 ```
 ## Sections
-Picker supports sections in order to group options. Sections can be used by wrapping groups of Items in a `Section` component. Each `Section` takes a `title` and `uniqueKey` prop.
+Picker supports sections in order to group options. Sections can be used by wrapping groups of Items in a `Section` component. Each `Section` takes a `title` and `key` prop.
 
 ### Static items
 ```tsx example
 <Picker label="Pick your favorite">
   <Section title="Animals">
-    <Item uniqueKey="Aardvark">Aardvark</Item>
-    <Item uniqueKey="Kangaroo">Kangaroo</Item>
-    <Item uniqueKey="Snake">Snake</Item>
+    <Item key="Aardvark">Aardvark</Item>
+    <Item key="Kangaroo">Kangaroo</Item>
+    <Item key="Snake">Snake</Item>
   </Section>
   <Section title="People">
-    <Item uniqueKey="Danni">Danni</Item>
-    <Item uniqueKey="Devon">Devon</Item>
-    <Item uniqueKey="Ross">Ross</Item>
+    <Item key="Danni">Danni</Item>
+    <Item key="Devon">Devon</Item>
+    <Item key="Ross">Ross</Item>
   </Section>
 </Picker>
 ```
@@ -180,7 +180,7 @@ function Example() {
     <>
       <Picker label="Pick an animal" items={options} onSelectionChange={selected => alert(selected)}>
         {item => (
-          <Section uniqueKey={item.name} items={item.children} title={item.name}>
+          <Section key={item.name} items={item.children} title={item.name}>
             {item => <Item>{item.name}</Item>}
           </Section>
         )}
@@ -192,7 +192,7 @@ function Example() {
 
 ## Events
 Picker supports selection via mouse, keyboard, and touch. You can handle all of these via the `onSelectionChange`
-prop. Picker will pass the selected `uniqueKey` to the `onSelectionChange` handler.
+prop. Picker will pass the selected `key` to the `onSelectionChange` handler.
 
 The following example uses an `onSelectionChange` handler to update the selection stored in React state.
 
@@ -203,9 +203,9 @@ function StaticExample() {
   return (
     <>
       <Picker label="Choose frequency" onSelectionChange={selected => setFrequency(selected)}>
-        <Item uniqueKey="Rarely">Rarely</Item>
-        <Item uniqueKey="Sometimes">Sometimes</Item>
-        <Item uniqueKey="Always">Always</Item>
+        <Item key="Rarely">Rarely</Item>
+        <Item key="Sometimes">Sometimes</Item>
+        <Item key="Always">Always</Item>
       </Picker>
       <p>You selected {frequency}</p>
     </>
@@ -213,7 +213,7 @@ function StaticExample() {
 }
 ```
 
-When using Picker with dynamic items, selection works much the same way using `uniqueKey`. However, if your data already has an `id` property (as is common with many data sets), Picker can use that id without needing to specify a `uniqueKey` prop. The below example shows Picker using the id of each item from the `items` array as the selected value without the need for `uniqueKey`. Note that `uniqueKey` will always take precedence if set.
+When using Picker with dynamic items, selection works much the same way using `key`. However, if your data already has an `id` property (as is common with many data sets), Picker can use that id without needing to specify a `key` prop. The below example shows Picker using the id of each item from the `items` array as the selected value without the need for `key`. Note that `key` will always take precedence if set.
 
 ```tsx example
 function DynamicExample() {
@@ -297,7 +297,7 @@ function AsyncLoadingExample() {
       items={list.items}
       isLoading={list.isLoading}
       onLoadMore={list.loadMore}>
-      {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+      {item => <Item key={item.name}>{item.name}</Item>}
     </Picker>
   );
 }
@@ -312,48 +312,48 @@ function AsyncLoadingExample() {
 ### Label alignment
 ```tsx example
 <Picker label="Choose frequency" labelAlign="end">
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 ```
 ### Label position
 ```tsx example
 <Picker label="Choose frequency" labelPosition="side">
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 ```
 ### Quiet
 ```tsx example
 <Picker label="Choose frequency" isQuiet labelPosition="side">
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 ```
 ### Disabled
 ```tsx example
 <Picker label="Choose frequency" isDisabled>
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 ```
 ### Custom widths
 ```tsx example
 <Flex flexDirection="column">
   <Picker label="Choose frequency" width="size-6000">
-    <Item uniqueKey="rarely">Rarely</Item>
-    <Item uniqueKey="sometimes">Sometimes</Item>
-    <Item uniqueKey="always">Always</Item>
+    <Item key="rarely">Rarely</Item>
+    <Item key="sometimes">Sometimes</Item>
+    <Item key="always">Always</Item>
   </Picker>
 
   <Picker label="Choose animal" menuWidth="size-6000">
-    <Item uniqueKey="Emu">Emu</Item>
-    <Item uniqueKey="Kangaroo">Kangaroo</Item>
-    <Item uniqueKey="Platypus">Platypus</Item>
+    <Item key="Emu">Emu</Item>
+    <Item key="Kangaroo">Kangaroo</Item>
+    <Item key="Platypus">Platypus</Item>
   </Picker>
 </Flex>
 ```
@@ -361,15 +361,15 @@ function AsyncLoadingExample() {
 ```tsx example
 <Flex flexDirection="column">
   <Picker label="Choose frequency" align="end" menuWidth="size-3000">
-    <Item uniqueKey="rarely">Rarely</Item>
-    <Item uniqueKey="sometimes">Sometimes</Item>
-    <Item uniqueKey="always">Always</Item>
+    <Item key="rarely">Rarely</Item>
+    <Item key="sometimes">Sometimes</Item>
+    <Item key="always">Always</Item>
   </Picker>
 
   <Picker label="Choose animal" direction="top">
-    <Item uniqueKey="Emu">Emu</Item>
-    <Item uniqueKey="Kangaroo">Kangaroo</Item>
-    <Item uniqueKey="Platypus">Platypus</Item>
+    <Item key="Emu">Emu</Item>
+    <Item key="Kangaroo">Kangaroo</Item>
+    <Item key="Platypus">Platypus</Item>
   </Picker>
 </Flex>
 ```
@@ -377,8 +377,8 @@ function AsyncLoadingExample() {
 The open state of the menu can be controlled via the `defaultOpen` and `isOpen` props
 ```tsx example
 <Picker label="Choose frequency" isOpen>
-  <Item uniqueKey="rarely">Rarely</Item>
-  <Item uniqueKey="sometimes">Sometimes</Item>
-  <Item uniqueKey="always">Always</Item>
+  <Item key="rarely">Rarely</Item>
+  <Item key="sometimes">Sometimes</Item>
+  <Item key="always">Always</Item>
 </Picker>
 ```

--- a/packages/@react-spectrum/picker/stories/Picker.stories.tsx
+++ b/packages/@react-spectrum/picker/stories/Picker.stories.tsx
@@ -55,9 +55,9 @@ storiesOf('Picker', module)
     'default',
     () => (
       <Picker label="Test" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -66,14 +66,14 @@ storiesOf('Picker', module)
     () => (
       <Picker label="Test" onSelectionChange={action('selectionChange')}>
         <Section title="Animals">
-          <Item uniqueKey="Aardvark">Aardvark</Item>
-          <Item uniqueKey="Kangaroo">Kangaroo</Item>
-          <Item uniqueKey="Snake">Snake</Item>
+          <Item key="Aardvark">Aardvark</Item>
+          <Item key="Kangaroo">Kangaroo</Item>
+          <Item key="Snake">Snake</Item>
         </Section>
         <Section title="People">
-          <Item uniqueKey="Danni">Danni</Item>
-          <Item uniqueKey="Devon">Devon</Item>
-          <Item uniqueKey="Ross">Ross</Item>
+          <Item key="Danni">Danni</Item>
+          <Item key="Devon">Devon</Item>
+          <Item key="Ross">Ross</Item>
         </Section>
       </Picker>
     )
@@ -89,10 +89,10 @@ storiesOf('Picker', module)
   .add(
     'dynamic with sections',
     () => (
-      <Picker label="Test" items={withSection} itemKey="name" onSelectionChange={action('selectionChange')}>
+      <Picker label="Test" items={withSection} onSelectionChange={action('selectionChange')}>
         {item => (
-          <Section items={item.children} itemKey="name" title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </Picker>
@@ -102,9 +102,9 @@ storiesOf('Picker', module)
     'isDisabled',
     () => (
       <Picker label="Test" isDisabled onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -112,9 +112,9 @@ storiesOf('Picker', module)
     'labelAlign: end',
     () => (
       <Picker direction="top" label="Test" labelAlign="end" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -122,9 +122,9 @@ storiesOf('Picker', module)
     'labelPosition: side',
     () => (
       <Picker label="Test" labelPosition="side" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -132,9 +132,9 @@ storiesOf('Picker', module)
     'isRequired',
     () => (
       <Picker label="Test" isRequired onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -142,9 +142,9 @@ storiesOf('Picker', module)
     'isRequired, necessityIndicator: label',
     () => (
       <Picker label="Test" isRequired necessityIndicator="label" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -152,9 +152,9 @@ storiesOf('Picker', module)
     'optional, necessityIndicator: label',
     () => (
       <Picker label="Test" necessityIndicator="label" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -162,9 +162,9 @@ storiesOf('Picker', module)
     'validationState: invalid',
     () => (
       <Picker label="Test" validationState="invalid" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -172,9 +172,9 @@ storiesOf('Picker', module)
     'isQuiet',
     () => (
       <Picker isQuiet label="Test" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="100">One hundred</Item>
-        <Item uniqueKey="2012">Two thousand and twelve</Item>
-        <Item uniqueKey="3">Three</Item>
+        <Item key="100">One hundred</Item>
+        <Item key="2012">Two thousand and twelve</Item>
+        <Item key="3">Three</Item>
       </Picker>
     )
   )
@@ -182,9 +182,9 @@ storiesOf('Picker', module)
     'isQuiet, isDisabled',
     () => (
       <Picker label="Test" isQuiet isDisabled onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two million">Two million</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two million">Two million</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -192,9 +192,9 @@ storiesOf('Picker', module)
     'isQuiet, labelAlign: end',
     () => (
       <Picker label="Test" isQuiet labelAlign="end" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="two">Two dollary-doos</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="two">Two dollary-doos</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -202,9 +202,9 @@ storiesOf('Picker', module)
     'isQuiet, labelPosition: side',
     () => (
       <Picker label="Test" isQuiet labelPosition="side" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -212,9 +212,9 @@ storiesOf('Picker', module)
     'isQuiet, isRequired',
     () => (
       <Picker label="Test" isQuiet isRequired onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -222,9 +222,9 @@ storiesOf('Picker', module)
     'isQuiet, isRequired, necessityIndicator: label',
     () => (
       <Picker label="Test" isQuiet isRequired necessityIndicator="label" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -232,9 +232,9 @@ storiesOf('Picker', module)
     'isQuiet, optional, necessityIndicator: label',
     () => (
       <Picker label="Test" isQuiet necessityIndicator="label" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -242,9 +242,9 @@ storiesOf('Picker', module)
     'isQuiet, validationState: invalid',
     () => (
       <Picker label="Test" isQuiet validationState="invalid" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -416,9 +416,9 @@ storiesOf('Picker', module)
     'selectedKey (controlled)',
     () => (
       <Picker label="Test" selectedKey="One" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -426,9 +426,9 @@ storiesOf('Picker', module)
     'defaultSelectedKey (uncontrolled)',
     () => (
       <Picker label="Test" defaultSelectedKey="One" onSelectionChange={action('selectionChange')}>
-        <Item uniqueKey="One">One</Item>
-        <Item uniqueKey="Two">Two</Item>
-        <Item uniqueKey="Three">Three</Item>
+        <Item key="One">One</Item>
+        <Item key="Two">Two</Item>
+        <Item key="Three">Three</Item>
       </Picker>
     )
   )
@@ -439,9 +439,9 @@ storiesOf('Picker', module)
         <div style={{display: 'flex', width: 'auto', margin: '250px 0'}}>
           <input placeholder="Shift tab here" />
           <Picker label="Test" defaultSelectedKey="One" onSelectionChange={action('selectionChange')}>
-            <Item uniqueKey="One">One</Item>
-            <Item uniqueKey="Two">Two</Item>
-            <Item uniqueKey="Three">Three</Item>
+            <Item key="One">One</Item>
+            <Item key="Two">Two</Item>
+            <Item key="Three">Three</Item>
           </Picker>
           <input placeholder="Tab here" />
         </div>
@@ -500,7 +500,7 @@ function AsyncLoadingExample() {
 
   return (
     <Picker label="Pick a Pokemon" items={list.items} isLoading={list.isLoading} onLoadMore={list.loadMore}>
-      {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+      {item => <Item key={item.name}>{item.name}</Item>}
     </Picker>
   );
 }

--- a/packages/@react-spectrum/picker/test/Picker.test.js
+++ b/packages/@react-spectrum/picker/test/Picker.test.js
@@ -849,9 +849,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -884,9 +884,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -925,9 +925,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -965,9 +965,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1064,9 +1064,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" selectedKey="two" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1104,9 +1104,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" defaultSelectedKey="two" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1144,9 +1144,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange} disabledKeys={['two']}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1187,30 +1187,30 @@ describe('Picker', function () {
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
             <Section title="Section 1">
-              <Item textValue="Copy" uniqueKey="copy">
+              <Item textValue="Copy" key="copy">
                 <Copy size="S" />
                 <Text>Copy</Text>
               </Item>
-              <Item textValue="Cut" uniqueKey="cut">
+              <Item textValue="Cut" key="cut">
                 <Cut size="S" />
                 <Text>Cut</Text>
               </Item>
-              <Item textValue="Paste" uniqueKey="paste">
+              <Item textValue="Paste" key="paste">
                 <Paste size="S" />
                 <Text>Paste</Text>
               </Item>
             </Section>
             <Section title="Section 2">
-              <Item textValue="Puppy" uniqueKey="puppy">
+              <Item textValue="Puppy" key="puppy">
                 <AlignLeft size="S" />
                 <Text>Puppy</Text>
                 <Text slot="description">Puppy description super long as well geez</Text>
               </Item>
-              <Item textValue="Doggo with really really really long long long text" uniqueKey="doggo">
+              <Item textValue="Doggo with really really really long long long text" key="doggo">
                 <AlignCenter size="S" />
                 <Text>Doggo with really really really long long long text</Text>
               </Item>
-              <Item textValue="Floof" uniqueKey="floof">
+              <Item textValue="Floof" key="floof">
                 <AlignRight size="S" />
                 <Text>Floof</Text>
               </Item>
@@ -1302,9 +1302,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1344,9 +1344,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" defaultSelectedKey="two" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1376,9 +1376,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1402,9 +1402,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1429,9 +1429,9 @@ describe('Picker', function () {
       let {getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1458,9 +1458,9 @@ describe('Picker', function () {
       let {getByText, getByRole} = render(
         <Provider theme={theme}>
           <Picker label="Test" onSelectionChange={onSelectionChange}>
-            <Item uniqueKey="one">One</Item>
-            <Item uniqueKey="two">Two</Item>
-            <Item uniqueKey="three">Three</Item>
+            <Item key="one">One</Item>
+            <Item key="two">Two</Item>
+            <Item key="three">Three</Item>
           </Picker>
         </Provider>
       );
@@ -1555,7 +1555,7 @@ describe('Picker', function () {
       let {getByRole, rerender} = render(
         <Provider theme={theme}>
           <Picker label="Test" items={items} isLoading>
-            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Picker>
         </Provider>
       );
@@ -1575,7 +1575,7 @@ describe('Picker', function () {
       rerender(
         <Provider theme={theme}>
           <Picker label="Test" items={items}>
-            {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Picker>
         </Provider>
       );

--- a/packages/@react-spectrum/sidenav/stories/SideNav.stories.tsx
+++ b/packages/@react-spectrum/sidenav/stories/SideNav.stories.tsx
@@ -40,50 +40,50 @@ storiesOf('SideNav', module)
   .add(
     'Default',
     () => (
-      <SideNav items={flatItems} itemKey="name" UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')}>
-        {item => <Item>{item.name}</Item>}
+      <SideNav items={flatItems} UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </SideNav>
     )
   )
   .add(
     'with default selected item',
     () => (
-      <SideNav defaultSelectedKeys={['Kangaroo']} items={flatItems} itemKey="name" UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')}>
-        {item => <Item>{item.name}</Item>}
+      <SideNav defaultSelectedKeys={['Kangaroo']} items={flatItems} UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </SideNav>
     )
   )
   .add(
     'with selected item (controlled)',
     () => (
-      <SideNav selectedKeys={['Kangaroo']} items={flatItems} itemKey="name" UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')}>
-        {item => <Item>{item.name}</Item>}
+      <SideNav selectedKeys={['Kangaroo']} items={flatItems} UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </SideNav>
     )
   )
   .add(
     'with disabled items',
     () => (
-      <SideNav disabledKeys={['Kangaroo']} UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')} items={flatItems} itemKey="name">
-        {item => <Item>{item.name}</Item>}
+      <SideNav disabledKeys={['Kangaroo']} UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')} items={flatItems}>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </SideNav>
     )
   )
   .add(
     'with keyboard selection wrapping',
     () => (
-      <SideNav items={flatItems} itemKey="name" UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')} shouldFocusWrap>
-        {item => <Item>{item.name}</Item>}
+      <SideNav items={flatItems} UNSAFE_className={snStyles['storybook-SideNav']} onSelectionChange={action('onSelectionChange')} shouldFocusWrap>
+        {item => <Item key={item.name}>{item.name}</Item>}
       </SideNav>
     )
   )
   .add(
     'Default with sections',
     () => (
-      <SideNav UNSAFE_className={snStyles['storybook-SideNav']} items={withSection} itemKey="name" onSelectionChange={action('onSelectionChange')}>
+      <SideNav UNSAFE_className={snStyles['storybook-SideNav']} items={withSection} onSelectionChange={action('onSelectionChange')}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
           </Section>
         )}
       </SideNav>

--- a/packages/@react-spectrum/sidenav/test/SideNav.test.js
+++ b/packages/@react-spectrum/sidenav/test/SideNav.test.js
@@ -39,26 +39,26 @@ function renderComponent(Name, Component, ComponentSection, ComponentItem, props
   switch (Name) {
     case 'SideNav':
       return render(
-        <Component {...props} items={flatItems} itemKey="name">
-          {item => <ComponentItem>{item.name}</ComponentItem>}
+        <Component {...props} items={flatItems}>
+          {item => <ComponentItem key={item.name}>{item.name}</ComponentItem>}
         </Component>
       );
     case 'V2SideNav':
     case 'SideNavStatic':
       return render(
         <Component {...props} >
-          <ComponentItem uniqueKey="Foo">Foo</ComponentItem>
-          <ComponentItem uniqueKey="Bar">Bar</ComponentItem>
-          <ComponentItem uniqueKey="Bob">Bob</ComponentItem>
-          <ComponentItem uniqueKey="Alice">Alice</ComponentItem>
+          <ComponentItem key="Foo">Foo</ComponentItem>
+          <ComponentItem key="Bar">Bar</ComponentItem>
+          <ComponentItem key="Bob">Bob</ComponentItem>
+          <ComponentItem key="Alice">Alice</ComponentItem>
         </Component>
       );
     case 'SideNavWithSections':
       return render(
-        <Component {...props} items={withSection} itemKey="name">
+        <Component {...props} items={withSection}>
           {item => (
-            <ComponentSection items={item.children} title={item.name}>
-              {item => <ComponentItem>{item.name}</ComponentItem>}
+            <ComponentSection key={item.name} items={item.children} title={item.name}>
+              {item => <ComponentItem key={item.name}>{item.name}</ComponentItem>}
             </ComponentSection>
           )}
         </Component>
@@ -67,12 +67,12 @@ function renderComponent(Name, Component, ComponentSection, ComponentItem, props
       return render(
         <Component {...props} >
           <ComponentSection title="Section 1">
-            <ComponentItem uniqueKey="Foo">Foo</ComponentItem>
-            <ComponentItem uniqueKey="Bar">Bar</ComponentItem>
+            <ComponentItem key="Foo">Foo</ComponentItem>
+            <ComponentItem key="Bar">Bar</ComponentItem>
           </ComponentSection>
           <ComponentSection title="Section 2">
-            <ComponentItem uniqueKey="Bob">Bob</ComponentItem>
-            <ComponentItem uniqueKey="Alice">Alice</ComponentItem>
+            <ComponentItem key="Bob">Bob</ComponentItem>
+            <ComponentItem key="Alice">Alice</ComponentItem>
           </ComponentSection>
         </Component>
       );

--- a/packages/@react-spectrum/table/stories/CRUDExample.tsx
+++ b/packages/@react-spectrum/table/stories/CRUDExample.tsx
@@ -89,10 +89,10 @@ export function CRUDExample() {
       </ActionGroup>
       <Table aria-label="People" width={500} height={300} isQuiet selectedKeys={list.selectedKeys} onSelectionChange={list.setSelectedKeys}>
         <TableHeader>
-          <Column isRowHeader uniqueKey="firstName">First Name</Column>
-          <Column isRowHeader uniqueKey="lastName">Last Name</Column>
-          <Column uniqueKey="birthday">Birthday</Column>
-          <Column uniqueKey="actions" align="end">Actions</Column>
+          <Column isRowHeader key="firstName">First Name</Column>
+          <Column isRowHeader key="lastName">Last Name</Column>
+          <Column key="birthday">Birthday</Column>
+          <Column key="actions" align="end">Actions</Column>
         </TableHeader>
         <TableBody items={list.items}>
           {item =>
@@ -103,8 +103,8 @@ export function CRUDExample() {
                     ? <MenuTrigger align="end">
                       <ActionButton isQuiet aria-label="Actions"><More /></ActionButton>
                       <Menu onAction={action => onAction(action, item)}>
-                        <Item uniqueKey="edit">Edit...</Item>
-                        <Item uniqueKey="delete">Delete...</Item>
+                        <Item key="edit">Edit...</Item>
+                        <Item key="delete">Delete...</Item>
                       </Menu>
                     </MenuTrigger>
                     : item[column]

--- a/packages/@react-spectrum/table/stories/Table.stories.tsx
+++ b/packages/@react-spectrum/table/stories/Table.stories.tsx
@@ -113,12 +113,12 @@ storiesOf('Table', module)
     'dynamic',
     () => (
       <Table aria-label="Table with dynamic contents" width={300} height={200} onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader columns={columns} columnKey="key">
+        <TableHeader columns={columns}>
           {column => <Column>{column.name}</Column>}
         </TableHeader>
-        <TableBody items={items} itemKey="foo">
+        <TableBody items={items}>
           {item =>
-            (<Row>
+            (<Row key={item.foo}>
               {key => <Cell>{item[key]}</Cell>}
             </Row>)
           }
@@ -161,14 +161,14 @@ storiesOf('Table', module)
     'dynamic with nested columns',
     () => (
       <Table aria-label="Table with nested columns" width={700} height={300} rowHeight="auto" onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader columns={nestedColumns} columnKey="key">
+        <TableHeader columns={nestedColumns}>
           {column =>
             <Column childColumns={column.children}>{column.name}</Column>
           }
         </TableHeader>
-        <TableBody items={items} itemKey="foo">
+        <TableBody items={items}>
           {item =>
-            (<Row>
+            (<Row key={item.foo}>
               {key => <Cell>{item[key]}</Cell>}
             </Row>)
           }
@@ -208,14 +208,14 @@ storiesOf('Table', module)
     'many columns and rows',
     () => (
       <Table aria-label="Table with many columns and rows" width={700} height={500} onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader columns={manyColunns} columnKey="key">
+        <TableHeader columns={manyColunns}>
           {column =>
             <Column minWidth={100}>{column.name}</Column>
           }
         </TableHeader>
-        <TableBody items={manyRows} itemKey="key">
+        <TableBody items={manyRows}>
           {item =>
-            (<Row>
+            (<Row key={item.foo}>
               {key => <Cell>{item[key]}</Cell>}
             </Row>)
           }
@@ -227,14 +227,14 @@ storiesOf('Table', module)
     'isQuiet, many columns and rows',
     () => (
       <Table aria-label="Quiet table with many columns and rows" width={700} height={500} isQuiet onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader columns={manyColunns} columnKey="key">
+        <TableHeader columns={manyColunns}>
           {column =>
             <Column minWidth={100}>{column.name}</Column>
           }
         </TableHeader>
-        <TableBody items={manyRows} itemKey="key">
+        <TableBody items={manyRows}>
           {item =>
-            (<Row>
+            (<Row key={item.foo}>
               {key => <Cell>{item[key]}</Cell>}
             </Row>)
           }
@@ -378,14 +378,14 @@ storiesOf('Table', module)
     'isLoading',
     () => (
       <Table aria-label="Table loading" width={700} height={200} onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader columns={manyColunns} columnKey="key">
+        <TableHeader columns={manyColunns}>
           {column =>
             <Column minWidth={100}>{column.name}</Column>
           }
         </TableHeader>
-        <TableBody items={[]} isLoading itemKey="key">
+        <TableBody items={[]} isLoading>
           {item =>
-            (<Row>
+            (<Row key={item.foo}>
               {key => <Cell>{item[key]}</Cell>}
             </Row>)
           }
@@ -397,14 +397,14 @@ storiesOf('Table', module)
     'isLoading more',
     () => (
       <Table aria-label="Table loading more" width={700} height={200} onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader columns={columns} columnKey="key">
+        <TableHeader columns={columns}>
           {column =>
             <Column minWidth={100}>{column.name}</Column>
           }
         </TableHeader>
-        <TableBody items={items} isLoading itemKey="foo">
+        <TableBody items={items} isLoading>
           {item =>
-            (<Row>
+            (<Row key={item.foo}>
               {key => <Cell>{item[key]}</Cell>}
             </Row>)
           }
@@ -416,7 +416,7 @@ storiesOf('Table', module)
     'renderEmptyState',
     () => (
       <Table aria-label="Table with empty state" width={700} height={400} isQuiet renderEmptyState={renderEmptyState} onSelectionChange={s => onSelectionChange([...s])}>
-        <TableHeader columns={manyColunns} columnKey="key">
+        <TableHeader columns={manyColunns}>
           {column =>
             <Column minWidth={100}>{column.name}</Column>
           }
@@ -471,14 +471,14 @@ function AsyncLoadingExample() {
       <ActionButton marginBottom={10} onPress={() => list.remove(list.items[0].data.id)}>Remove first item</ActionButton>
       <Table aria-label="Top news from Reddit" width={1000} height={400} isQuiet sortDescriptor={list.sortDescriptor} onSortChange={list.sort}>
         <TableHeader>
-          <Column uniqueKey="score" width={100} allowsSorting>Score</Column>
-          <Column uniqueKey="title" isRowHeader allowsSorting>Title</Column>
-          <Column uniqueKey="author" width={200} allowsSorting>Author</Column>
-          <Column uniqueKey="num_comments" width={100} allowsSorting>Comments</Column>
+          <Column key="score" width={100} allowsSorting>Score</Column>
+          <Column key="title" isRowHeader allowsSorting>Title</Column>
+          <Column key="author" width={200} allowsSorting>Author</Column>
+          <Column key="num_comments" width={100} allowsSorting>Comments</Column>
         </TableHeader>
         <TableBody items={list.items} isLoading={list.isLoading} onLoadMore={list.loadMore}>
           {item =>
-            (<Row uniqueKey={item.data.id}>
+            (<Row key={item.data.id}>
               {key => 
                 key === 'title'
                   ? <Cell textValue={item.data.title}><Link isQuiet><a href={item.data.url} target="_blank">{item.data.title}</a></Link></Cell>

--- a/packages/@react-spectrum/tree/stories/TreeView.stories.tsx
+++ b/packages/@react-spectrum/tree/stories/TreeView.stories.tsx
@@ -43,18 +43,18 @@ storiesOf('Tree', module)
   .add(
     'Default',
     () => (
-      <Tree items={items} itemKey="name" onSelectionChange={keys => console.log(keys)}>
-        {item => <Item childItems={item.children}>{item.name}</Item>}
+      <Tree items={items} onSelectionChange={keys => console.log(keys)}>
+        {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
       </Tree>
     )
   )
   .add(
     'Sections',
     () => (
-      <Tree items={items} itemKey="name">
+      <Tree items={items}>
         {item => (
-          <Section items={item.children} title={item.name}>
-            {item => <Item childItems={item.children}>{item.name}</Item>}
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name} childItems={item.children}>{item.name}</Item>}
           </Section>
         )}
       </Tree>
@@ -97,8 +97,8 @@ storiesOf('Tree', module)
     () => (
       <div>
         <input />
-        <Tree items={longList} itemKey="name">
-          {item => <Item>{item.name}</Item>}
+        <Tree items={longList}>
+          {item => <Item key={item.name}>{item.name}</Item>}
         </Tree>
         <input />
       </div>

--- a/packages/@react-stately/actiongroup/src/useActionGroupState.ts
+++ b/packages/@react-stately/actiongroup/src/useActionGroupState.ts
@@ -23,7 +23,7 @@ export function useActionGroupState<T extends object>(props: ActionGroupProps<T>
     props.disabledKeys ? new Set(props.disabledKeys) : new Set<Key>()
   , [props.disabledKeys]);
 
-  let builder = useMemo(() => new CollectionBuilder<T>(props.itemKey), [props.itemKey]);
+  let builder = useMemo(() => new CollectionBuilder<T>(), []);
   let collection = useMemo(() => {
     let nodes = builder.build(props);
     return new TreeCollection(nodes);

--- a/packages/@react-stately/collections/docs/collections.mdx
+++ b/packages/@react-stately/collections/docs/collections.mdx
@@ -134,9 +134,8 @@ returns an &lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt;.
 
 All items in a collection must have a unique key or id, which is used to determine what items in the collection changed
 when updates occur. By default, React Spectrum looks for an `id` or `key` property on each item, which is often returned 
-from a database. You can also specify a custom key on each item that should be used as the unique key for the item with 
-the `itemKey` prop. For example, if all animals in the example had a unique `name` property, then `itemKey` could be set 
-to `"name"` to use it as the unique key.
+from a database. You can also specify a custom key on each item using the `key` prop. For example, if all animals in the 
+example had a unique `name` property, then each item's `key` could be set to `item.name` to use it as the unique key.
 
 ```tsx
 let [animals, setAnimals] = useState([
@@ -145,8 +144,8 @@ let [animals, setAnimals] = useState([
   {name: 'Snake'}
 ]);
 
-<ListBox items={animals} itemKey="name">
-  {item => <Item>{item.name}</Item>}
+<ListBox items={animals}>
+  {item => <Item key={item.name}>{item.name}</Item>}
 </ListBox>
 ```
 
@@ -203,8 +202,8 @@ function addAnimal(name) {
   list.append({name});
 }
 
-<ListBox items={list.items} itemKey="name">
-  {item => <Item>{item.name}</Item>}
+<ListBox items={list.items}>
+  {item => <Item key={item.name}>{item.name}</Item>}
 </ListBox>
 ```
 
@@ -212,7 +211,7 @@ function addAnimal(name) {
 
 Sections can be built by returning a &lt;<TypeLink links={docs.links} type={docs.exports.Section} />&gt; instead of
 an &lt;<TypeLink links={docs.links} type={docs.exports.Item} />&gt; item from the top-level item renderer. Sections
-also support an `items` prop with `itemKey` and a renderer function for their children.
+also support an `items` prop and a renderer function for their children.
 
 ```tsx
 let [sections, setSections] = useState([
@@ -234,10 +233,10 @@ let [sections, setSections] = useState([
   }
 ]);
 
-<Picker items={sections} itemKey="name">
+<Picker items={sections}>
   {section =>
-    <Section title={section.name} items={section.items} itemKey="name">
-      {item => <Item>{item.name}</Item>}
+    <Section key={item.name} title={section.name} items={section.items}>
+      {item => <Item key={item.name}>{item.name}</Item>}
     </Section>
   }
 </Picker>
@@ -333,9 +332,9 @@ let [items, setItems] = useState([
   ]}
 ]);
 
-<Tree items={items} itemKey="name">
+<Tree items={items}>
   {item =>
-    <Item childItems={item.children}>{item.name}</Item>
+    <Item key={item.name} childItems={item.children}>{item.name}</Item>
   }
 </Tree>
 ```
@@ -370,7 +369,7 @@ let list = useAsyncList({
   label="Pick a Pokemon"
   items={list.items}
   isLoading={list.isLoading}>
-  {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+  {item => <Item key={item.name}>{item.name}</Item>}
 </Picker>
 ```
 
@@ -405,7 +404,7 @@ let list = useAsyncList({
   items={list.items}
   isLoading={list.isLoading}
   onLoadMore={list.loadMore}>
-  {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+  {item => <Item key={item.name}>{item.name}</Item>}
 </Picker>
 ```
 

--- a/packages/@react-stately/collections/src/CollectionBuilder.ts
+++ b/packages/@react-stately/collections/src/CollectionBuilder.ts
@@ -15,18 +15,12 @@ import {Node, PartialNode} from './types';
 import React, {Key, ReactElement} from 'react';
 
 interface CollectionBuilderState {
-  renderer?: (value: any) => ReactElement,
-  childKey?: string
+  renderer?: (value: any) => ReactElement
 }
 
 export class CollectionBuilder<T extends object> {
-  private itemKey: string;
   private context?: unknown;
   private cache: WeakMap<T, Node<T>> = new WeakMap();
-
-  constructor(itemKey: string) {
-    this.itemKey = itemKey;
-  }
 
   build(props: CollectionBase<T>, context?: unknown) {
     this.context = context;
@@ -44,48 +38,54 @@ export class CollectionBuilder<T extends object> {
       for (let item of props.items) {
         yield* this.getFullNode({
           value: item
-        }, {renderer: children, childKey: this.itemKey});
+        }, {renderer: children});
       }
     } else {
-      let items = React.Children.toArray(children);
+      let items: CollectionElement<T>[] = [];
+      React.Children.forEach(children, child => {
+        items.push(child);
+      });
+      
+      let index = 0;
       for (let item of items) {
-        yield* this.getFullNode({
-          element: item
-        }, {childKey: this.itemKey});
+        let nodes = this.getFullNode({
+          element: item,
+          index: index++
+        }, {});
+
+        for (let node of nodes) {
+          index++;
+          yield node;
+        }
       }
     }
   }
 
   private getKey(item: CollectionElement<T>, partialNode: PartialNode<T>, state: CollectionBuilderState, parentKey?: Key): Key {
-    if (item.props.uniqueKey != null) {
-      return item.props.uniqueKey;
-    }
-
     if (item.key != null) {
-      return parentKey ? `${parentKey}${item.key}` : item.key;
+      return item.key;
     }
 
     if (partialNode.type === 'cell' && partialNode.key != null) {
       return `${parentKey}${partialNode.key}`;
     }
-
-    if (state.childKey && partialNode.value[state.childKey] != null) {
-      return partialNode.value[state.childKey];
-    }
   
     let v = partialNode.value as any;
-    let key = v.key ?? v.id;
-    if (key == null) {
-      throw new Error('No key found for item');
+    if (v != null) {
+      let key = v.key ?? v.id;
+      if (key == null) {
+        throw new Error('No key found for item');
+      }
+      
+      return key;
     }
-    
-    return key;
+
+    return parentKey ? `${parentKey}.${partialNode.index}` : `$.${partialNode.index}`;
   }
 
   private getChildState(state: CollectionBuilderState, partialNode: PartialNode<T>) {
     return {
-      renderer: partialNode.renderer || state.renderer,
-      childKey: partialNode.childKey || state.childKey
+      renderer: partialNode.renderer || state.renderer
     };
   }
 
@@ -96,6 +96,7 @@ export class CollectionBuilder<T extends object> {
     if (!element && partialNode.value && state && state.renderer) {
       let cached = this.cache.get(partialNode.value);
       if (cached && (!cached.shouldInvalidate || !cached.shouldInvalidate(this.context))) {
+        cached.index = partialNode.index;
         yield cached;
         return;
       }
@@ -105,7 +106,7 @@ export class CollectionBuilder<T extends object> {
 
     // If there's an element with a getCollectionNode function on its type, then it's a supported component.
     // Call this function to get a partial node, and recursively build a full node from there.
-    if (element) {
+    if (React.isValidElement(element)) {      
       let type = element.type as any;
       if (typeof type !== 'function' || typeof type.getCollectionNode !== 'function') {
         let name = typeof element.type === 'function' ? element.type.name : element.type;
@@ -113,13 +114,16 @@ export class CollectionBuilder<T extends object> {
       }
 
       let childNodes = type.getCollectionNode(element.props, this.context) as Generator<PartialNode<T>, void, Node<T>[]>;
+      let index = partialNode.index;
       let result = childNodes.next();
       while (!result.done && result.value) {
         let childNode = result.value;
+        
+        partialNode.index = index;
         let nodes = this.getFullNode({
           ...childNode,
-          key: childNode.element ? null : this.getKey(element, partialNode, state, parentKey),
-          index: partialNode.index,
+          key: childNode.element ? null : this.getKey(element as CollectionElement<T>, partialNode, state, parentKey),
+          index,
           wrapper: compose(partialNode.wrapper, childNode.wrapper)
         }, this.getChildState(state, childNode), parentKey ? `${parentKey}${element.key}` : element.key, parentNode);
 
@@ -137,12 +141,18 @@ export class CollectionBuilder<T extends object> {
             throw new Error(`Unsupported type <${capitalize(node.type)}> in <${capitalize(parentNode.type)}>. Only <${capitalize(partialNode.type)}> is supported.`);
           }
 
+          index++;
           yield node;
         }
 
         result = childNodes.next(children);
       }
 
+      return;
+    }
+
+    // Ignore invalid elements
+    if (partialNode.key == null) {
       return;
     }
 
@@ -167,13 +177,19 @@ export class CollectionBuilder<T extends object> {
           return;
         }
 
+        let index = 0;
         for (let child of partialNode.childNodes()) {
           // Ensure child keys are globally unique by prepending the parent node's key
-          if (child.key) {
+          if (child.key != null) {
             child.key = `${node.key}${child.key}`;
           }
 
-          yield* builder.getFullNode(child, builder.getChildState(state, child), node.key, node);
+          child.index = index;
+          let nodes = builder.getFullNode(child, builder.getChildState(state, child), node.key, node);
+          for (let node of nodes) {
+            index++;
+            yield node;
+          }
         }
       })
     };

--- a/packages/@react-stately/collections/src/Item.ts
+++ b/packages/@react-stately/collections/src/Item.ts
@@ -43,13 +43,15 @@ Item.getCollectionNode = function* getCollectionNode<T>(props: ItemProps<T>): Ge
           };
         }
       } else if (title) {
-        let items = React.Children.toArray(children) as ItemElement<T>[];
-        for (let item of items) {
-          yield {
+        let items: PartialNode<T>[] = [];
+        React.Children.forEach(children, child => {
+          items.push({
             type: 'item',
-            element: item
-          };
-        }
+            element: child as ItemElement<T>
+          });
+        });
+
+        yield* items;
       }
     }
   };

--- a/packages/@react-stately/collections/src/Section.ts
+++ b/packages/@react-stately/collections/src/Section.ts
@@ -19,7 +19,7 @@ function Section<T>(props: SectionProps<T>): ReactElement { // eslint-disable-li
 }
 
 Section.getCollectionNode = function* getCollectionNode<T>(props: SectionProps<T>): Generator<PartialNode<T>> {
-  let {children, title, items, itemKey} = props;
+  let {children, title, items} = props;
   yield {
     type: 'section',
     hasChildNodes: true,
@@ -35,18 +35,19 @@ Section.getCollectionNode = function* getCollectionNode<T>(props: SectionProps<T
           yield {
             type: 'item',
             value: item,
-            childKey: itemKey,
             renderer: children
           };
         }
       } else {
-        let items = React.Children.toArray(children);
-        for (let item of items) {
-          yield {
+        let items: PartialNode<T>[] = [];
+        React.Children.forEach(children, child => {
+          items.push({
             type: 'item',
-            element: item
-          };
-        }
+            element: child
+          });
+        });
+
+        yield* items;
       }
     }
   };

--- a/packages/@react-stately/collections/src/types.ts
+++ b/packages/@react-stately/collections/src/types.ts
@@ -63,7 +63,6 @@ export interface PartialNode<T> {
   'aria-label'?: string,
   index?: number,
   renderer?: ItemRenderer<T>,
-  childKey?: string,
   hasChildNodes?: boolean,
   childNodes?: () => IterableIterator<PartialNode<T>>,
   props?: any,

--- a/packages/@react-stately/data/docs/useAsyncList.mdx
+++ b/packages/@react-stately/data/docs/useAsyncList.mdx
@@ -63,7 +63,7 @@ let list = useAsyncList({
   label="Pick a Pokemon"
   items={list.items}
   isLoading={list.isLoading}>
-  {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+  {item => <Item key={item.name}>{item.name}</Item>}
 </Picker>
 ```
 
@@ -98,7 +98,7 @@ let list = useAsyncList({
   items={list.items}
   isLoading={list.isLoading}
   onLoadMore={list.loadMore}>
-  {item => <Item uniqueKey={item.name}>{item.name}</Item>}
+  {item => <Item key={item.name}>{item.name}</Item>}
 </Picker>
 ```
 

--- a/packages/@react-stately/grid/src/Column.ts
+++ b/packages/@react-stately/grid/src/Column.ts
@@ -35,13 +35,15 @@ Column.getCollectionNode = function* getCollectionNode<T>(props: ColumnProps<T>,
           };
         }
       } else if (title) {
-        let childColumns = React.Children.toArray(children) as ReactElement<ColumnProps<T>>[];
-        for (let child of childColumns) {
-          yield {
+        let childColumns: PartialNode<T>[] = [];
+        React.Children.forEach(children, child => {
+          childColumns.push({
             type: 'column',
-            element: child
-          };
-        }
+            element: child as ReactElement<ColumnProps<T>>
+          });
+        });
+
+        yield* childColumns;
       }
     },
     shouldInvalidate(newContext: CollectionBuilderContext<T>) {

--- a/packages/@react-stately/grid/src/GridCollection.ts
+++ b/packages/@react-stately/grid/src/GridCollection.ts
@@ -83,7 +83,6 @@ export class GridCollection<T> implements Collection<GridNode<T>> {
 
       let childKeys = new Set();
       let last: GridNode<T>;
-      let index = 0;
       for (let child of node.childNodes) {
         childKeys.add(child.key);
 
@@ -94,7 +93,6 @@ export class GridCollection<T> implements Collection<GridNode<T>> {
           child.prevKey = null;
         }
   
-        child.index = index++;
         visit(child);
         last = child;
       }
@@ -124,7 +122,6 @@ export class GridCollection<T> implements Collection<GridNode<T>> {
     
     let bodyKeys = new Set();
     let last: GridNode<T>;
-    let index = 0;
     for (let node of nodes) {
       if (last) {
         last.nextKey = node.key;
@@ -133,7 +130,6 @@ export class GridCollection<T> implements Collection<GridNode<T>> {
         node.prevKey = null;
       }
 
-      node.index = index++;
       visit(node);
       if (node.type !== 'column') {
         bodyKeys.add(node.key);

--- a/packages/@react-stately/grid/src/Row.ts
+++ b/packages/@react-stately/grid/src/Row.ts
@@ -30,13 +30,10 @@ Row.getCollectionNode = function* getCollectionNode<T>(props: RowProps<T>, conte
     hasChildNodes: true,
     *childNodes() {
       // Process cells first
-      let index = 0;
-
       if (context.showSelectionCheckboxes && context.selectionMode !== 'none') {
         yield {
           type: 'cell',
           key: 'header', // this is combined with the row key by CollectionBuilder
-          index: index++,
           props: {
             isSelectionCell: true
           }
@@ -48,23 +45,23 @@ Row.getCollectionNode = function* getCollectionNode<T>(props: RowProps<T>, conte
           yield {
             type: 'cell',
             element: children(column.key),
-            key: column.key, // this is combined with the row key by CollectionBuilder
-            index: index++
+            key: column.key // this is combined with the row key by CollectionBuilder
           };
         }
       } else {
-        let cells = React.Children.toArray(children);
+        let cells: PartialNode<T>[] = [];
+        React.Children.forEach(children, cell => {
+          cells.push({
+            type: 'cell',
+            element: cell
+          });
+        });
+
         if (cells.length !== context.columns.length) {
           throw new Error(`Cell count must match column count. Found ${cells.length} cells and ${context.columns.length} columns.`);
         }
 
-        for (let cell of cells) {
-          yield {
-            type: 'cell',
-            element: cell,
-            index: index++
-          };
-        }
+        yield* cells;
       }
 
       // Then process child rows (e.g. treeble)

--- a/packages/@react-stately/grid/src/TableBody.ts
+++ b/packages/@react-stately/grid/src/TableBody.ts
@@ -19,7 +19,7 @@ function TableBody<T>(props: TableBodyProps<T>): ReactElement { // eslint-disabl
 }
 
 TableBody.getCollectionNode = function* getCollectionNode<T>(props: TableBodyProps<T>): Generator<PartialNode<T>> {
-  let {children, items, itemKey} = props;
+  let {children, items} = props;
   yield {
     type: 'body',
     hasChildNodes: true,
@@ -34,18 +34,19 @@ TableBody.getCollectionNode = function* getCollectionNode<T>(props: TableBodyPro
           yield {
             type: 'item',
             value: item,
-            childKey: itemKey,
             renderer: children
           };
         }
       } else {
-        let items = React.Children.toArray(children);
-        for (let item of items) {
-          yield {
+        let items: PartialNode<T>[] = [];
+        React.Children.forEach(children, item => {
+          items.push({
             type: 'item',
             element: item
-          };
-        }
+          });
+        });
+
+        yield* items;
       }
     }
   };

--- a/packages/@react-stately/grid/src/TableHeader.ts
+++ b/packages/@react-stately/grid/src/TableHeader.ts
@@ -18,8 +18,8 @@ function TableHeader<T>(props: TableHeaderProps<T>): ReactElement { // eslint-di
   return null;
 }
 
-TableHeader.getCollectionNode = function* getCollectionNode<T>(props: TableHeaderProps<T>): Generator<PartialNode<T>> {
-  let {children, columns, columnKey} = props;
+TableHeader.getCollectionNode = function* getCollectionNode<T>(props: TableHeaderProps<T>): Generator<PartialNode<T>, void, any> {
+  let {children, columns} = props;
   if (typeof children === 'function') {
     if (!columns) {
       throw new Error('props.children was a function but props.columns is missing');
@@ -29,18 +29,19 @@ TableHeader.getCollectionNode = function* getCollectionNode<T>(props: TableHeade
       yield {
         type: 'column',
         value: column,
-        childKey: columnKey,
         renderer: children
       };
     }
   } else {
-    let columns = React.Children.toArray(children);
-    for (let column of columns) {
-      yield {
+    let columns: PartialNode<T>[] = [];
+    React.Children.forEach(children, column => {
+      columns.push({
         type: 'column',
         element: column
-      };
-    }
+      });
+    });
+
+    yield* columns;
   }
 };
 

--- a/packages/@react-stately/grid/src/useGridState.ts
+++ b/packages/@react-stately/grid/src/useGridState.ts
@@ -46,7 +46,7 @@ export function useGridState<T extends object>(props: GridStateProps<T>): GridSt
     props.disabledKeys ? new Set(props.disabledKeys) : new Set<Key>()
   , [props.disabledKeys]);
   
-  let builder = useMemo(() => new CollectionBuilder<T>(props.itemKey), [props.itemKey]);
+  let builder = useMemo(() => new CollectionBuilder<T>(), []);
   let collectionRef = useRef<GridCollection<T>>();
   let collection = useMemo(() => {
     let context = {

--- a/packages/@react-stately/list/src/useListState.ts
+++ b/packages/@react-stately/list/src/useListState.ts
@@ -36,7 +36,7 @@ export function useListState<T extends object>(props: CollectionBase<T> & Multip
     props.disabledKeys ? new Set(props.disabledKeys) : new Set<Key>()
   , [props.disabledKeys]);
 
-  let builder = useMemo(() => new CollectionBuilder<T>(props.itemKey), [props.itemKey]);
+  let builder = useMemo(() => new CollectionBuilder<T>(), []);
   let collection = useMemo(() => {
     let nodes = builder.build(props);
     return new TreeCollection(nodes);

--- a/packages/@react-stately/selection/docs/selection.mdx
+++ b/packages/@react-stately/selection/docs/selection.mdx
@@ -45,9 +45,9 @@ behavior on a static collection, but could be applied to a dynamic collection th
 let [selectedKeys, setSelectedKeys] = useState(new Set());
 
 <ListBox selectedKeys={selectedKeys} onSelectionChange={setSelectedKeys}>
-  <Item uniqueKey="one">One</Item>
-  <Item uniqueKey="two">Two</Item>
-  <Item uniqueKey="three">Three</Item>
+  <Item key="one">One</Item>
+  <Item key="two">Two</Item>
+  <Item key="three">Three</Item>
 </ListBox>
 ```
 
@@ -62,9 +62,9 @@ single key instead of a Set as their value, and `onSelectionChange` is also call
 let [selectedKey, setSelectedKey] = useState(null);
 
 <ComboBox selectedKey={selectedKey} onSelectionChange={setSelectedKey}>
-  <Item uniqueKey="one">One</Item>
-  <Item uniqueKey="two">Two</Item>
-  <Item uniqueKey="three">Three</Item>
+  <Item key="one">One</Item>
+  <Item key="two">Two</Item>
+  <Item key="three">Three</Item>
 </ComboBox>
 ```
 
@@ -79,9 +79,9 @@ let [selectedKeys, setSelectedKeys] = useState(new Set());
   selectionMode="single"
   selectedKeys={selectedKeys}
   onSelectionChange={setSelectedKeys}>
-  <Item uniqueKey="one">One</Item>
-  <Item uniqueKey="two">Two</Item>
-  <Item uniqueKey="three">Three</Item>
+  <Item key="one">One</Item>
+  <Item key="two">Two</Item>
+  <Item key="three">Three</Item>
 </ListBox>
 ```
 
@@ -109,10 +109,9 @@ function removeItem() {
 
 <ListBox
   items={list.items}
-  itemKey="name"
   selectedKeys={list.selectedKeys}
   onSelectionChange={list.setSelectedKeys}>
-  {item => <Item>{item.name}</Item>}
+  {item => <Item key={item.name}>{item.name}</Item>}
 </ListBox>
 ```
 

--- a/packages/@react-stately/tree/src/useTreeState.ts
+++ b/packages/@react-stately/tree/src/useTreeState.ts
@@ -49,7 +49,7 @@ export function useTreeState<T extends object>(props: CollectionBase<T> & Expand
     props.disabledKeys ? new Set(props.disabledKeys) : new Set<Key>()
   , [props.disabledKeys]);
 
-  let builder = useMemo(() => new CollectionBuilder<T>(props.itemKey), [props.itemKey]);
+  let builder = useMemo(() => new CollectionBuilder<T>(), []);
   let tree = useMemo(() => {
     let nodes = builder.build(props);
     return new TreeCollection(nodes, {expandedKeys});

--- a/packages/@react-types/actiongroup/src/index.d.ts
+++ b/packages/@react-types/actiongroup/src/index.d.ts
@@ -24,9 +24,7 @@ export interface ActionGroupProps<T> extends MultipleSelection {
   children: ItemElement<T> | ItemElement<T>[] | ItemRenderer<T>,
   /** A list of items to iterate through and display as children. Must be used with an `ItemRenderer` as the sole child. */
   items?: Iterable<T>,
-  /** A field used as the `uniqueKey` if providing a list of items as a prop. */
-  itemKey?: string,
-  /** A list of `uniqueKeys` to disable. */
+  /** A list of keys to disable. */
   disabledKeys?: Iterable<Key>,
   /**
    * Whether the ActionGroup is disabled.
@@ -35,7 +33,7 @@ export interface ActionGroupProps<T> extends MultipleSelection {
   isDisabled?: boolean,
   /**
    * Invoked when an action is taken on a child. Especially useful when `selectionMode` is none.
-   * The sole argument `key` is the uniqueKey for the item.
+   * The sole argument `key` is the key for the item.
    */
   onAction?: (key: Key) => void
 }

--- a/packages/@react-types/shared/src/collections.d.ts
+++ b/packages/@react-types/shared/src/collections.d.ts
@@ -25,8 +25,6 @@ export interface ItemProps<T> {
   childItems?: Iterable<T>,
   /** Whether this item has children, even if not loaded yet. */
   hasChildItems?: boolean,
-  /** A unique key for this item. */
-  uniqueKey?: Key
 }
 
 export type ItemElement<T> = ReactElement<ItemProps<T>>;
@@ -35,8 +33,6 @@ export type ItemRenderer<T> = (item: T) => ItemElement<T>;
 interface AsyncLoadable<T> {
   /** Item objects in the collection or section. */
   items?: Iterable<T>,
-  /** Property name on each item object to use as the unique key. `id` or `key` by default. */
-  itemKey?: string,
   /** Whether the items are currently loading. */
   isLoading?: boolean, // possibly isLoadingMore
   /** Handler that is called when more items should be loaded, e.g. while scrolling near the bottom. */
@@ -49,9 +45,7 @@ export interface SectionProps<T> extends AsyncLoadable<T> {
   /** An accessibility label for the section. */
   'aria-label'?: string,
   /** Static child items or a function to render children. */
-  children: ItemElement<T> | ItemElement<T>[] | ItemRenderer<T>,
-  /** A unique key for the section. */
-  uniqueKey?: Key
+  children: ItemElement<T> | ItemElement<T>[] | ItemRenderer<T>
 }
 
 export type SectionElement<T> = ReactElement<SectionProps<T>>;

--- a/packages/@react-types/table/src/index.d.ts
+++ b/packages/@react-types/table/src/index.d.ts
@@ -11,7 +11,7 @@
  */
 
 import {AriaLabelingProps, AsyncLoadable, CollectionChildren, DOMProps, MultipleSelection, SectionProps, Sortable, StyleProps} from '@react-types/shared';
-import {Key, ReactElement} from 'react';
+import {Key, ReactElement, ReactNode} from 'react';
 
 export interface TableProps<T> extends MultipleSelection, Sortable {
   children: ReactElement<TableHeaderProps | TableBodyProps | SectionProps | RowProps>[],
@@ -26,7 +26,6 @@ export interface SpectrumTableProps<T> extends TableProps<T>, DOMProps, AriaLabe
 
 export interface TableHeaderProps<T> {
   columns?: T[],
-  columnKey?: string,
   children: ColumnElement<T> | ColumnElement<T>[] | ColumnRenderer<T>
 }
 
@@ -36,8 +35,7 @@ export interface ColumnProps<T> {
   title?: ReactNode,
   children: ReactNode | ColumnElement<T> | ColumnElement<T>[],
   childColumns?: T[],
-  'aria-label'?: string,
-  uniqueKey?: Key
+  'aria-label'?: string
 }
 
 // TODO: how to support these in CollectionBuilder...
@@ -65,8 +63,7 @@ export interface RowProps<T> {
   hasChildItems?: boolean,
   children: CellElement | CellElement[] | CellRenderer,
   textValue?: string, // ???
-  'aria-label'?: string, // ???
-  uniqueKey?: Key
+  'aria-label'?: string // ???
 }
 
 export interface CellProps {

--- a/packages/dev/docs/src/docs.js
+++ b/packages/dev/docs/src/docs.js
@@ -59,7 +59,7 @@ function LinkPopover({id}) {
       <View slot="heading">
         <Breadcrumbs isHeading headingAriaLevel={3} onAction={(key) => setBreadcrumbs(breadcrumbs.slice(0, key))}>
           {breadcrumbs.map((b, i) => (
-            <Item uniqueKey={i + 1}>
+            <Item key={i + 1}>
               {b.dataset.title}
             </Item>
           ))}


### PR DESCRIPTION
This replaces our custom `uniqueKey` prop with the standard React `key` prop, and removes the `itemKey` prop from collection components. This should make the API simpler and more consistent with React itself.

Previously we had issues because `React.Children.toArray` updates the key to add a prefix. I've updated this to use `React.Children.forEach` instead, which doesn't have this issue. This does mean we need to generate our own keys if the user doesn't provide one, however, since React no longer generates them for us.

`itemKey` wasn't a great API because it's not flexible enough (e.g. what about nested keys?), and it's confusing to explain in the docs. Better to keep things simpler (one way to do things) and more consistent with React.