### PR TITLE
Remove unsupported props from ActionButton

### DIFF
--- a/packages/@react-spectrum/button/docs/ActionButton.mdx
+++ b/packages/@react-spectrum/button/docs/ActionButton.mdx
@@ -103,15 +103,6 @@ function Example() {
 <ActionButton isQuiet>Action!</ActionButton>
 ```
 
-### Hold affordance
-[View guidelines](https://spectrum.adobe.com/page/action-button/#Hold-icon)
-
-```tsx example
-<ActionButton holdAffordance aria-label="Edit">
-  <Edit />
-</ActionButton>
-```
-
 ### Disabled
 [View guidelines](https://spectrum.adobe.com/page/action-button/#Disabled)
 

--- a/packages/@react-spectrum/button/src/ActionButton.tsx
+++ b/packages/@react-spectrum/button/src/ActionButton.tsx
@@ -11,10 +11,9 @@
  */
 
 import {classNames, SlotProvider, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
-import CornerTriangle from '@spectrum-icons/ui/CornerTriangle';
 import {FocusableRef} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
-import React from 'react';
+import React, {RefObject} from 'react';
 import {SpectrumActionButtonProps} from '@react-types/button';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {Text} from '@react-spectrum/typography';
@@ -24,23 +23,21 @@ import {useProviderProps} from '@react-spectrum/provider';
 function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef) {
   props = useProviderProps(props);
   let {
-    elementType: ElementType = 'button',
     isQuiet,
     isDisabled,
     children,
-    holdAffordance,
     autoFocus,
     ...otherProps
   } = props;
 
-  let domRef = useFocusableRef(ref);
+  let domRef = useFocusableRef(ref) as RefObject<HTMLButtonElement>;
   let {buttonProps, isPressed} = useButton(props, domRef);
   let {styleProps} = useStyleProps(otherProps);
   let isTextOnly = React.Children.toArray(props.children).every(c => !React.isValidElement(c));
 
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
-      <ElementType
+      <button
         {...styleProps}
         {...buttonProps}
         ref={domRef}
@@ -56,9 +53,6 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef) {
             styleProps.className
           )
         }>
-        {holdAffordance &&
-          <CornerTriangle UNSAFE_className={classNames(styles, 'spectrum-ActionButton-hold')} />
-        }
         <SlotProvider
           slots={{
             icon: {
@@ -73,7 +67,7 @@ function ActionButton(props: SpectrumActionButtonProps, ref: FocusableRef) {
             ? <Text>{children}</Text>
             : children}
         </SlotProvider>
-      </ElementType>
+      </button>
     </FocusRing>
   );
 }

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -10,15 +10,15 @@
  * governing permissions and limitations under the License.
  */
 
-import {ButtonProps, LinkButtonProps} from '@react-types/button';
+import {ButtonProps} from '@react-types/button';
 import {classNames, SlotProvider, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMProps, FocusableRef, StyleProps} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
-import React from 'react';
+import React, {RefObject} from 'react';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {useButton} from '@react-aria/button';
 
-interface FieldButtonProps extends ButtonProps, LinkButtonProps, DOMProps, StyleProps {
+interface FieldButtonProps extends ButtonProps, DOMProps, StyleProps {
   isQuiet?: boolean,
   isActive?: boolean,
   validationState?: 'valid' | 'invalid'
@@ -27,7 +27,6 @@ interface FieldButtonProps extends ButtonProps, LinkButtonProps, DOMProps, Style
 // @private
 function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
   let {
-    elementType: ElementType = 'button',
     isQuiet,
     isDisabled,
     validationState,
@@ -36,13 +35,13 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
     isActive,
     ...otherProps
   } = props;
-  let domRef = useFocusableRef(ref);
+  let domRef = useFocusableRef(ref) as RefObject<HTMLButtonElement>;
   let {buttonProps, isPressed} = useButton(props, domRef);
   let {styleProps} = useStyleProps(otherProps);
 
   return (
     <FocusRing focusRingClass={classNames(styles, 'focus-ring')} autoFocus={autoFocus}>
-      <ElementType
+      <button
         {...buttonProps}
         ref={domRef}
         className={
@@ -67,7 +66,7 @@ function FieldButton(props: FieldButtonProps, ref: FocusableRef) {
           }}>
           {children}
         </SlotProvider>
-      </ElementType>
+      </button>
     </FocusRing>
   );
 }

--- a/packages/@react-spectrum/button/src/FieldButton.tsx
+++ b/packages/@react-spectrum/button/src/FieldButton.tsx
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {ButtonProps} from '@react-types/button';
+import {ButtonProps, LinkButtonProps} from '@react-types/button';
 import {classNames, SlotProvider, useFocusableRef, useStyleProps} from '@react-spectrum/utils';
 import {DOMProps, FocusableRef, StyleProps} from '@react-types/shared';
 import {FocusRing} from '@react-aria/focus';
@@ -18,7 +18,7 @@ import React from 'react';
 import styles from '@adobe/spectrum-css-temp/components/button/vars.css';
 import {useButton} from '@react-aria/button';
 
-interface FieldButtonProps extends ButtonProps, DOMProps, StyleProps {
+interface FieldButtonProps extends ButtonProps, LinkButtonProps, DOMProps, StyleProps {
   isQuiet?: boolean,
   isActive?: boolean,
   validationState?: 'valid' | 'invalid'

--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -66,56 +66,6 @@ storiesOf('Button/ActionButton', module)
     )
   )
   .add(
-    'holdAffordance',
-    () => render({holdAffordance: true})
-  )
-  .add(
-    'icon, holdAffordance',
-    () => (
-      <div>
-        <ActionButton
-          holdAffordance
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}>
-          <Add />
-          <Text>Default</Text>
-        </ActionButton>
-        <ActionButton
-          holdAffordance
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled>
-          <Text>Disabled</Text>
-          <Add />
-        </ActionButton>
-      </div>
-    )
-  )
-  .add(
-    'icon only, holdAffordance',
-    () => (
-      <div>
-        <ActionButton
-          holdAffordance
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}>
-          <Add />
-        </ActionButton>
-        <ActionButton
-          holdAffordance
-          onPress={action('press')}
-          onPressStart={action('pressstart')}
-          onPressEnd={action('pressend')}
-          isDisabled>
-          <Add />
-        </ActionButton>
-      </div>
-    )
-  )
-  .add(
     'quiet,',
     () => render({isQuiet: true})
   )

--- a/packages/@react-spectrum/button/test/ActionButton.test.js
+++ b/packages/@react-spectrum/button/test/ActionButton.test.js
@@ -47,26 +47,4 @@ describe('ActionButton', function () {
     let button = getByRole('button', {hidden: true});
     expect(button).toHaveAttribute('data-foo', 'bar');
   });
-
-  it.each`
-    Name              | Component        | props
-    ${'ActionButton'} | ${ActionButton}  | ${{onPress: onPressSpy, holdAffordance: true}}
-    ${'V2Button'}     | ${V2Button}      | ${{variant: 'action', onClick: onPressSpy, holdAffordance: true}}
-  `('$Name hold affordance', function ({Component, props}) {
-    let {getByRole} = render(<Component {...props}>Click Me</Component>);
-
-    let button = getByRole('button');
-    let holdAffordance;
-    if (Component === V2Button) {
-      holdAffordance = getByRole('presentation');
-      expect(holdAffordance).toBeTruthy();
-      expect(holdAffordance).not.toHaveAttribute('aria-hidden');
-    } else {
-      holdAffordance = getByRole('img', {hidden: true});
-      expect(holdAffordance).toBeTruthy();
-      expect(holdAffordance).toHaveAttribute('aria-hidden');
-    }
-    triggerPress(button);
-    expect(onPressSpy).toHaveBeenCalledTimes(1);
-  });
 });

--- a/packages/@react-types/actiongroup/src/index.d.ts
+++ b/packages/@react-types/actiongroup/src/index.d.ts
@@ -3,7 +3,7 @@
  * This file is licensed to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy
  * of the License at http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under
  * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
  * OF ANY KIND, either express or implied. See the License for the specific language
@@ -48,7 +48,5 @@ export interface SpectrumActionGroupProps<T> extends AriaActionGroupProps<T>, St
   /** Whether the ActionButtons should be justified in their container. */
   isJustified?: boolean,
   /** Whether ActionButtons should use the [quiet style](https://spectrum.adobe.com/page/action-button/#Quiet). */
-  isQuiet?: boolean,
-  /** Whether the ActionButtons should be displayed with a [hold icon](https://spectrum.adobe.com/page/action-button/#Hold-icon). */
-  holdAffordance?: boolean
+  isQuiet?: boolean
 }

--- a/packages/@react-types/button/src/index.d.ts
+++ b/packages/@react-types/button/src/index.d.ts
@@ -13,23 +13,26 @@
 import {AriaLabelingProps, FocusableDOMProps, FocusableProps, PressEvents, StyleProps} from '@react-types/shared';
 import {JSXElementConstructor, ReactNode} from 'react';
 
-export interface ButtonProps extends PressEvents, FocusableProps {
+interface ButtonProps extends PressEvents, FocusableProps {
   /** Whether the button is disabled */
   isDisabled?: boolean,
+  /** The content to display in the button. */
+  children?: ReactNode,
+}
+
+export interface LinkButtonProps {
   /**
    * The HTML element or React element used to render the button, e.g. "div", "a", or `RouterLink`.
    * @default "button"
    */
   elementType?: string | JSXElementConstructor<any>,
-  /** The content to display in the button. */
-  children?: ReactNode,
   /** A URL to link to if elementType="a". */
   href?: string,
   /** The target window for the link. */
   target?: string
 }
 
-export interface AriaButtonProps extends ButtonProps, FocusableDOMProps, AriaLabelingProps {
+interface AriaBaseButtonProps extends FocusableDOMProps, AriaLabelingProps {
   /** Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. */
   'aria-expanded'?: boolean,
   /** Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element. */
@@ -38,28 +41,28 @@ export interface AriaButtonProps extends ButtonProps, FocusableDOMProps, AriaLab
   'aria-controls'?: string,
   /** Indicates the current "pressed" state of toggle buttons. */
   'aria-pressed'?: boolean,
-  /** 
+  /**
    * The behavior of the button when used in an HTML form.
    * @default "button"
    */
   type?: 'button' | 'submit' | 'reset'
 }
 
-export interface SpectrumButtonProps extends AriaButtonProps, StyleProps {
+export interface AriaButtonProps extends ButtonProps, LinkButtonProps, AriaBaseButtonProps {}
+
+export interface SpectrumButtonProps extends AriaBaseButtonProps, ButtonProps, LinkButtonProps, StyleProps {
   /** The [visual style](https://spectrum.adobe.com/page/button/#Options) of the button. */
   variant: 'cta' | 'overBackground' | 'primary' | 'secondary' | 'negative',
   /** Whether the button should be displayed with a quiet style. */
   isQuiet?: boolean
 }
 
-export interface SpectrumActionButtonProps extends AriaButtonProps, StyleProps {
+export interface SpectrumActionButtonProps extends AriaBaseButtonProps, ButtonProps, StyleProps {
   /** Whether the ActionButton should be displayed with a [quiet style](https://spectrum.adobe.com/page/action-button/#Quiet). */
-  isQuiet?: boolean,
-  /** Whether the ActionButton should be displayed with a [hold icon](https://spectrum.adobe.com/page/action-button/#Hold-icon). */
-  holdAffordance?: boolean
+  isQuiet?: boolean
 }
 
-export interface SpectrumLogicButtonProps extends AriaButtonProps, StyleProps {
+export interface SpectrumLogicButtonProps extends AriaBaseButtonProps, ButtonProps, LinkButtonProps, StyleProps {
   /** The type of boolean sequence to be represented by the LogicButton. */
   variant: 'and' | 'or'
 }


### PR DESCRIPTION
holdAffordance, elementType, href, target


Closes https://jira.corp.adobe.com/browse/RSP-1806

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Team:

<!--- Which product/company is this pull request for? -->
