### PR TITLE
Fix RadioGroup can be tabbed through each Radio

### DIFF
--- a/packages/@react-aria/radio/src/useRadioGroup.ts
+++ b/packages/@react-aria/radio/src/useRadioGroup.ts
@@ -63,7 +63,6 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
   });
 
   let onKeyDown = (e) => {
-    e.preventDefault();
     let walker = getFocusableTreeWalker(e.currentTarget, {from: e.target});
     let nextDir;
     switch (e.key) {
@@ -87,7 +86,10 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
       case 'ArrowUp':
         nextDir = 'prev';
         break;
+      default:
+        return;
     }
+    e.preventDefault();
     let nextElem;
     if (nextDir === 'next') {
       nextElem = walker.nextNode();

--- a/packages/@react-aria/radio/src/useRadioGroup.ts
+++ b/packages/@react-aria/radio/src/useRadioGroup.ts
@@ -63,7 +63,6 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
   });
 
   let onKeyDown = (e) => {
-    let walker = getFocusableTreeWalker(e.currentTarget, {from: e.target});
     let nextDir;
     switch (e.key) {
       case 'ArrowRight':
@@ -90,6 +89,7 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
         return;
     }
     e.preventDefault();
+    let walker = getFocusableTreeWalker(e.currentTarget, {from: e.target});
     let nextElem;
     if (nextDir === 'next') {
       nextElem = walker.nextNode();

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {fireEvent, render} from '@testing-library/react';
+import {act, fireEvent, render} from '@testing-library/react';
 import {Provider} from '@react-spectrum/provider';
 import {Radio, RadioGroup} from '../';
 import React from 'react';
@@ -18,6 +18,7 @@ import {theme} from '@react-spectrum/theme-default';
 import userEvent from '@testing-library/user-event';
 import V2Radio from '@react/react-spectrum/Radio';
 import V2RadioGroup from '@react/react-spectrum/RadioGroup';
+import {Button} from '@react-spectrum/button';
 
 function renderRadioGroup(ComponentGroup, Component, groupProps, radioProps) {
   return render(
@@ -422,12 +423,54 @@ describe('Radios', function () {
     expect(radioGroup).toHaveAttribute('aria-disabled', 'true');
   });
 
-  describe('V3 Radio group supports roving tabIndex ', function () {
+  describe('Radio group supports roving tabIndex ', function () {
     afterEach(() => {
       radioBehavior.reset();
     });
 
-    it('v3 RadioGroup default roving tabIndex', async () => {
+
+    it('does not tab through individual radios', () => {
+      // this test gives a false sense of security, it doesn't catch the problem
+      // where all keydown events were being stopped in the radio group
+      let {getByRole, getAllByRole} = render(
+        <Provider theme={theme} locale="en-US">
+          <Button variant="primary" aria-label="extra button" />
+          <RadioGroup aria-label="favorite pet" orientation="horizontal">
+            <Radio value="dogs">Dogs</Radio>
+            <Radio value="cats">Cats</Radio>
+            <Radio value="dragons">Dragons</Radio>
+          </RadioGroup>
+        </Provider>
+      );
+      let radios = getAllByRole('radio');
+      let button = getByRole('button');
+
+      act(() => {
+        userEvent.tab();
+      });
+      expect(document.activeElement).toBe(button);
+      expect(document.activeElement).not.toBe(radios[0]);
+      expect(document.activeElement).not.toBe(radios[1]);
+      expect(document.activeElement).not.toBe(radios[2]);
+
+      act(() => {
+        userEvent.tab();
+      });
+      expect(document.activeElement).not.toBe(button);
+      expect(document.activeElement).toBe(radios[0]);
+      expect(document.activeElement).not.toBe(radios[1]);
+      expect(document.activeElement).not.toBe(radios[2]);
+
+      act(() => {
+        userEvent.tab();
+      });
+      expect(document.activeElement).toBe(button);
+      expect(document.activeElement).not.toBe(radios[0]);
+      expect(document.activeElement).not.toBe(radios[1]);
+      expect(document.activeElement).not.toBe(radios[2]);
+    });
+
+    it('RadioGroup default roving tabIndex', async () => {
       let {getAllByRole} = renderRadioGroup(RadioGroup, Radio, {}, {});
       let radios = getAllByRole('radio');
       expect(radios[0]).toHaveAttribute('tabIndex', '0');
@@ -444,7 +487,7 @@ describe('Radios', function () {
       expect(radios[2]).toHaveAttribute('tabIndex', '-1');
     });
 
-    it('v3 RadioGroup roving tabIndex for autoFocus', async () => {
+    it('RadioGroup roving tabIndex for autoFocus', async () => {
       let {getAllByRole} = renderRadioGroup(RadioGroup, Radio, {}, [{}, {autoFocus: true}, {}]);
       let radios = getAllByRole('radio');
       expect(radios[0]).toHaveAttribute('tabIndex', '-1');

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import {act, fireEvent, render} from '@testing-library/react';
+import {act, createEvent, fireEvent, render} from '@testing-library/react';
 import {Button} from '@react-spectrum/button';
 import {Provider} from '@react-spectrum/provider';
 import {Radio, RadioGroup} from '../';
@@ -445,10 +445,14 @@ describe('Radios', function () {
       let radios = getAllByRole('radio');
       let button = getByRole('button');
 
+      let preventDefault = jest.fn();
       act(() => {
-        fireEvent.keyDown(button, {key: 'Tab'});
-        userEvent.tab();
-        fireEvent.keyUp(button, {key: 'Tab'});
+        let tabEvent = createEvent.keyDown(button, {key: 'Tab'});
+        fireEvent(button, tabEvent);
+        if (!tabEvent.defaultPrevented) {
+          userEvent.tab();
+        }
+        fireEvent.keyUp(button, {key: 'Tab', preventDefault});
       });
       expect(document.activeElement).toBe(button);
       expect(document.activeElement).not.toBe(radios[0]);
@@ -456,9 +460,12 @@ describe('Radios', function () {
       expect(document.activeElement).not.toBe(radios[2]);
 
       act(() => {
-        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
-        userEvent.tab();
-        fireEvent.keyUp(document.activeElement, {key: 'Tab'});
+        let tabEvent = createEvent.keyDown(button, {key: 'Tab'});
+        fireEvent(document.activeElement, tabEvent);
+        if (!tabEvent.defaultPrevented) {
+          userEvent.tab();
+        }
+        fireEvent.keyUp(document.activeElement, {key: 'Tab', preventDefault});
       });
       expect(document.activeElement).not.toBe(button);
       expect(document.activeElement).toBe(radios[0]);
@@ -466,9 +473,12 @@ describe('Radios', function () {
       expect(document.activeElement).not.toBe(radios[2]);
 
       act(() => {
-        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
-        userEvent.tab();
-        fireEvent.keyUp(document.activeElement, {key: 'Tab'});
+        let tabEvent = createEvent.keyDown(button, {key: 'Tab'});
+        fireEvent(document.activeElement, tabEvent);
+        if (!tabEvent.defaultPrevented) {
+          userEvent.tab();
+        }
+        fireEvent.keyUp(document.activeElement, {key: 'Tab', preventDefault});
       });
       expect(document.activeElement).toBe(button);
       expect(document.activeElement).not.toBe(radios[0]);

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -446,7 +446,9 @@ describe('Radios', function () {
       let button = getByRole('button');
 
       act(() => {
+        fireEvent.keyDown(button, {key: 'Tab'});
         userEvent.tab();
+        fireEvent.keyUp(button, {key: 'Tab'});
       });
       expect(document.activeElement).toBe(button);
       expect(document.activeElement).not.toBe(radios[0]);
@@ -454,7 +456,9 @@ describe('Radios', function () {
       expect(document.activeElement).not.toBe(radios[2]);
 
       act(() => {
+        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
         userEvent.tab();
+        fireEvent.keyUp(document.activeElement, {key: 'Tab'});
       });
       expect(document.activeElement).not.toBe(button);
       expect(document.activeElement).toBe(radios[0]);
@@ -462,7 +466,9 @@ describe('Radios', function () {
       expect(document.activeElement).not.toBe(radios[2]);
 
       act(() => {
+        fireEvent.keyDown(document.activeElement, {key: 'Tab'});
         userEvent.tab();
+        fireEvent.keyUp(document.activeElement, {key: 'Tab'});
       });
       expect(document.activeElement).toBe(button);
       expect(document.activeElement).not.toBe(radios[0]);

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -11,6 +11,7 @@
  */
 
 import {act, fireEvent, render} from '@testing-library/react';
+import {Button} from '@react-spectrum/button';
 import {Provider} from '@react-spectrum/provider';
 import {Radio, RadioGroup} from '../';
 import React from 'react';
@@ -18,7 +19,6 @@ import {theme} from '@react-spectrum/theme-default';
 import userEvent from '@testing-library/user-event';
 import V2Radio from '@react/react-spectrum/Radio';
 import V2RadioGroup from '@react/react-spectrum/RadioGroup';
-import {Button} from '@react-spectrum/button';
 
 function renderRadioGroup(ComponentGroup, Component, groupProps, radioProps) {
   return render(


### PR DESCRIPTION
Let key events that we aren't handling continue
I don't know why the jest test can't catch it...
Pushing anyways so that i can at least get feedback


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
