### PR TITLE
Avoid false positive in a11y checkers for Picker hidden input

### DIFF
--- a/packages/@react-aria/interactions/src/useFocusVisible.ts
+++ b/packages/@react-aria/interactions/src/useFocusVisible.ts
@@ -27,7 +27,7 @@ interface FocusVisibleResult {
   isFocusVisible: boolean
 }
 
-let isGlobalFocusVisible = true;
+let currentModality = null;
 let changeHandlers = new Set<Handler>();
 let hasSetupGlobalListeners = false;
 let hasEventBeforeFocus = false;
@@ -57,13 +57,13 @@ function isValidKey(e: KeyboardEvent) {
 function handleKeyboardEvent(e: KeyboardEvent) {
   hasEventBeforeFocus = true;
   if (isValidKey(e)) {
-    isGlobalFocusVisible = true;
+    currentModality = 'keyboard';
     triggerChangeHandlers('keyboard', e);
   }
 }
 
 function handlePointerEvent(e: PointerEvent | MouseEvent) {
-  isGlobalFocusVisible = false;
+  currentModality = 'pointer';
   if (e.type === 'mousedown' || e.type === 'pointerdown') {
     hasEventBeforeFocus = true;
     triggerChangeHandlers('pointer', e);
@@ -81,7 +81,7 @@ function handleFocusEvent(e: FocusEvent) {
   // If a focus event occurs without a preceding keyboard or pointer event, switch to keyboard modality.
   // This occurs, for example, when navigating a form with the next/previous buttons on iOS.
   if (!hasEventBeforeFocus) {
-    isGlobalFocusVisible = true;
+    currentModality = 'keyboard';
     triggerChangeHandlers('keyboard', e);
   }
 
@@ -89,7 +89,7 @@ function handleFocusEvent(e: FocusEvent) {
 }
 
 function handleWindowBlur() {
-  // When the window is blurred, reset state. This is necessary when tabbing out of the window, 
+  // When the window is blurred, reset state. This is necessary when tabbing out of the window,
   // for example, since a subsequent focus event won't be fired.
   hasEventBeforeFocus = false;
 }
@@ -112,12 +112,12 @@ function setupGlobalFocusEvents() {
 
   document.addEventListener('keydown', handleKeyboardEvent, true);
   document.addEventListener('keyup', handleKeyboardEvent, true);
-  
-  // Register focus events on the window so they are sure to happen 
+
+  // Register focus events on the window so they are sure to happen
   // before React's event listeners (registered on the document).
   window.addEventListener('focus', handleFocusEvent, true);
   window.addEventListener('blur', handleWindowBlur, false);
-  
+
   if (typeof PointerEvent !== 'undefined') {
     document.addEventListener('pointerdown', handlePointerEvent, true);
     document.addEventListener('pointermove', handlePointerEvent, true);
@@ -132,7 +132,25 @@ function setupGlobalFocusEvents() {
 }
 
 export function isFocusVisible(): boolean {
-  return isGlobalFocusVisible;
+  return currentModality !== 'pointer';
+}
+
+export function useInteractionModality(): Modality {
+  setupGlobalFocusEvents();
+
+  let [modality, setModality] = useState(currentModality);
+  useEffect(() => {
+    let handler = () => {
+      setModality(currentModality);
+    };
+
+    changeHandlers.add(handler);
+    return () => {
+      changeHandlers.delete(handler);
+    };
+  }, []);
+
+  return modality;
 }
 
 /**
@@ -142,23 +160,23 @@ export function useFocusVisible(props: FocusVisibleProps = {}): FocusVisibleResu
   setupGlobalFocusEvents();
 
   let {isTextInput, autoFocus} = props;
-  let [isFocusVisible, setFocusVisible] = useState(autoFocus || isGlobalFocusVisible);
+  let [isFocusVisibleState, setFocusVisible] = useState(autoFocus || isFocusVisible());
   useEffect(() => {
     let handler = (modality, e) => {
-      // If this is a text input component, don't update the focus visible style when 
+      // If this is a text input component, don't update the focus visible style when
       // typing except for when the Tab and Escape keys are pressed.
       if (isTextInput && modality === 'keyboard' && !FOCUS_VISIBLE_INPUT_KEYS[e.key]) {
         return;
       }
 
-      setFocusVisible(isGlobalFocusVisible);
+      setFocusVisible(isFocusVisible());
     };
-  
+
     changeHandlers.add(handler);
     return () => {
       changeHandlers.delete(handler);
     };
   }, [isTextInput]);
 
-  return {isFocusVisible};
+  return {isFocusVisible: isFocusVisibleState};
 }

--- a/packages/@react-aria/select/src/HiddenSelect.tsx
+++ b/packages/@react-aria/select/src/HiddenSelect.tsx
@@ -12,6 +12,7 @@
 
 import React, {ReactNode, RefObject} from 'react';
 import {SelectState} from '@react-stately/select';
+import {useInteractionModality} from '@react-aria/interactions';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
 
 interface HiddenSelectProps<T> {
@@ -34,6 +35,7 @@ interface HiddenSelectProps<T> {
  */
 export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
   let {state, triggerRef, label, name} = props;
+  let modality = useInteractionModality();
 
   // If used in a <form>, use a hidden input so the value can be submitted to a server.
   // If the collection isn't too big, use a hidden <select> element for this so that browser
@@ -53,11 +55,15 @@ export function HiddenSelect<T>(props: HiddenSelectProps<T>) {
     // input in the form. Using the <select> for this also works, but Safari on iOS briefly flashes
     // the native menu on focus, so this isn't ideal. A font-size of 16px or greater is required to
     // prevent Safari from zooming in on the input when it is focused.
+    //
+    // If the current interaction modality is null, then the user hasn't interacted with the page yet.
+    // In this case, we set the tabIndex to -1 on the input element so that automated accessibility
+    // checkers don't throw false-positives about focusable elements inside an aria-hidden parent.
     return (
       <VisuallyHidden aria-hidden="true">
         <input
           type="text"
-          tabIndex={state.isFocused || state.isOpen ? -1 : 0}
+          tabIndex={modality == null || state.isFocused || state.isOpen ? -1 : 0}
           style={{fontSize: 16}}
           onFocus={() => triggerRef.current.focus()} />
         <label>


### PR DESCRIPTION
This avoids false positive in automated accessibility checks for the hidden input inside Picker. The error was that focusable elements cannot be inside an `aria-hidden` container. The hidden input is used to marshal focus on mobile, so we can't get rid of it. To work around this, we set its `tabIndex` to `-1` until a user actually interacts with the page in any way. This way, automated checkers that just look at the DOM with doing any interaction won't fail.

This is accomplished by refactoring the existing listeners in `useFocusVisible` to expose the current interaction modality. If it's null, then the user hasn't interacted with the page yet.