### PR TITLE
Fix focus halo stroke width in FF

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -111,6 +111,7 @@ governing permissions and limitations under the License.
     bottom: 0;
     top: 0;
     margin: calc(var(--spectrum-alias-focus-ring-gap) * -1);
+    transform: translateX(0);
 
     transition: box-shadow var(--spectrum-global-animation-duration-100) ease-out,
                 margin var(--spectrum-global-animation-duration-100) ease-out;
@@ -149,7 +150,7 @@ governing permissions and limitations under the License.
     box-shadow: none;
   }
 
-  /* there should be space between the icon and text no matter the DOM order */ 
+  /* there should be space between the icon and text no matter the DOM order */
   .spectrum-Icon + .spectrum-Button-label {
     margin-inline-start: var(--spectrum-button-primary-text-gap);
   }

--- a/packages/@adobe/spectrum-css-temp/components/checkbox/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/checkbox/index.css
@@ -164,6 +164,7 @@ governing permissions and limitations under the License.
     bottom: 0;
     top: 0;
     margin: var(--spectrum-alias-focus-ring-gap);
+    transform: translateX(0);
 
     transition: box-shadow var(--spectrum-global-animation-duration-100) ease-out,
                 margin var(--spectrum-global-animation-duration-100) ease-out;

--- a/packages/@adobe/spectrum-css-temp/components/radio/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/radio/index.css
@@ -142,6 +142,7 @@ governing permissions and limitations under the License.
     bottom: 0;
     top: 0;
     margin: var(--spectrum-alias-focus-ring-gap);
+    transform: translateX(0);
 
     transition: box-shadow var(--spectrum-global-animation-duration-100) ease-out,
                 margin var(--spectrum-global-animation-duration-100) ease-out;

--- a/packages/@adobe/spectrum-css-temp/components/toggle/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/toggle/index.css
@@ -152,6 +152,7 @@ governing permissions and limitations under the License.
     bottom: 0;
     top: 0;
     margin: 0;
+    transform: translateX(0);
 
     transition: box-shadow var(--spectrum-global-animation-duration-100) ease-out,
                 margin var(--spectrum-global-animation-duration-100) ease-out;


### PR DESCRIPTION
This forces the halo to be rendered on the pixel grid instead of slightly off which caused it to look like one side was thinner than the other due to anti-aliasing
see https://github.com/adobe/spectrum-css/pull/742

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
