### PR TITLE
Smooth checkbox focus animation

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/checkbox/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/checkbox/index.css
@@ -165,7 +165,7 @@ governing permissions and limitations under the License.
     top: 0;
     margin: var(--spectrum-alias-focus-ring-gap);
 
-    transition: box-shadow var(--spectrum-global-animation-duration-100) ease-out,
+    transition: opacity var(--spectrum-global-animation-duration-100) ease-out,
                 margin var(--spectrum-global-animation-duration-100) ease-out;
   }
 }

--- a/packages/@adobe/spectrum-css-temp/components/checkbox/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/checkbox/skin.css
@@ -103,12 +103,18 @@ governing permissions and limitations under the License.
 
 /* Focus */
 .spectrum-Checkbox-input {
+  & + .spectrum-Checkbox-box {
+    &:after {
+      box-shadow: 0 0 0 var(--spectrum-checkbox-focus-ring-size-key-focus) var(--spectrum-checkbox-focus-ring-color-key-focus);
+      opacity: 0;
+    }
+  }
   &:focus-ring + .spectrum-Checkbox-box {
     &:before {
       border-color: var(--spectrum-checkbox-box-border-color-key-focus);
     }
     &:after {
-      box-shadow: 0 0 0 var(--spectrum-checkbox-focus-ring-size-key-focus) var(--spectrum-checkbox-focus-ring-color-key-focus);
+      opacity: 1;
     }
   }
   .spectrum-Checkbox.is-indeterminate &,


### PR DESCRIPTION
If you try to scroll in tableview with the arrow keys while on the checkbox column it becomes very jumpy because of the box-shadow transition
Instead, have the box-shadow always there and only change it's opacity
We should be doing this to more items... it's a huge savings


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
