### PR TITLE
Fix FF implicit form submission to behave like other browsers

### DIFF
--- a/packages/@react-spectrum/form/src/Form.tsx
+++ b/packages/@react-spectrum/form/src/Form.tsx
@@ -65,6 +65,8 @@ function Form(props: SpectrumFormProps, ref: DOMRef<HTMLFormElement>) {
           styleProps.className
         )
       }>
+      {/* https://stackoverflow.com/questions/895171/prevent-users-from-submitting-a-form-by-hitting-enter */}
+      <button type="submit" disabled style={{display: 'none'}} aria-hidden="true" />
       <FormContext.Provider value={ctx}>
         <Provider
           isQuiet={isQuiet}


### PR DESCRIPTION
Firefox will submit if "Enter" is pressed on a checkbox in a form. This does not happen in Chrome or Safari.
Easy to try out in Dialog story with form in it.

Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
