### PR TITLE
Fix ActionGroup wrapping

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -115,6 +115,10 @@ governing permissions and limitations under the License.
       &:hover {
         z-index: 2;
       }
+
+      &:focus {
+        z-index: 3;
+      }
     }
 
     &.spectrum-ActionGroup--vertical {

--- a/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/actiongroup/index.css
@@ -11,21 +11,41 @@ governing permissions and limitations under the License.
 */
 
 :root {
-  --spectrum-actiongroup-button-gap-reset: 0;
+  --spectrum-actiongroup-button-gap-reset: 0px;
   --spectrum-actiongroup-quiet-compact-button-gap: var(--spectrum-global-dimension-size-25);
 }
+
+/* This is copied from our Flex component for now. */
+.flex-container {
+  /* this is necessary so that the inner margins don't affect anything outside */
+  display: flex;
+}
+
+.flex-gap {
+  /* apply a negative margin to counteract the margin on each item at the edges */
+  margin: calc(var(--row-gap) / -2) calc(var(--column-gap) / -2);
+
+  /* increase the width and height to account for this margin */
+  /* Add 1px to fix rounding error in Safari (╯°□°)╯︵ ┻━┻ */
+  width: calc(100% + calc(var(--column-gap) + 1px));
+  height: calc(100% + var(--row-gap));
+}
+
+.flex-gap > * {
+  /* apply half of the gap to each side of every item */
+  margin: calc(var(--row-gap) / 2) calc(var(--column-gap) / 2);
+}
+
 
 .spectrum-ActionGroup {
   display: flex;
   flex-wrap: wrap;
   isolation: isolate;
+  --column-gap: var(--spectrum-actionbuttongroup-text-button-gap-x);
+  --row-gap: var(--spectrum-actionbuttongroup-text-button-gap-y);
 
   .spectrum-ActionGroup-item {
     flex-shrink: 0;
-  }
-
-  .spectrum-ActionGroup-item + .spectrum-ActionGroup-item {
-    margin-inline-start: var(--spectrum-actionbuttongroup-text-button-gap-x);
   }
 
   &:focus {
@@ -37,17 +57,8 @@ governing permissions and limitations under the License.
   display: inline-flex;
   flex-direction: column;
   align-items: flex-start;
-
-  .spectrum-ActionGroup-item + .spectrum-ActionGroup-item {
-    margin-block-start: var(--spectrum-actionbuttongroup-text-button-gap-y);
-    margin-inline-start: var(--spectrum-actiongroup-button-gap-reset);
-  }
-
-  /* increase specificity (not sure why spectrum-css did this one) */
-  &.spectrum-ActionGroup--vertical {
-    margin-block-start: var(--spectrum-actionbuttongroup-text-button-gap-y);
-    margin-inline-start: var(--spectrum-actiongroup-button-gap-reset);
-  }
+  --column-gap: var(--spectrum-actiongroup-button-gap-reset);
+  --row-gap: var(--spectrum-actionbuttongroup-text-button-gap-y);
 
   .spectrum-ActionGroup-item {
     > :not(svg) {
@@ -68,17 +79,15 @@ governing permissions and limitations under the License.
 }
 
 .spectrum-ActionGroup--compact {
+  --column-gap: calc(-1 * var(--spectrum-actionbutton-border-size));
+  --row-gap: var(--spectrum-actiongroup-button-gap-reset);
+
   &.spectrum-ActionGroup--quiet {
-    .spectrum-ActionGroup-item + .spectrum-ActionGroup-item {
-      margin-inline-start: var(--spectrum-actiongroup-quiet-compact-button-gap);
-      margin-block-start: var(--spectrum-actiongroup-button-gap-reset);
-    }
+    --column-gap: var(--spectrum-actiongroup-quiet-compact-button-gap);
 
     &.spectrum-ActionGroup--vertical {
-      .spectrum-ActionGroup-item + .spectrum-ActionGroup-item {
-        margin-inline-start: var(--spectrum-actiongroup-button-gap-reset);
-        margin-block-start: var(--spectrum-actiongroup-quiet-compact-button-gap);
-      }
+      --column-gap: var(--spectrum-actiongroup-button-gap-reset);
+      --row-gap: var(--spectrum-actiongroup-quiet-compact-button-gap);
     }
   }
 
@@ -92,14 +101,11 @@ governing permissions and limitations under the License.
       &:first-child {
         border-start-start-radius: var(--spectrum-actionbutton-border-radius);
         border-end-start-radius: var(--spectrum-actionbutton-border-radius);
-        margin-inline-end: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
       }
 
       &:last-child {
         border-start-end-radius: var(--spectrum-actionbutton-border-radius);
         border-end-end-radius: var(--spectrum-actionbutton-border-radius);
-        margin-inline-start: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-        margin-inline-end: 0;
       }
 
       &.is-selected {
@@ -109,41 +115,25 @@ governing permissions and limitations under the License.
       &:hover {
         z-index: 2;
       }
-
-      & + .spectrum-ActionGroup-item {
-        margin-inline-start: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-        margin-inline-end: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-      }
     }
 
     &.spectrum-ActionGroup--vertical {
+      --column-gap: var(--spectrum-actiongroup-button-gap-reset);
+      --row-gap: calc(-1 * var(--spectrum-actionbutton-border-size));
+
       .spectrum-ActionGroup-item {
         border-radius: 0;
-
-        & + .spectrum-ActionGroup-item {
-          margin-block-start: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-          margin-block-end: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-          margin-inline-start: 0;
-          margin-inline-end: 0;
-        }
 
         &:first-child {
           border-start-start-radius: var(--spectrum-actionbutton-border-radius);
           border-start-end-radius: var(--spectrum-actionbutton-border-radius);
           border-radius: 0;
-          margin-block-end: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-          margin-inline-start: 0;
-          margin-inline-end: 0;
         }
 
         &:last-child {
           border-end-start-radius: var(--spectrum-actionbutton-border-radius);
           border-end-end-radius: var(--spectrum-actionbutton-border-radius);
           border-radius: 0;
-          margin-block-start: calc(-1 * var(--spectrum-actionbutton-border-size) / 2);
-          margin-block-end: 0;
-          margin-inline-start: 0;
-          margin-inline-end: 0;
         }
       }
     }

--- a/packages/@adobe/spectrum-css-temp/components/button/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/index.css
@@ -382,12 +382,3 @@ a.spectrum-ActionButton {
   inline-size: var(--spectrum-clearbutton-small-width);
   block-size: var(--spectrum-clearbutton-small-height);
 }
-
-/* Potentially temporary: Add back default margin between all buttons when adjacent */
-.spectrum-Button + .spectrum-Button {
-  margin-inline-start: var(--spectrum-buttongroup-button-gap-x);
-}
-
-.spectrum-ActionButton + .spectrum-ActionButton {
-  margin-inline-start: var(--spectrum-actionbuttongroup-text-button-gap-x);
-}

--- a/packages/@adobe/spectrum-css-temp/components/button/skin.css
+++ b/packages/@adobe/spectrum-css-temp/components/button/skin.css
@@ -390,16 +390,6 @@ governing permissions and limitations under the License.
       color: var(--spectrum-actionbutton-icon-color-selected);
     }
 
-    &:focus-ring {
-      background-color: var(--spectrum-actionbutton-background-color-selected-key-focus);
-      border-color: var(--spectrum-actionbutton-border-color-selected-key-focus);
-      color: var(--spectrum-actionbutton-text-color-selected-key-focus);
-
-      .spectrum-Icon {
-        color: var(--spectrum-actionbutton-icon-color-selected-key-focus);
-      }
-    }
-
     &:hover {
       background-color: var(--spectrum-actionbutton-background-color-selected-hover);
       border-color: var(--spectrum-actionbutton-border-color-selected-hover);
@@ -407,6 +397,16 @@ governing permissions and limitations under the License.
 
       .spectrum-Icon {
         color: var(--spectrum-actionbutton-icon-color-selected-hover);
+      }
+    }
+
+    &:focus-ring {
+      background-color: var(--spectrum-actionbutton-background-color-selected-key-focus);
+      border-color: var(--spectrum-actionbutton-border-color-selected-key-focus);
+      color: var(--spectrum-actionbutton-text-color-selected-key-focus);
+
+      .spectrum-Icon {
+        color: var(--spectrum-actionbutton-icon-color-selected-key-focus);
       }
     }
 

--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -50,34 +50,36 @@ function ActionGroup<T extends object>(props: SpectrumActionGroupProps<T>, ref: 
   let {styleProps} = useStyleProps(props);
 
   return (
-    <div
-      {...actionGroupProps}
-      {...styleProps}
-      ref={domRef}
-      className={
-        classNames(
-          styles,
-          'spectrum-ActionGroup',
-          {
-            'spectrum-ActionGroup--quiet': isQuiet,
-            'spectrum-ActionGroup--vertical': isVertical,
-            'spectrum-ActionGroup--compact': density === 'compact',
-            'spectrum-ActionGroup--justified': isJustified
-          },
-          otherProps.UNSAFE_className
-        )
-      }>
-      <Provider {...providerProps}>
-        {[...state.collection].map((item) => (
-          <ActionGroupItem
-            key={item.key}
-            onAction={onAction}
-            isDisabled={isDisabled}
-            isEmphasized={isEmphasized}
-            item={item}
-            state={state} />
-        ))}
-      </Provider>
+    <div {...styleProps} className={classNames(styles, 'flex-container', styleProps.className)}>
+      <div
+        {...actionGroupProps}
+        ref={domRef}
+        className={
+          classNames(
+            styles,
+            'flex-gap',
+            'spectrum-ActionGroup',
+            {
+              'spectrum-ActionGroup--quiet': isQuiet,
+              'spectrum-ActionGroup--vertical': isVertical,
+              'spectrum-ActionGroup--compact': density === 'compact',
+              'spectrum-ActionGroup--justified': isJustified
+            },
+            otherProps.UNSAFE_className
+          )
+        }>
+        <Provider {...providerProps}>
+          {[...state.collection].map((item) => (
+            <ActionGroupItem
+              key={item.key}
+              onAction={onAction}
+              isDisabled={isDisabled}
+              isEmphasized={isEmphasized}
+              item={item}
+              state={state} />
+          ))}
+        </Provider>
+      </div>
     </div>
   );
 }

--- a/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
+++ b/packages/@react-spectrum/actiongroup/stories/ActionGroup.stories.tsx
@@ -59,7 +59,7 @@ storiesOf('ActionGroup', module)
     'default',
     () => (
       <Flex UNSAFE_className={styles['container']} gap="size-200" width="100%" margin="size-100" justifyContent="center">
-        <Flex UNSAFE_className={classNames(styles, 'item', 'large')} justifyContent="center">
+        <div className={classNames(styles, 'item', 'large')}>
           <ActionGroup onAction={action('onAction')}>
             {
               docItems.map((itemProps) => (
@@ -67,9 +67,9 @@ storiesOf('ActionGroup', module)
               ))
             }
           </ActionGroup>
-        </Flex>
+        </div>
         <Divider orientation="vertical" size="M" />
-        <Flex UNSAFE_className={classNames(styles, 'item', 'large')} justifyContent="center">
+        <div className={classNames(styles, 'item', 'large')}>
           <ActionGroup onAction={action('onAction')}>
             {
               docItems.map((itemProps) => {
@@ -83,9 +83,9 @@ storiesOf('ActionGroup', module)
               })
             }
           </ActionGroup>
-        </Flex>
+        </div>
         <Divider orientation="vertical" size="M" />
-        <Flex UNSAFE_className={classNames(styles, 'item')} justifyContent="center">
+        <div className={classNames(styles, 'item')}>
           <ActionGroup onAction={action('onAction')}>
             {
               docItems.map((itemProps) => {
@@ -98,7 +98,7 @@ storiesOf('ActionGroup', module)
               })
             }
           </ActionGroup>
-        </Flex>
+        </div>
       </Flex>
     )
   )
@@ -223,11 +223,11 @@ storiesOf('ActionGroup', module)
 function render(props, items) {
   return (
     <Flex UNSAFE_className={styles['container']} gap="size-200" width="100%" margin="size-100" justifyContent="center">
-      <Flex UNSAFE_className={classNames(styles, 'item', 'large')} justifyContent="center">{renderText(props, items)}</Flex>
+      <div className={classNames(styles, 'item', 'large')}>{renderText(props, items)}</div>
       <Divider orientation="vertical" size="M" />
-      <Flex UNSAFE_className={classNames(styles, 'item', 'large')} justifyContent="center">{renderBoth(props, items)}</Flex>
+      <div className={classNames(styles, 'item', 'large')}>{renderBoth(props, items)}</div>
       <Divider orientation="vertical" size="M" />
-      <Flex UNSAFE_className={classNames(styles, 'item')} justifyContent="center">{renderIcons(props, items)}</Flex>
+      <div className={classNames(styles, 'item')}>{renderIcons(props, items)}</div>
     </Flex>
   );
 }

--- a/packages/@react-spectrum/actiongroup/stories/styles.css
+++ b/packages/@react-spectrum/actiongroup/stories/styles.css
@@ -10,6 +10,7 @@
 @media only screen and (max-width: 800px) {
   .container > div {
     flex-direction: column;
+    align-items: center;
   }
   .container > div [role='separator'],
   .container > div hr {

--- a/packages/@react-spectrum/button/docs/ActionButton.mdx
+++ b/packages/@react-spectrum/button/docs/ActionButton.mdx
@@ -52,14 +52,8 @@ A visible label can be provided by passing a string or a Text component as a chi
 
 ```tsx example
 <ActionButton>
-  Label only
-</ActionButton>
-<ActionButton>
   <Edit />
   <Text>Icon + Label</Text>
-</ActionButton>
-<ActionButton aria-label="Icon only">
-  <Edit />
 </ActionButton>
 ```
 
@@ -68,6 +62,12 @@ A visible label can be provided by passing a string or a Text component as a chi
 If no visible label is provided (e.g. an icon only button),
 an alternative text label must be provided to identify the control for accessibility. This should be added using
 the `aria-label` prop.
+
+```tsx example
+<ActionButton aria-label="Icon only">
+  <Edit />
+</ActionButton>
+```
 
 ### Internationalization
 

--- a/packages/@react-spectrum/button/docs/Button.mdx
+++ b/packages/@react-spectrum/button/docs/Button.mdx
@@ -43,19 +43,15 @@ category: Buttons
 
 ## Content
 
-Buttons can have a label, and icon, or both. An icon is provided by passing an icon component to the `icon` prop.
-A visible label can be provided by passing children.
+Buttons must have a visible label, and can optionally have an icon. Text only buttons accept a string
+as children. Icons can also be added as children, with a sibling [Text](Text.html) element for the label.
 
 ```tsx example
 import {Text} from '@react-spectrum/text';
 
-<Button variant="primary">Label only</Button>
 <Button variant="primary">
   <Bell />
   <Text>Icon + Label</Text>
-</Button>
-<Button variant="primary" aria-label="Icon only">
-  <Bell />
 </Button>
 ```
 
@@ -104,6 +100,12 @@ function Example() {
 
 ```tsx example
 <Button variant="primary">Save</Button>
+```
+
+### Quiet primary
+[View guidelines](https://spectrum.adobe.com/page/button/#Quiet)
+
+```tsx example
 <Button variant="primary" isQuiet>Save</Button>
 ```
 
@@ -112,6 +114,12 @@ function Example() {
 
 ```tsx example
 <Button variant="secondary">Save</Button>
+```
+
+### Quiet secondary
+[View guidelines](https://spectrum.adobe.com/page/button/#Quiet)
+
+```tsx example
 <Button variant="secondary" isQuiet>Save</Button>
 ```
 
@@ -121,6 +129,14 @@ function Example() {
 ```tsx example
 <View backgroundColor="positive" padding="size-300">
   <Button variant="overBackground">Save</Button>
+</View>
+```
+
+### Quiet over background
+[View guidelines](https://spectrum.adobe.com/page/button/#Quiet)
+
+```tsx example
+<View backgroundColor="positive" padding="size-300">
   <Button variant="overBackground" isQuiet>Save</Button>
 </View>
 ```
@@ -130,5 +146,18 @@ function Example() {
 
 ```tsx example
 <Button variant="negative">Save</Button>
+```
+
+### Quiet negative
+[View guidelines](https://spectrum.adobe.com/page/button/#Quiet)
+
+```tsx example
 <Button variant="negative" isQuiet>Save</Button>
+```
+
+### Disabled
+[View guidelines](https://spectrum.adobe.com/page/button/#Disabled)
+
+```tsx example
+<Button variant="cta" isDisabled>Save</Button>
 ```

--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -13,6 +13,7 @@
 import {action} from '@storybook/addon-actions';
 import {ActionButton} from '../';
 import Add from '@spectrum-icons/workflow/Add';
+import {Flex} from '@react-spectrum/layout';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/text';
@@ -26,7 +27,7 @@ storiesOf('Button/ActionButton', module)
   .add(
     'icon',
     () => (
-      <div>
+      <Flex gap="size-100">
         <ActionButton
           onPress={action('press')}
           onPressStart={action('pressstart')}
@@ -42,13 +43,13 @@ storiesOf('Button/ActionButton', module)
           <Text>Disabled</Text>
           <Add />
         </ActionButton>
-      </div>
+      </Flex>
     )
   )
   .add(
     'icon only',
     () => (
-      <div>
+      <Flex gap="size-100">
         <ActionButton
           onPress={action('press')}
           onPressStart={action('pressstart')}
@@ -62,7 +63,7 @@ storiesOf('Button/ActionButton', module)
           isDisabled>
           <Add />
         </ActionButton>
-      </div>
+      </Flex>
     )
   )
   .add(
@@ -76,7 +77,7 @@ storiesOf('Button/ActionButton', module)
 
 function render(props = {}) {
   return (
-    <div>
+    <Flex gap="size-100">
       <ActionButton
         onPress={action('press')}
         onPressStart={action('pressstart')}
@@ -92,6 +93,6 @@ function render(props = {}) {
         {...props}>
         Disabled
       </ActionButton>
-    </div>
+    </Flex>
   );
 }

--- a/packages/@react-spectrum/button/stories/Button.stories.tsx
+++ b/packages/@react-spectrum/button/stories/Button.stories.tsx
@@ -13,6 +13,7 @@
 import {action} from '@storybook/addon-actions';
 import Bell from '@spectrum-icons/workflow/Bell';
 import {Button} from '../';
+import {Flex} from '@react-spectrum/layout';
 import React from 'react';
 import {storiesOf} from '@storybook/react';
 import {Text} from '@react-spectrum/text';
@@ -26,7 +27,7 @@ storiesOf('Button', module)
   .add(
     'with icon',
     () => (
-      <div>
+      <Flex gap="size-200">
         <Button
           onPress={action('press')}
           onPressStart={action('pressstart')}
@@ -53,7 +54,7 @@ storiesOf('Button', module)
           <Bell />
           <Text>Quiet</Text>
         </Button>
-      </div>
+      </Flex>
     )
   )
   .add(
@@ -87,7 +88,7 @@ storiesOf('Button', module)
 
 function render(props: any = {}) {
   return (
-    <div>
+    <Flex gap="size-200">
       <Button
         onPress={action('press')}
         onPressStart={action('pressstart')}
@@ -113,6 +114,6 @@ function render(props: any = {}) {
         Quiet
       </Button>
       )}
-    </div>
+    </Flex>
   );
 }

--- a/packages/@react-spectrum/layout/src/Flex.tsx
+++ b/packages/@react-spectrum/layout/src/Flex.tsx
@@ -64,11 +64,20 @@ function Flex(props: FlexProps, ref: DOMRef<HTMLDivElement>) {
   // If no gaps, or native support exists, then we only need to render a single div.
   let style = {
     ...styleProps.style,
-    ...flexStyle.style,
-    columnGap: props.columnGap != null ? dimensionValue(props.columnGap) : undefined,
-    rowGap: props.rowGap != null ? dimensionValue(props.rowGap) : undefined,
-    gap: props.gap != null ? dimensionValue(props.gap) : undefined
+    ...flexStyle.style
   };
+
+  if (props.gap != null) {
+    style.gap = dimensionValue(props.gap);
+  }
+
+  if (props.columnGap != null) {
+    style.columnGap = dimensionValue(props.columnGap);
+  }
+
+  if (props.rowGap != null) {
+    style.rowGap = dimensionValue(props.rowGap);
+  }
 
   return (
     <div className={classNames(styles, 'flex', styleProps.className)} style={style} ref={domRef}>

--- a/packages/@react-spectrum/layout/src/flex.css
+++ b/packages/@react-spectrum/layout/src/flex.css
@@ -28,7 +28,8 @@
   margin: calc(var(--row-gap) / -2) calc(var(--column-gap) / -2);
 
   /* increase the width and height to account for this margin */
-  width: calc(100% + var(--column-gap));
+  /* Add 1px to fix rounding error in Safari (╯°□°)╯︵ ┻━┻ */
+  width: calc(100% + calc(var(--column-gap) + 1px));
   height: calc(100% + var(--row-gap));
 }
 


### PR DESCRIPTION
This fixes ActionGroup wrapping behavior so that there is space between the rows and no extra margin at the start of each row. It uses the same technique used by our `<Flex>` component to implement `gap`. We cannot actually use this component though due to API limitations, so for now, I've copied the CSS into action group. We should move this somewhere shared later so other things in Spectrum CSS can use it.