### PR TITLE
removing trailing comma from isQuiet story name

### DIFF
--- a/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
+++ b/packages/@react-spectrum/button/stories/ActionButton.stories.tsx
@@ -67,7 +67,7 @@ storiesOf('Button/ActionButton', module)
     )
   )
   .add(
-    'quiet,',
+    'isQuiet',
     () => render({isQuiet: true})
   )
   .add(


### PR DESCRIPTION
no jira

## 📝 Test Instructions:

Confirm that the ActionButton `isQuiet` story doesn't have a trialing comma

## 🧢 Your Project:
RSP
