### PR TITLE
changing div wrapping Button in Form to Flex

### DIFF
--- a/packages/@react-spectrum/provider/stories/Provider.stories.tsx
+++ b/packages/@react-spectrum/provider/stories/Provider.stories.tsx
@@ -13,6 +13,7 @@
 import {Button} from '@react-spectrum/button';
 import {Checkbox} from '@react-spectrum/checkbox';
 import customTheme from './custom-theme.css';
+import {Flex} from '@react-spectrum/layout';
 import {Form} from '@react-spectrum/form';
 import {Provider} from '../';
 import {Radio, RadioGroup} from '@react-spectrum/radio';
@@ -94,9 +95,9 @@ function render(props = {}) {
   return (
     <Provider {...props} UNSAFE_style={{padding: 50}}>
       <Form>
-        <div> {/* Extra div so that the button does not expand to 100% width */}
+        <Flex> {/* Extra div via Flex so that the button does not expand to 100% width */}
           <Button variant="primary">I am a button</Button>
-        </div>
+        </Flex>
         <TextField
           label="A text field"
           placeholder="Something"


### PR DESCRIPTION
no jira

Problem was the button was staying LTR when the language change to RTL and the rest of the form switched to right.
changing div wrapping Button in Form to Flex

## 📝 Test Instructions:

In the provider stories with a form, the button will now be RTL too.

## 🧢 Your Project:
RSP
