### PR TITLE
set modal min width to dialog min width

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/modal/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/modal/index.css
@@ -72,6 +72,7 @@ governing permissions and limitations under the License.
   /* Don't be bigger than the screen */
   max-height: var(--spectrum-dialog-max-height);
   max-width: 90vw;
+  min-width: var(--spectrum-dialog-min-width);
 
   border-radius: var(--spectrum-dialog-border-radius);
   outline: none; /* Firefox shows outline */


### PR DESCRIPTION
Adds a min-width to the modal equal to the dialog min width. This stops the contents of the dialog from spilling out of the modal at screen sizes smaller than 280 px like so: 
![image](https://user-images.githubusercontent.com/9661127/84307839-66c26b80-ab12-11ea-8534-faeb150a5e85.png)


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
