### PR TITLE
adding selected items to autofocus=true stories to menu/list

### DIFF
--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -395,7 +395,7 @@ storiesOf('ListBox', module)
   .add(
     'ListBox with autoFocus=true',
     () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} autoFocus>
+      <ListBox width={200} aria-labelledby="label" items={withSection} autoFocus defaultSelectedKeys={['Snake']} selectionMode="single">
         {item => (
           <Section key={item.name} items={item.children} title={item.name}>
             {item => <Item key={item.name}>{item.name}</Item>}

--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -405,18 +405,6 @@ storiesOf('ListBox', module)
     )
   )
   .add(
-    'ListBox with autoFocus=false',
-    () => (
-      <ListBox width={200} aria-labelledby="label" items={withSection} autoFocus={false}>
-        {item => (
-          <Section key={item.name} items={item.children} title={item.name}>
-            {item => <Item key={item.name}>{item.name}</Item>}
-          </Section>
-        )}
-      </ListBox>
-    )
-  )
-  .add(
     'ListBox with autoFocus=true, selectionMode=single, default selected key (uncontrolled)',
     () => (
       <ListBox width={200} aria-labelledby="label" items={withSection} autoFocus defaultSelectedKeys={['Snake']} selectionMode="single">

--- a/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
+++ b/packages/@react-spectrum/listbox/stories/ListBox.stories.tsx
@@ -395,6 +395,30 @@ storiesOf('ListBox', module)
   .add(
     'ListBox with autoFocus=true',
     () => (
+      <ListBox width={200} aria-labelledby="label" items={withSection} autoFocus>
+        {item => (
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
+          </Section>
+        )}
+      </ListBox>
+    )
+  )
+  .add(
+    'ListBox with autoFocus=false',
+    () => (
+      <ListBox width={200} aria-labelledby="label" items={withSection} autoFocus={false}>
+        {item => (
+          <Section key={item.name} items={item.children} title={item.name}>
+            {item => <Item key={item.name}>{item.name}</Item>}
+          </Section>
+        )}
+      </ListBox>
+    )
+  )
+  .add(
+    'ListBox with autoFocus=true, selectionMode=single, default selected key (uncontrolled)',
+    () => (
       <ListBox width={200} aria-labelledby="label" items={withSection} autoFocus defaultSelectedKeys={['Snake']} selectionMode="single">
         {item => (
           <Section key={item.name} items={item.children} title={item.name}>

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -293,6 +293,14 @@ storiesOf('MenuTrigger', module)
   )
   .add(
     'Menu with autoFocus=true',
+    () => render(defaultMenu, {}, {autoFocus: true})
+  )
+  .add(
+    'Menu with autoFocus=false',
+    () => render(defaultMenu, {}, {autoFocus: false})
+  )
+  .add(
+    'Menu with autoFocus=true, default selected key (uncontrolled)',
     () => render(defaultMenu, {}, {autoFocus: true, defaultSelectedKeys: ['Kangaroo']})
   )
   .add(

--- a/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
+++ b/packages/@react-spectrum/menu/stories/MenuTrigger.stories.tsx
@@ -293,7 +293,7 @@ storiesOf('MenuTrigger', module)
   )
   .add(
     'Menu with autoFocus=true',
-    () => render(defaultMenu, {}, {autoFocus: true})
+    () => render(defaultMenu, {}, {autoFocus: true, defaultSelectedKeys: ['Kangaroo']})
   )
   .add(
     'Menu with autoFocus="first"',


### PR DESCRIPTION
no jira

adding selected items to the autoFocus=true menu and listbox stories since they mean focus on the selected item. For listbox it worked without setting a selectionMode, but that seemed weird to focus on something that wasn't visible selected.

## 📝 Test Instructions:

autoFocus=true stories for menu and listbox focus on items now

## 🧢 Your Project:
RSP