### PR TITLE
Update calculation to accomodate for focus ring gap margin

### DIFF
--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -42,7 +42,7 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
       let buttonGroupChildren = Array.from(domRef.current.children) as HTMLElement[];
       // Calculate negative margin added by focus ring gap in css
       let marginStart = (parseInt(window.getComputedStyle(domRef.current)
-      .getPropertyValue('--spectrum-alias-focus-ring-gap')) || 0) * 2;
+      .getPropertyValue('--spectrum-alias-focus-ring-gap'), 10) || 0) * 2;
       // Accomodate for negative margin added to button group
       let maxX = domRef.current.offsetWidth - (marginStart || -1); // + 1 to account for rounding errors when marginStart is undef/null
 

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -40,11 +40,16 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
     if (domRef.current && orientation === 'horizontal') {
       setHasOverflow(false);
       let buttonGroupChildren = Array.from(domRef.current.children) as HTMLElement[];
-      let maxX = domRef.current.offsetWidth + 1; // + 1 to account for rounding errors
+      // Calculate negative margin added by focus ring gap in css
+      let marginStart = (parseInt(window.getComputedStyle(domRef.current)
+      .getPropertyValue('--spectrum-alias-focus-ring-gap')) || 0) * 2;
+      // Accomodate for negative margin added to button group
+      let maxX = domRef.current.offsetWidth - (marginStart || -1); // + 1 to account for rounding errors when marginStart is undef/null
 
       // If any buttons have negative X positions (align="end") or extend beyond
       // the width of the button group (align="start"), then switch to vertical.
-      if (buttonGroupChildren.some(child => child.offsetLeft < 0 || child.offsetLeft + child.offsetWidth > maxX)) {
+      // Accomodate for negative margin when checking child.offsetLeft
+      if (buttonGroupChildren.some(child => child.offsetLeft < marginStart || child.offsetLeft + child.offsetWidth > maxX)) {
         setHasOverflow(true);
       }
     }

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -41,15 +41,14 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
       setHasOverflow(false);
       let buttonGroupChildren = Array.from(domRef.current.children) as HTMLElement[];
       // Calculate negative margin added by focus ring gap in css
-      let marginStart = (parseInt(window.getComputedStyle(domRef.current)
-      .getPropertyValue('--spectrum-alias-focus-ring-gap'), 10) || 0) * 2;
+      let marginStart = (parseInt(window.getComputedStyle(domRef.current).marginLeft, 10) || 0);
       // Accomodate for negative margin added to button group
-      let maxX = domRef.current.offsetWidth - (marginStart || -1); // + 1 to account for rounding errors when marginStart is undef/null
+      let maxX = domRef.current.offsetWidth + (marginStart || 1); // + 1 to account for rounding errors when marginStart is undef/null
 
       // If any buttons have negative X positions (align="end") or extend beyond
       // the width of the button group (align="start"), then switch to vertical.
       // Accomodate for negative margin when checking child.offsetLeft
-      if (buttonGroupChildren.some(child => child.offsetLeft < marginStart || child.offsetLeft + child.offsetWidth > maxX)) {
+      if (buttonGroupChildren.some(child => child.offsetLeft < (-1 * marginStart) || child.offsetLeft + child.offsetWidth > maxX)) {
         setHasOverflow(true);
       }
     }


### PR DESCRIPTION
Noticed that the buttongroup button focus ring was a bit off, updated the calculation to take in account the negative margin applied by the halo focus ring.
![image](https://user-images.githubusercontent.com/9661127/84330109-5f638800-ab3b-11ea-9c44-ec75bbd25c28.png)


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
