### PR TITLE
Fix firefox buttongroup without breaking dialog headers

### DIFF
--- a/packages/@adobe/spectrum-css-temp/components/dialog/index.css
+++ b/packages/@adobe/spectrum-css-temp/components/dialog/index.css
@@ -195,21 +195,17 @@ governing permissions and limitations under the License.
 
 .spectrum-Dialog-buttonGroup {
   grid-area: buttonGroup;
+  /* this padding isn't built into the grid because it disappears with this buttonGroup */
+  padding-block-start: var(--spectrum-global-dimension-static-size-500);
   display: flex;
   justify-content: flex-end;
   /* this padding should be safe as button group is always end aligned */
   padding-inline-start: var(--spectrum-dialog-gap-size);
-  /* account for halo focus ring */
-  padding: calc(var(--spectrum-alias-focus-ring-gap) * 2);
-  /* this padding isn't built into the grid because it disappears with this buttonGroup */
-  padding-block-start: calc(calc(var(--spectrum-alias-focus-ring-gap) * 2) + var(--spectrum-global-dimension-static-size-500));
-  margin: calc(var(--spectrum-alias-focus-ring-gap) * -2);
-  /* fix so Firefox buttongroups properly calculate overflow and switch from horizontal to vertical when not enough room to render */
-  overflow: hidden;
+  /* Fixes Firefox buttongroup overflow (switch from horizontal buttongroup to vertical buttongroup) */
+  max-width: 100%;
 
   &.spectrum-Dialog-buttonGroup--noFooter {
     grid-area: footer-start / footer-start / buttonGroup-end / buttonGroup-end;
-    padding-inline-start: calc(var(--spectrum-alias-focus-ring-gap) * 2);
   }
 }
 

--- a/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
+++ b/packages/@react-spectrum/buttongroup/src/ButtonGroup.tsx
@@ -40,15 +40,10 @@ function ButtonGroup(props: SpectrumButtonGroupProps, ref: DOMRef<HTMLDivElement
     if (domRef.current && orientation === 'horizontal') {
       setHasOverflow(false);
       let buttonGroupChildren = Array.from(domRef.current.children) as HTMLElement[];
-      // Calculate negative margin added by focus ring gap in css
-      let marginStart = (parseInt(window.getComputedStyle(domRef.current).marginLeft, 10) || 0);
-      // Accomodate for negative margin added to button group
-      let maxX = domRef.current.offsetWidth + (marginStart || 1); // + 1 to account for rounding errors when marginStart is undef/null
-
+      let maxX = domRef.current.offsetWidth + 1; // + 1 to account for rounding errors
       // If any buttons have negative X positions (align="end") or extend beyond
       // the width of the button group (align="start"), then switch to vertical.
-      // Accomodate for negative margin when checking child.offsetLeft
-      if (buttonGroupChildren.some(child => child.offsetLeft < (-1 * marginStart) || child.offsetLeft + child.offsetWidth > maxX)) {
+      if (buttonGroupChildren.some(child => child.offsetLeft < 0 || child.offsetLeft + child.offsetWidth > maxX)) {
         setHasOverflow(true);
       }
     }


### PR DESCRIPTION
Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
