### PR TITLE
Fix scrolling to radios in Safari

### DIFF
--- a/packages/@react-aria/radio/src/useRadio.ts
+++ b/packages/@react-aria/radio/src/useRadio.ts
@@ -82,6 +82,7 @@ export function useRadio(props: RadioAriaProps, state: RadioGroupState, ref: Ref
       readOnly: isReadOnly,
       required: isRequired,
       checked,
+      value,
       onChange
     })
   };

--- a/packages/@react-aria/radio/src/useRadioGroup.ts
+++ b/packages/@react-aria/radio/src/useRadioGroup.ts
@@ -107,7 +107,7 @@ export function useRadioGroup(props: AriaRadioGroupProps, state: RadioGroupState
     if (nextElem) {
       // Call focus on nextElem so that keyboard navigation scrolls the radio into view
       nextElem.focus();
-      nextElem.click();
+      state.setSelectedValue(nextElem.value);
     }
   };
 

--- a/packages/@react-spectrum/radio/test/Radio.test.js
+++ b/packages/@react-spectrum/radio/test/Radio.test.js
@@ -148,6 +148,10 @@ describe('Radios', function () {
       });
     }
 
+    expect(radios[0].value).toBe('dogs');
+    expect(radios[1].value).toBe('cats');
+    expect(radios[2].value).toBe('dragons');
+
     expect(radios[0].checked).toBe(false);
     expect(radios[1].checked).toBe(false);
     expect(radios[2].checked).toBe(false);


### PR DESCRIPTION
Calling `.click()` in Safari prevented scrolling to that radio for some reason. Instead, update our state directly. Also ensure that we pass through the `value` prop to the `<input>` element.