### PR TITLE
Add missing dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ let rulesDirPlugin = require('eslint-plugin-rulesdir');
 rulesDirPlugin.RULES_DIR = './bin';
 
 module.exports = {
-  plugins: ['react', 'rulesdir', 'jsx-a11y', 'react-hooks', 'jest', 'import', 'monorepo'],
+  plugins: ['react', 'rulesdir', 'jsx-a11y', 'react-hooks', 'jest', 'monorepo'],
   extends: ['eslint:recommended'],
   parser: 'babel-eslint',
   parserOptions: {
@@ -16,7 +16,7 @@ module.exports = {
   },
   overrides: [{
     files: ['packages/**/*.ts', 'packages/**/*.tsx'],
-    plugins: ['react', 'rulesdir', 'jsx-a11y', 'react-hooks', 'jest', '@typescript-eslint', 'import', 'monorepo'],
+    plugins: ['react', 'rulesdir', 'jsx-a11y', 'react-hooks', 'jest', '@typescript-eslint', 'monorepo'],
     parser: '@typescript-eslint/parser',
     parserOptions: {
       ecmaFeatures: {
@@ -34,7 +34,7 @@ module.exports = {
   }, {
     files: ['**/test/**', '**/stories/**'],
     rules: {
-      'import/no-extraneous-dependencies': OFF,
+      'rulesdir/imports': OFF,
       'monorepo/no-internal-import': OFF
     }
   }],
@@ -49,13 +49,6 @@ module.exports = {
     'importSpectrumCSS': 'readonly',
     'jest': true,
     'expect': true
-  },
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.ts', '.tsx', '.js', '.jsx', '.json']
-      }
-    }
   },
   rules: {
     'comma-dangle': ERROR,
@@ -132,6 +125,7 @@ module.exports = {
 
     // custom rules
     'rulesdir/sort-imports': [ERROR],
+    'rulesdir/imports': [ERROR],
 
     // jsx-a11y rules
     'jsx-a11y/accessible-emoji': ERROR,
@@ -172,12 +166,6 @@ module.exports = {
     'jsx-a11y/media-has-caption': ERROR,
     'jsx-a11y/mouse-events-have-key-events': ERROR,
     'jsx-a11y/no-access-key': ERROR,
-    // 'jsx-a11y/no-autofocus': [
-    //   ERROR,
-    //   {
-    //     ignoreNonDOM: true
-    //   }
-    // ],
     'jsx-a11y/no-distracting-elements': ERROR,
     'jsx-a11y/no-interactive-element-to-noninteractive-role': ERROR,
     'jsx-a11y/no-noninteractive-element-interactions': [
@@ -247,7 +235,6 @@ module.exports = {
     'jsx-a11y/tabindex-no-positive': ERROR,
 
     // importing rules
-    'import/no-extraneous-dependencies': ERROR,
     'monorepo/no-internal-import': [
       ERROR,
       {

--- a/bin/imports.js
+++ b/bin/imports.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const findUp = require('find-up');
+const path = require('path');
+const fs = require('fs');
+const Module = require('module');
+
+module.exports = function (context) {
+  return {
+    ImportDeclaration(node) {
+      let source = node.source.value.replace(/^[a-z]+:/, '');
+      if (source.startsWith('.') || Module.builtinModules.includes(source)) {
+        return;
+      }
+
+      // Split the import specifier on slashes. If it starts with an @ then it's
+      // a scoped package, otherwise just take the first part.
+      let parts = source.split('/');
+      let pkgName = source.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0];
+
+      // Search for a package.json starting from the current filename
+      let pkgPath = findUp.sync('package.json', {cwd: path.dirname(context.getFilename())});
+      if (!pkgPath) {
+        return;
+      }
+
+      let pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+
+      // The only dev dependency should be spectrum-css.
+      if (exists(pkg.devDependencies, pkgName) && pkgName === '@adobe/spectrum-css-temp') {
+        return;
+      }
+
+      if (!exists(pkg.dependencies, pkgName) && !exists(pkg.peerDependencies, pkgName)) {
+        context.report({
+          node,
+          message: `Missing dependency on ${pkgName}.`,
+          fix(fixer) {
+            // Attempt to find a package in the monorepo. If the dep is for an external library,
+            // then we cannot auto fix it because we don't know the version to add.
+            let depPath = __dirname + '/../packages/' + pkgName + '/package.json';
+            if (!fs.existsSync(depPath)) {
+              return;
+            }
+
+            let depPkg = JSON.parse(fs.readFileSync(depPath, 'utf8'));
+
+            if (pkgName === '@react-spectrum/provider') {
+              pkg.peerDependencies = insertObject(pkg.peerDependencies, pkgName, depPkg.version);
+            } else {
+              pkg.dependencies = insertObject(pkg.dependencies, pkgName, depPkg.version);
+            }
+
+            fs.writeFileSync(pkgPath, JSON.stringify(pkg, false, 2) + '\n');
+
+            // Fake fix so eslint doesn't show the error.
+            return {
+              range: [0, 0],
+              text: ''
+            };
+          }
+        });
+      }
+    }
+  };
+};
+
+function exists(deps, name) {
+  return deps && deps[name];
+}
+
+// Insert a key into an object and sort it.
+function insertObject(obj, key, value) {
+  obj[key] = value;
+
+  let res = {};
+  for (let key of Object.keys(obj).sort()) {
+    res[key] = obj[key];
+  }
+
+  return res;
+}

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "core-js": "^3.0.0",
     "css-loader": "^2.1.1",
     "eslint": "^5.0.0",
-    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.5.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-monorepo": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "core-js": "^3.0.0",
     "css-loader": "^2.1.1",
     "eslint": "^5.0.0",
+    "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jest": "^22.5.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-monorepo": "^0.2.1",

--- a/packages/@react-aria/actiongroup/package.json
+++ b/packages/@react-aria/actiongroup/package.json
@@ -17,13 +17,14 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
+    "@react-aria/i18n": "^3.0.0-rc.2",
+    "@react-aria/interactions": "^3.0.0-rc.2",
+    "@react-aria/selection": "^3.0.0-alpha.1",
+    "@react-aria/utils": "^3.0.0-rc.2",
     "@react-stately/collections": "^3.0.0-alpha.1",
     "@react-stately/list": "^3.0.0-alpha.1",
-    "@react-aria/utils": "^3.0.0-rc.2",
-    "@react-aria/interactions": "^3.0.0-rc.2",
-    "@react-aria/i18n": "^3.0.0-rc.2",
-    "@react-aria/selection": "^3.0.0-alpha.1",
-    "@react-types/actiongroup": "^3.0.0-alpha.1"
+    "@react-types/actiongroup": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-aria/breadcrumbs/package.json
+++ b/packages/@react-aria/breadcrumbs/package.json
@@ -21,7 +21,8 @@
     "@react-aria/interactions": "^3.0.0-rc.2",
     "@react-aria/link": "^3.0.0-alpha.1",
     "@react-aria/utils": "^3.0.0-rc.2",
-    "@react-types/breadcrumbs": "^3.0.0-alpha.1"
+    "@react-types/breadcrumbs": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-aria/calendar/package.json
+++ b/packages/@react-aria/calendar/package.json
@@ -23,6 +23,7 @@
     "@react-aria/live-announcer": "^3.0.0-alpha.1",
     "@react-aria/utils": "^3.0.0-alpha.1",
     "@react-stately/calendar": "^3.0.0-alpha.1",
+    "@react-types/button": "3.0.0-rc.2",
     "@react-types/calendar": "^3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-alpha.1",
     "date-fns": "^1.30.1"

--- a/packages/@react-aria/datepicker/package.json
+++ b/packages/@react-aria/datepicker/package.json
@@ -24,7 +24,9 @@
     "@react-aria/spinbutton": "^3.0.0-alpha.1",
     "@react-aria/utils": "^3.0.0-alpha.1",
     "@react-stately/datepicker": "^3.0.0-alpha.1",
+    "@react-types/button": "3.0.0-rc.2",
     "@react-types/datepicker": "^3.0.0-alpha.1",
+    "@react-types/dialog": "3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/packages/@react-aria/listbox/package.json
+++ b/packages/@react-aria/listbox/package.json
@@ -22,7 +22,8 @@
     "@react-aria/selection": "^3.0.0-alpha.1",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-stately/list": "^3.0.0-alpha.1",
-    "@react-types/listbox": "^3.0.0-alpha.1"
+    "@react-types/listbox": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-aria/menu/package.json
+++ b/packages/@react-aria/menu/package.json
@@ -24,6 +24,7 @@
     "@react-stately/collections": "^3.0.0-alpha.1",
     "@react-stately/menu": "^3.0.0-alpha.1",
     "@react-stately/tree": "^3.0.0-alpha.1",
+    "@react-types/button": "3.0.0-rc.2",
     "@react-types/menu": "^3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-rc.2"
   },

--- a/packages/@react-aria/numberfield/package.json
+++ b/packages/@react-aria/numberfield/package.json
@@ -23,6 +23,7 @@
     "@react-aria/textfield": "^3.0.0-rc.2",
     "@react-aria/utils": "^3.0.0-alpha.1",
     "@react-stately/numberfield": "^3.0.0-alpha.1",
+    "@react-types/button": "3.0.0-rc.2",
     "@react-types/numberfield": "^3.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/packages/@react-aria/overlays/package.json
+++ b/packages/@react-aria/overlays/package.json
@@ -22,6 +22,7 @@
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-aria/visually-hidden": "^3.0.0-alpha.1",
     "@react-stately/overlays": "^3.0.0-alpha.1",
+    "@react-types/button": "3.0.0-rc.2",
     "@react-types/overlays": "^3.0.0-alpha.1",
     "dom-helpers": "^3.3.1"
   },

--- a/packages/@react-aria/searchfield/package.json
+++ b/packages/@react-aria/searchfield/package.json
@@ -22,6 +22,7 @@
     "@react-aria/textfield": "^3.0.0-rc.2",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-stately/searchfield": "^3.0.0-rc.2",
+    "@react-types/button": "3.0.0-rc.2",
     "@react-types/searchfield": "^3.0.0-rc.2",
     "@react-types/shared": "^3.0.0-rc.2"
   },

--- a/packages/@react-aria/select/package.json
+++ b/packages/@react-aria/select/package.json
@@ -25,7 +25,9 @@
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-aria/visually-hidden": "^3.0.0-alpha.1",
     "@react-stately/select": "^3.0.0-alpha.1",
-    "@react-types/select": "^3.0.0-alpha.1"
+    "@react-types/button": "3.0.0-rc.2",
+    "@react-types/select": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-aria/selection/package.json
+++ b/packages/@react-aria/selection/package.json
@@ -17,12 +17,13 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@react-aria/i18n": "^3.0.0-rc.2",
     "@react-aria/focus": "^3.0.0-rc.2",
+    "@react-aria/i18n": "^3.0.0-rc.2",
     "@react-aria/interactions": "^3.0.0-rc.2",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-stately/collections": "^3.0.0-alpha.1",
     "@react-stately/selection": "^3.0.0-alpha.1",
+    "@react-types/menu": "3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-rc.2"
   },
   "peerDependencies": {

--- a/packages/@react-aria/table/package.json
+++ b/packages/@react-aria/table/package.json
@@ -8,7 +8,9 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "source": "src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "repository": {
     "type": "git",
@@ -24,6 +26,8 @@
     "@react-stately/collections": "^3.0.0-alpha.1",
     "@react-stately/table": "^3.0.0-alpha.1",
     "@react-stately/virtualizer": "^3.0.0-alpha.1",
+    "@react-types/checkbox": "3.0.0-rc.2",
+    "@react-types/shared": "3.0.0-rc.2",
     "@react-types/table": "^3.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/packages/@react-aria/tabs/package.json
+++ b/packages/@react-aria/tabs/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-aria/utils": "^3.0.0-alpha.1",
-    "@react-stately/tabs": "^3.0.0-alpha.1"
+    "@react-stately/tabs": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-aria/toggle/package.json
+++ b/packages/@react-aria/toggle/package.json
@@ -21,8 +21,9 @@
     "@react-aria/interactions": "^3.0.0-rc.2",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-stately/toggle": "^3.0.0-rc.2",
-    "@react-types/switch": "^3.0.0-rc.2",
-    "@react-types/shared": "^3.0.0-rc.2"
+    "@react-types/checkbox": "3.0.0-rc.2",
+    "@react-types/shared": "^3.0.0-rc.2",
+    "@react-types/switch": "^3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-aria/tooltip/package.json
+++ b/packages/@react-aria/tooltip/package.json
@@ -18,10 +18,11 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.6.2",
-    "@react-aria/utils": "^3.0.0-alpha.1",
-    "@react-aria/overlays": "^3.0.0-alpha.1",
     "@react-aria/interactions": "^3.0.0-alpha.1",
+    "@react-aria/overlays": "^3.0.0-alpha.1",
+    "@react-aria/utils": "^3.0.0-alpha.1",
     "@react-stately/tooltip": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2",
     "@react-types/tooltip": "^3.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/packages/@react-spectrum/dialog/package.json
+++ b/packages/@react-spectrum/dialog/package.json
@@ -45,6 +45,7 @@
     "@react-spectrum/view": "^3.0.0-alpha.1",
     "@react-stately/overlays": "^3.0.0-alpha.1",
     "@react-stately/utils": "^3.0.0-rc.2",
+    "@react-types/button": "3.0.0-rc.2",
     "@react-types/dialog": "^3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-rc.2",
     "@spectrum-icons/ui": "^3.0.0-rc.2"

--- a/packages/@react-spectrum/image/package.json
+++ b/packages/@react-spectrum/image/package.json
@@ -31,7 +31,8 @@
     "@babel/runtime": "^7.6.2",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-spectrum/utils": "^3.0.0-rc.2",
-    "@react-types/image": "^3.0.0-alpha.1"
+    "@react-types/image": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "^3.0.0-alpha.1"

--- a/packages/@react-spectrum/layout/package.json
+++ b/packages/@react-spectrum/layout/package.json
@@ -32,6 +32,7 @@
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-spectrum/utils": "^3.0.0-rc.2",
     "@react-types/layout": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2",
     "classnames": "^2.2.6"
   },
   "devDependencies": {

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -45,6 +45,8 @@
     "@react-stately/list": "^3.0.0-alpha.1",
     "@react-stately/virtualizer": "^3.0.0-alpha.1",
     "@react-types/listbox": "^3.0.0-alpha.1",
+    "@react-types/menu": "3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2",
     "@spectrum-icons/ui": "^3.0.0-rc.2"
   },
   "devDependencies": {

--- a/packages/@react-spectrum/menu/package.json
+++ b/packages/@react-spectrum/menu/package.json
@@ -48,6 +48,7 @@
     "@react-stately/tree": "^3.0.0-alpha.1",
     "@react-stately/utils": "^3.0.0-rc.2",
     "@react-types/menu": "^3.0.0-alpha.1",
+    "@react-types/overlays": "3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-rc.2",
     "@spectrum-icons/ui": "^3.0.0-rc.2"
   },

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -44,7 +44,9 @@
     "@react-spectrum/text": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-rc.2",
     "@react-stately/select": "^3.0.0-alpha.1",
+    "@react-types/overlays": "3.0.0-alpha.1",
     "@react-types/select": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2",
     "@spectrum-icons/ui": "^3.0.0-rc.2"
   },
   "devDependencies": {

--- a/packages/@react-spectrum/searchfield/package.json
+++ b/packages/@react-spectrum/searchfield/package.json
@@ -35,6 +35,7 @@
     "@react-spectrum/utils": "^3.0.0-rc.2",
     "@react-stately/searchfield": "^3.0.0-rc.2",
     "@react-types/searchfield": "^3.0.0-rc.2",
+    "@react-types/textfield": "3.0.0-rc.2",
     "@spectrum-icons/ui": "^3.0.0-rc.2"
   },
   "devDependencies": {

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -8,14 +8,20 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "source": "src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "targets": {
     "main": {
-      "includeNodeModules": ["@adobe/spectrum-css-temp"]
+      "includeNodeModules": [
+        "@adobe/spectrum-css-temp"
+      ]
     },
     "module": {
-      "includeNodeModules": ["@adobe/spectrum-css-temp"]
+      "includeNodeModules": [
+        "@adobe/spectrum-css-temp"
+      ]
     }
   },
   "repository": {
@@ -25,17 +31,18 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-aria/focus": "^3.0.0-rc.2",
-    "@react-aria/table": "^3.0.0-alpha.1",
     "@react-aria/i18n": "^3.0.0-rc.2",
+    "@react-aria/table": "^3.0.0-alpha.1",
     "@react-aria/utils": "^3.0.0-alpha.1",
     "@react-aria/virtualizer": "^3.0.0-alpha.1",
     "@react-spectrum/checkbox": "^3.0.0-rc.2",
+    "@react-spectrum/progress": "^3.0.0-rc.2",
     "@react-spectrum/utils": "^3.0.0-alpha.1",
     "@react-stately/collections": "^3.0.0-alpha.1",
-    "@react-stately/table": "^3.0.0-alpha.1",
     "@react-stately/layout": "^3.0.0-alpha.1",
+    "@react-stately/table": "^3.0.0-alpha.1",
     "@react-stately/virtualizer": "^3.0.0-alpha.1",
-    "@react-spectrum/progress": "^3.0.0-rc.2",
+    "@react-types/shared": "3.0.0-rc.2",
     "@react-types/table": "^3.0.0-alpha.1",
     "@spectrum-icons/ui": "^3.0.0-rc.2"
   },

--- a/packages/@react-spectrum/tabs/package.json
+++ b/packages/@react-spectrum/tabs/package.json
@@ -33,6 +33,7 @@
     "@react-aria/tabs": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-alpha.1",
     "@react-stately/tabs": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2",
     "classnames": "^2.2.5"
   },
   "devDependencies": {

--- a/packages/@react-spectrum/test-utils/package.json
+++ b/packages/@react-spectrum/test-utils/package.json
@@ -29,9 +29,12 @@
     "url": "https://github.com/adobe-private/react-spectrum-v3"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.2"
+    "@babel/runtime": "^7.6.2",
+    "@react-spectrum/layout": "3.0.0-alpha.1",
+    "@react-spectrum/theme-default": "3.0.0-rc.2"
   },
   "peerDependencies": {
+    "@react-spectrum/provider": "3.0.0-rc.2",
     "@testing-library/react": "^8.0.1",
     "react": "^16.8.0"
   },

--- a/packages/@react-spectrum/text/package.json
+++ b/packages/@react-spectrum/text/package.json
@@ -31,6 +31,7 @@
     "@babel/runtime": "^7.6.2",
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-spectrum/utils": "^3.0.0-rc.2",
+    "@react-types/shared": "3.0.0-rc.2",
     "@react-types/text": "^3.0.0-alpha.1"
   },
   "devDependencies": {

--- a/packages/@react-spectrum/textfield/package.json
+++ b/packages/@react-spectrum/textfield/package.json
@@ -36,6 +36,7 @@
     "@react-spectrum/form": "^3.0.0-rc.2",
     "@react-spectrum/label": "^3.0.0-rc.2",
     "@react-spectrum/utils": "^3.0.0-rc.2",
+    "@react-types/shared": "3.0.0-rc.2",
     "@react-types/textfield": "^3.0.0-rc.2",
     "@spectrum-icons/ui": "^3.0.0-rc.2"
   },

--- a/packages/@react-spectrum/tooltip/package.json
+++ b/packages/@react-spectrum/tooltip/package.json
@@ -36,10 +36,11 @@
     "@react-aria/utils": "^3.0.0-rc.2",
     "@react-spectrum/overlays": "^3.0.0-alpha.1",
     "@react-spectrum/utils": "^3.0.0-alpha.1",
-    "@react-stately/utils": "^3.0.0-alpha.1",
     "@react-stately/tooltip": "^3.0.0-alpha.1",
-    "@react-types/tooltip": "^3.0.0-alpha.1",
-    "@react-types/shared": "^3.0.0-rc.1"
+    "@react-stately/utils": "^3.0.0-alpha.1",
+    "@react-types/overlays": "3.0.0-alpha.1",
+    "@react-types/shared": "^3.0.0-rc.1",
+    "@react-types/tooltip": "^3.0.0-alpha.1"
   },
   "devDependencies": {
     "@adobe/spectrum-css-temp": "^3.0.0-alpha.1"

--- a/packages/@react-stately/calendar/package.json
+++ b/packages/@react-stately/calendar/package.json
@@ -21,6 +21,7 @@
     "@react-aria/i18n": "^3.0.0-alpha.1",
     "@react-stately/utils": "^3.0.0-alpha.1",
     "@react-types/calendar": "^3.0.0-alpha.1",
+    "@react-types/datepicker": "3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-alpha.1",
     "date-fns": "^1.30.1",
     "react": "^16.8.0"

--- a/packages/@react-stately/list/package.json
+++ b/packages/@react-stately/list/package.json
@@ -19,7 +19,8 @@
     "@babel/runtime": "^7.6.2",
     "@react-stately/collections": "^3.0.0-alpha.1",
     "@react-stately/selection": "^3.0.0-alpha.1",
-    "@react-stately/utils": "^3.0.0-rc.2"
+    "@react-stately/utils": "^3.0.0-rc.2",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-stately/numberfield/package.json
+++ b/packages/@react-stately/numberfield/package.json
@@ -20,7 +20,8 @@
     "@babel/runtime": "^7.6.2",
     "@react-aria/utils": "^3.0.0-alpha.1",
     "@react-stately/utils": "^3.0.0-alpha.1",
-    "@react-types/numberfield": "^3.0.0-alpha.1"
+    "@react-types/numberfield": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-stately/select/package.json
+++ b/packages/@react-stately/select/package.json
@@ -22,7 +22,8 @@
     "@react-stately/menu": "^3.0.0-alpha.1",
     "@react-stately/selection": "^3.0.0-alpha.1",
     "@react-stately/utils": "^3.0.0-rc.2",
-    "@react-types/select": "^3.0.0-alpha.1"
+    "@react-types/select": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-stately/selection/package.json
+++ b/packages/@react-stately/selection/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-stately/collections": "^3.0.0-alpha.1",
-    "@react-stately/utils": "^3.0.0-rc.2"
+    "@react-stately/utils": "^3.0.0-rc.2",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/@react-stately/splitview/package.json
+++ b/packages/@react-stately/splitview/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/runtime": "^7.6.2",
     "@react-stately/utils": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2",
     "react": "^16.8.0"
   },
   "devDependencies": {

--- a/packages/@react-stately/table/package.json
+++ b/packages/@react-stately/table/package.json
@@ -8,7 +8,9 @@
   "module": "dist/module.js",
   "types": "dist/types.d.ts",
   "source": "src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "repository": {
     "type": "git",
@@ -19,6 +21,7 @@
     "@react-stately/collections": "^3.0.0-alpha.1",
     "@react-stately/selection": "^3.0.0-alpha.1",
     "@react-stately/utils": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2",
     "@react-types/table": "^3.0.0-alpha.1"
   },
   "peerDependencies": {

--- a/packages/@react-types/menu/package.json
+++ b/packages/@react-types/menu/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/adobe-private/react-spectrum-v3"
   },
   "dependencies": {
+    "@react-types/overlays": "3.0.0-alpha.1",
     "@react-types/shared": "^3.0.0-rc.2"
   },
   "peerDependencies": {

--- a/packages/@react-types/meter/package.json
+++ b/packages/@react-types/meter/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/adobe-private/react-spectrum-v3"
   },
   "dependencies": {
+    "@react-types/progress": "3.0.0-rc.2",
     "@react-types/shared": "^3.0.0-rc.2"
   },
   "peerDependencies": {

--- a/packages/@react-types/tooltip/package.json
+++ b/packages/@react-types/tooltip/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/adobe-private/react-spectrum-v3"
   },
   "dependencies": {
-    "@react-types/overlays": "^3.0.0-alpha.1"
+    "@react-types/overlays": "^3.0.0-alpha.1",
+    "@react-types/shared": "3.0.0-rc.2"
   },
   "peerDependencies": {
     "react": "^16.12.0"


### PR DESCRIPTION
This adds missing dependencies that weren't caught by our existing linter, which didn't handle types imports correctly. I've replaced it with a custom lint rule that supports this, and also added an auto fixer.