### PR TITLE
Ensure cta is the first button in dialog docs

### DIFF
--- a/packages/@react-spectrum/dialog/docs/Dialog.mdx
+++ b/packages/@react-spectrum/dialog/docs/Dialog.mdx
@@ -221,8 +221,8 @@ function Example() {
           <Heading>Profile</Heading>
           <Divider />
           <ButtonGroup>
-            <Button autoFocus variant="cta" onPress={() => alertSave(close)}>Save</Button>
             <Button variant="secondary" onPress={() => alertCancel(close)}>Cancel</Button>
+            <Button autoFocus variant="cta" onPress={() => alertSave(close)}>Save</Button>
           </ButtonGroup>
           <Content>
             <Form>
@@ -339,8 +339,8 @@ respectively for container sizing considerations. Modal sizes on mobile devices 
       <Heading>Profile</Heading>
       <Divider />
       <ButtonGroup>
-        <Button autoFocus variant="cta" onPress={close}>Save</Button>
         <Button variant="secondary" onPress={close}>Cancel</Button>
+        <Button autoFocus variant="cta" onPress={close}>Save</Button>
       </ButtonGroup>
       <Content>
         <Form>
@@ -360,8 +360,8 @@ respectively for container sizing considerations. Modal sizes on mobile devices 
       <Heading>Profile</Heading>
       <Divider />
       <ButtonGroup>
-        <Button autoFocus variant="cta" onPress={close}>Save</Button>
         <Button variant="secondary" onPress={close}>Cancel</Button>
+        <Button autoFocus variant="cta" onPress={close}>Save</Button>
       </ButtonGroup>
       <Content>
         <Form>
@@ -381,8 +381,8 @@ respectively for container sizing considerations. Modal sizes on mobile devices 
       <Heading>Profile</Heading>
       <Divider />
       <ButtonGroup>
-        <Button autoFocus variant="cta" onPress={close}>Save</Button>
         <Button variant="secondary" onPress={close}>Cancel</Button>
+        <Button autoFocus variant="cta" onPress={close}>Save</Button>
       </ButtonGroup>
       <Content>
         <Form>


### PR DESCRIPTION
This ensures the docs are correct per https://spectrum.adobe.com/page/dialog/#Primary-action-label.
> The primary action label is for the first (right-most) button.


## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

React Spectrum
