### PR TITLE
Fix status light types

### DIFF
--- a/packages/@react-types/statuslight/src/index.d.ts
+++ b/packages/@react-types/statuslight/src/index.d.ts
@@ -15,7 +15,7 @@ import {ReactNode} from 'react';
 
 export interface SpectrumStatusLightProps extends DOMProps, StyleProps {
   /** The content to display as the label. */
-  children: ReactNode,
+  children?: ReactNode,
   /**
    * The variant changes the color of the status light.
    * When status lights have a semantic meaning, they should use the variant for semantic colors.
@@ -24,7 +24,7 @@ export interface SpectrumStatusLightProps extends DOMProps, StyleProps {
   /** Whether the status light is disabled. */
   isDisabled?: boolean,
   /**
-   * An accessibility role for the status light. Should be set when the status 
+   * An accessibility role for the status light. Should be set when the status
    * can change at runtime, and no more than one status light will update simultaneously.
    * For cases where multiple statuses can change at the same time, use a Toast instead.
    */


### PR DESCRIPTION
Children shouldn't be required. You can provide an `aria-label` instead.