### PR TITLE
Mark useTextField's  parameter as optional

### DIFF
--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -30,7 +30,7 @@ interface TextFieldAria {
  */
 export function useTextField(
   props: AriaTextFieldProps,
-  ref: RefObject<HTMLInputElement>
+  ref?: RefObject<HTMLInputElement>
 ): TextFieldAria {
   let {
     isDisabled = false,


### PR DESCRIPTION
The only thing that it is used for is `useFocusable` and as `ref` is optional for `useFocusable` itself:
https://github.com/adobe-private/react-spectrum-v3/blob/4c53104f80ba25c112bb27ed3591b5d0e0c26a24/packages/%40react-aria/focus/src/useFocusable.ts#L22
then I would say that this should be optional for `useTextField` as well. One might not want to use `autoFocus` at all so requiring a ref just for not used feature seems like overkill.