### PR TITLE
Move children prop definition from RadioGroupProps to SpectrumRadioGroupProps

### DIFF
--- a/packages/@react-types/radio/src/index.d.ts
+++ b/packages/@react-types/radio/src/index.d.ts
@@ -27,10 +27,6 @@ import {ReactElement, ReactNode} from 'react';
 
 export interface RadioGroupProps extends ValueBase<string>, InputBase, Validation, LabelableProps {
   /**
-   * The Radio(s) contained within the RadioGroup.
-   */
-  children: ReactElement<RadioProps> | ReactElement<RadioProps>[],
-  /**
    * The axis the Radio Button(s) should align with.
    * @default 'vertical'
    */
@@ -61,6 +57,10 @@ export interface RadioProps extends FocusableProps {
 
 export interface AriaRadioGroupProps extends RadioGroupProps, DOMProps, AriaLabelingProps, AriaValidationProps {}
 export interface SpectrumRadioGroupProps extends AriaRadioGroupProps, SpectrumLabelableProps, StyleProps {
+  /**
+   * The Radio(s) contained within the RadioGroup.
+   */
+  children: ReactElement<RadioProps> | ReactElement<RadioProps>[],
   /**
    * By default, radio buttons are not emphasized (gray).
    * The emphasized (blue) version provides visual prominence.


### PR DESCRIPTION
`AriaRadioGroupProps` depends on `RadioGroupProps` and is an input type for `useRadioGroup`, as this hook is not responsible for rendering it doesn't really depend on things like `children` so it doesn't make sense to require it there. From what I understand this prop might actually be needed for `SpectrumRadioGroupProps` as it's the puzzle piece that is responsible for actual rendering 😉 