### PR TITLE
Accessible colors for syntax highlighting

### DIFF
--- a/packages/dev/docs/src/PropTable.js
+++ b/packages/dev/docs/src/PropTable.js
@@ -81,14 +81,14 @@ export function PropTable({component, links}) {
   return (
     <>
       <TypeContext.Provider value={links}>
-        <InterfaceType properties={ungrouped} showRequired showDefault />
+        <InterfaceType properties={ungrouped} showRequired showDefault isComponent />
         {Object.keys(groups).map(group => (
           <details>
             <summary className={typographyStyles['spectrum-Heading4']}>
               <ChevronRight size="S" />
               {group}
             </summary>
-            <InterfaceType properties={groups[group]} showRequired showDefault />
+            <InterfaceType properties={groups[group]} showRequired showDefault isComponent />
           </details>
         ))}
       </TypeContext.Provider>

--- a/packages/dev/docs/src/syntax-highlight.css
+++ b/packages/dev/docs/src/syntax-highlight.css
@@ -14,15 +14,16 @@
 .spectrum {
   --hljs-color: var(--spectrum-global-color-gray-800);
   --hljs-background: var(--spectrum-global-color-gray-75);
-  --hljs-keyword-color: var(--spectrum-global-color-fuchsia-600);
+  --hljs-keyword-color: var(--spectrum-global-color-fuchsia-700);
   --hljs-section-color: var(--spectrum-global-color-red-600);
-  --hljs-string-color: var(--spectrum-global-color-celery-600);
-  --hljs-literal-color: var(--spectrum-global-color-orange-600);
-  --hljs-attribute-color: var(--spectrum-global-color-orange-600);
-  --hljs-class-color: var(--spectrum-global-color-yellow-600);
+  --hljs-string-color: var(--spectrum-global-color-green-600);
+  --hljs-literal-color: var(--spectrum-global-color-purple-700);
+  --hljs-attribute-color: var(--spectrum-global-color-indigo-700);
+  --hljs-class-color: var(--spectrum-global-color-seafoam-600);
   --hljs-function-color: var(--spectrum-global-color-blue-600);
-  --hljs-variable-color: var(--spectrum-global-color-yellow-600);
-  --hljs-title-color: var(--spectrum-global-color-indigo-600);
+  --hljs-variable-color: var(--spectrum-global-color-magenta-600);
+  --hljs-title-color: var(--spectrum-global-color-indigo-700);
+  --hljs-comment-color: var(--spectrum-global-color-gray-700);
 }
 
 /** for now keep syntax highlighting different from prop table. we can join them later if need be,
@@ -40,7 +41,7 @@
 
 :global(.hljs-comment),
 :global(.hljs-quote) {
-  color: #a0a1a7;
+  color: var(--hljs-comment-color);
   font-style: italic;
 }
 
@@ -159,7 +160,7 @@
 }
 
 :global(.class-name) {
-  color: var(--hljs-section-color);
+  color: var(--hljs-class-color);
 }
 
 :global(.entity.attribute-name) {
@@ -183,6 +184,6 @@
 }
 
 :global(.comment) {
-  color: #a0a1a7;
+  color: var(--hljs-comment-color);
   font-style: italic;
 }

--- a/packages/dev/docs/src/types.js
+++ b/packages/dev/docs/src/types.js
@@ -307,7 +307,7 @@ function Parameter({name, value, default: defaultValue, rest}) {
   return (
     <>
       {rest && <span className="token punctuation">...</span>}
-      <span className="token hljs-attr">{name}</span>
+      <span className="token">{name}</span>
       {value &&
         <>
           <span className="token punctuation">: </span>
@@ -379,7 +379,7 @@ export function renderHTMLfromMarkdown(description) {
   return '';
 }
 
-export function InterfaceType({description, properties: props, showRequired, showDefault}) {
+export function InterfaceType({description, properties: props, showRequired, showDefault, isComponent}) {
   let properties = Object.values(props).filter(prop => prop.type === 'property' && prop.access !== 'private' && prop.access !== 'protected');
   let methods = Object.values(props).filter(prop => prop.type === 'method' && prop.access !== 'private' && prop.access !== 'protected');
 
@@ -424,7 +424,7 @@ export function InterfaceType({description, properties: props, showRequired, sho
               <tr key={index} className={tableStyles['spectrum-Table-row']}>
                 <td className={tableStyles['spectrum-Table-cell']} data-column="Name">
                   <code className={`${typographyStyles['spectrum-Code4']}`}>
-                    <span className="token hljs-attr">{prop.name}</span>
+                    <span className={`token ${isComponent ? 'hljs-attr' : 'hljs-variable'}`}>{prop.name}</span>
                   </code>
                   {!prop.optional && showRequired
                     ? <Asterisk size="XXS" UNSAFE_className={styles.requiredIcon} alt="Required" />
@@ -507,7 +507,7 @@ function ObjectType({properties, exact}) {
         if (value && value.type === 'function' && !optional && token === 'method') {
           return (
             <div key={property.key} style={{paddingLeft: '1.5em'}}>
-              <span className="token hljs-attr">{k}</span>
+              <span className="token hljs-function">{k}</span>
               <span className="token punctuation">(</span>
               <JoinList elements={value.parameters} joiner=", " />
               <span className="token punctuation">)</span>


### PR DESCRIPTION
This ensures the Spectrum colors we use for syntax highlighting are accessible for both light and dark theme. The celery, orange, and yellow are replaced with green, purple, and indigo.