### PR TITLE
Unify react versions in the packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@testing-library/react": "^10.0.3",
     "@testing-library/react-hooks": "^3.2.1",
     "@testing-library/user-event": "^10.3.1",
-    "@types/react": "^16.8.0",
+    "@types/react": "16.9.23",
     "@types/storybook__react": "^4.0.1",
     "@typescript-eslint/eslint-plugin": "^2.28.0",
     "@typescript-eslint/parser": "^2.28.0",

--- a/packages/@react-aria/tabs/src/useTabList.ts
+++ b/packages/@react-aria/tabs/src/useTabList.ts
@@ -22,11 +22,12 @@ interface AriaTabProps {
   isDisabled?: boolean,
   isSelected?: boolean,
   onSelect?: () => void,
-  id?: string
+  id?: string,
+  value: any
 }
 
 interface AriaTabsProps extends HTMLAttributes<HTMLElement>{
-  children?: ReactElement | ReactElement[],
+  children?: ReactElement<AriaTabProps> | ReactElement<AriaTabProps>[]
 }
 
 interface TabListAria {
@@ -100,7 +101,10 @@ export function useTabs(props: AriaTabsProps, state: any): TabsAria {
   });
 
   if (selectedTabId == null) {
-    selectedTabId = React.Children.toArray(props.children)[0].props.id;
+    let childArray = React.Children.toArray(props.children);
+    if (childArray.length && React.isValidElement(childArray[0])) {
+      selectedTabId = childArray[0].props.id;
+    }
   }
 
   return {

--- a/packages/@react-spectrum/tabs/src/TabList.tsx
+++ b/packages/@react-spectrum/tabs/src/TabList.tsx
@@ -69,7 +69,7 @@ export function TabList(props: TabListProps) {
 
   let renderTabs = () =>
     childArray.map((child) =>
-      child ? React.cloneElement(child, {
+      React.isValidElement(child) ? React.cloneElement(child, {
         isSelected: state.selectedItem === child.props.value,
         onSelect: () => state.setSelectedItem(child.props.value),
         isDisabled

--- a/packages/@react-stately/tabs/src/useTabListState.ts
+++ b/packages/@react-stately/tabs/src/useTabListState.ts
@@ -18,7 +18,7 @@ interface SingleSelectionBaseProps extends React.HTMLAttributes<HTMLElement> {
   defaultSelectedItem?: any,
   onSelectionChange?: (selectedItem: any) => void,
   typeToSelect?: boolean,
-  children?: ReactElement | ReactElement[]
+  children: ReactElement | ReactElement[]
 }
 
 export function useTabListState(props: SingleSelectionBaseProps): {selectedItem: any, setSelectedItem: (val: any) => void} {
@@ -34,7 +34,8 @@ export function useTabListState(props: SingleSelectionBaseProps): {selectedItem:
     defaultSelectedValue = getSelectedValue(childrenArray, props.defaultSelectedItem);
   }
 
-  let [selectedItem, setSelectedItem] = useControlledState(selectedValue, defaultSelectedValue || childrenArray[0].props.value, props.onSelectionChange);
+  let firstChildProps = React.isValidElement(childrenArray[0]) ? childrenArray[0].props : {};
+  let [selectedItem, setSelectedItem] = useControlledState(selectedValue, defaultSelectedValue || firstChildProps.value, props.onSelectionChange);
 
   // In the case that a uncontrolled tablist's child is removed/added, update the selected tab
   useEffect(() => {

--- a/packages/@react-types/listbox/package.json
+++ b/packages/@react-types/listbox/package.json
@@ -12,7 +12,7 @@
     "@react-types/shared": "3.0.0-rc.3"
   },
   "peerDependencies": {
-    "react": "^16.12.0"
+    "react": "^16.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/@react-types/menu/package.json
+++ b/packages/@react-types/menu/package.json
@@ -13,7 +13,7 @@
     "@react-types/shared": "3.0.0-rc.3"
   },
   "peerDependencies": {
-    "react": "^16.12.0"
+    "react": "^16.8.0"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4320,18 +4320,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@16.9.23":
   version "16.9.23"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.23.tgz#1a66c6d468ba11a8943ad958a8cb3e737568271c"
   integrity sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@^16.8.0":
-  version "16.9.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.8.tgz#6b01592193213263300f8b242a08b172cc49f63f"
-  integrity sha512-FlifFL8nuWkLqXG3F7UhjglhlONeIUbt+PZOz3fUEba85azJwXGxR18WYnOUfaLW6jt7fMykYO9TTM980em34A==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
2 things:
1. a couple instances where these had higher deps verses other packages
2. when running `tsc` with `skipLibCheck: false` there would be multiple conflicting copies of `@types/react` floating around. This attempts to unify on a single version and reduces the number of errors (when running the aformentioned command) from around ~200-300 to ~50.

This fixes a number of linting errors that occur with the `Tab` and `TabList` work. I know this is going to be reconsidered, so I provided workarounds for now.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

React Spectrum
