### PR TITLE
RSP-1746 [Safari/VoiceOver] Listbox options with aria-labelledby announce as "Text"

### DIFF
--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -84,7 +84,7 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
 
   // Safari with VoiceOver on macOS misreads options with aria-labelledby or aria-label as simply "text".
   // We should not map slots to the label and description on Safari and instead just have VoiceOver read the textContent. 
-  // WebKit issue: https://bugs.webkit.org/show_bug.cgi?id=209279
+  // https://bugs.webkit.org/show_bug.cgi?id=209279
   if (!isSafariMacOS) {
     optionProps['aria-label'] = props['aria-label'];
     optionProps['aria-labelledby'] = labelId;

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -84,6 +84,7 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
 
   // Safari with VoiceOver on macOS misreads options with aria-labelledby or aria-label as simply "text".
   // We should not map slots to the label and description on Safari and instead just have VoiceOver read the textContent. 
+  // WebKit issue: https://bugs.webkit.org/show_bug.cgi?id=209279
   if (!isSafariMacOS) {
     optionProps['aria-label'] = props['aria-label'];
     optionProps['aria-labelledby'] = labelId;

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -50,6 +50,13 @@ interface AriaOptionProps {
   isVirtualized?: boolean
 }
 
+const isSafariMacOS =
+  typeof window !== 'undefined' && window.navigator != null
+    ? /^Mac/.test(window.navigator.platform) &&
+      /Safari/.test(window.navigator.userAgent) &&
+      !/Chrome/.test(window.navigator.userAgent)
+    : false;
+
 /**
  * Provides the behavior and accessibility implementation for an option in a listbox.
  * See `useListBox` for more details about listboxes.
@@ -72,11 +79,16 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
   let optionProps = {
     role: 'option',
     'aria-disabled': isDisabled,
-    'aria-selected': isSelected,
-    'aria-label': props['aria-label'],
-    'aria-labelledby': labelId,
-    'aria-describedby': descriptionId
+    'aria-selected': isSelected
   };
+
+  // Safari with VoiceOver on macOS misreads options with aria-labelledby or aria-label as simply "text".
+  // We should not map slots to the label and description on Safari and instead just have VoiceOver read the textContent. 
+  if (!isSafariMacOS) {
+    optionProps['aria-label'] = props['aria-label'],
+    optionProps['aria-labelledby'] = labelId,
+    optionProps['aria-describedby'] = descriptionId
+  }
 
   if (isVirtualized) {
     optionProps['aria-posinset'] = state.collection.getItem(key).index + 1;

--- a/packages/@react-aria/listbox/src/useOption.ts
+++ b/packages/@react-aria/listbox/src/useOption.ts
@@ -85,9 +85,9 @@ export function useOption<T>(props: AriaOptionProps, state: ListState<T>, ref: R
   // Safari with VoiceOver on macOS misreads options with aria-labelledby or aria-label as simply "text".
   // We should not map slots to the label and description on Safari and instead just have VoiceOver read the textContent. 
   if (!isSafariMacOS) {
-    optionProps['aria-label'] = props['aria-label'],
-    optionProps['aria-labelledby'] = labelId,
-    optionProps['aria-describedby'] = descriptionId
+    optionProps['aria-label'] = props['aria-label'];
+    optionProps['aria-labelledby'] = labelId;
+    optionProps['aria-describedby'] = descriptionId;
   }
 
   if (isVirtualized) {


### PR DESCRIPTION
With Safari and VoiceOver, options using `aria-labelledby` or `aria-label` to label the item by referencing an internal content slot are announced simply as "Text". Fix may be to not use `aria-labelledby` or `aria-describedby` to label the option using slots, and simply allow the option to be labeled by its textContent.


Closes [RSP-1746](https://jira.corp.adobe.com/browse/RSP-1746)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [Issue RSP-1746](https://jira.corp.adobe.com/browse/RSP-1746).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

1. On MacOS with VoiceOver running, open https://reactspectrum.blob.core.windows.net/reactspectrum/4ac4e0d7a3c371215be9a6d990ca577266294815/storybook/iframe.html?id=listbox--with-semantic-elements-static in Safari
2. Navigate into the listbox
3. Verify that VoiceOver announces each option item using its full textContent, rather than just announcing "text"
4. In Chrome, VoiceOver will announce each item, but there will be a delay before the item description is announced, because aria-labelledby and and aria-describedby are still supported in Chrome.

## 🧢 Your Project:

Accessibility
