### PR TITLE
Icons - clean up api

### DIFF
--- a/packages/@react-aria/toast/src/useToast.ts
+++ b/packages/@react-aria/toast/src/useToast.ts
@@ -55,7 +55,7 @@ export function useToast(props: ToastAriaProps, state: ToastState): ToastAria {
     }
   };
 
-  let iconProps = variant ? {alt: formatMessage(variant)} : {};
+  let iconProps = variant ? {'aria-label': formatMessage(variant)} : {};
 
   let pauseTimer = () => {
     timer && timer.pause();

--- a/packages/@react-aria/toast/test/useToast.test.js
+++ b/packages/@react-aria/toast/test/useToast.test.js
@@ -37,16 +37,16 @@ describe('useToast', () => {
     let {actionButtonProps, closeButtonProps, iconProps, toastProps} = renderToastHook({}, {onRemove});
 
     expect(toastProps.role).toBe('alert');
-    expect(iconProps.alt).toBe(undefined);
+    expect(iconProps['aria-label']).toBe(undefined);
     expect(typeof actionButtonProps.onPress).toBe('function');
     expect(closeButtonProps['aria-label']).toBe('Close');
     expect(typeof closeButtonProps.onPress).toBe('function');
   });
 
-  it('variant sets icon alt property', function () {
+  it('variant sets icon aria-label property', function () {
     let {iconProps} = renderToastHook({variant: 'info'}, {onRemove});
 
-    expect(iconProps.alt).toBe('Info');
+    expect(iconProps['aria-label']).toBe('Info');
   });
 
   it('with a localized aria-label', () => {
@@ -54,7 +54,7 @@ describe('useToast', () => {
     let wrapper = ({children}) => <Provider locale={locale} theme={theme}>{children}</Provider>;
     let expectedIntl = intlMessages[locale]['info'];
     let {iconProps} = renderToastHook({variant: 'info'}, {onRemove}, wrapper);
-    expect(iconProps.alt).toBe(expectedIntl);
+    expect(iconProps['aria-label']).toBe(expectedIntl);
   });
 
   it('handles onClose', function () {

--- a/packages/@react-spectrum/alert/src/Alert.tsx
+++ b/packages/@react-spectrum/alert/src/Alert.tsx
@@ -58,7 +58,7 @@ export function Alert(props: SpectrumAlertProps) {
         )
       }
       role="alert">
-      <Icon UNSAFE_className={classNames(styles, 'spectrum-Alert-icon')} alt={iconAlt} />
+      <Icon UNSAFE_className={classNames(styles, 'spectrum-Alert-icon')} aria-label={iconAlt} />
       <div className={classNames(styles, 'spectrum-Alert-header')}>{title}</div>
       <div className={classNames(styles, 'spectrum-Alert-content')}>{children}</div>
     </div>

--- a/packages/@react-spectrum/icon/src/Icon.tsx
+++ b/packages/@react-spectrum/icon/src/Icon.tsx
@@ -21,9 +21,9 @@ type Scale = 'M' | 'L'
 
 interface IconProps extends DOMProps, AriaLabelingProps, StyleProps {
   /**
-   * Alternate text for assistive technologies
+   * A screen reader only label for the Icon.
    */
-  alt?: string,
+  'aria-label'?: string,
   /**
    * The content to display. Should be an SVG
    */
@@ -32,14 +32,6 @@ interface IconProps extends DOMProps, AriaLabelingProps, StyleProps {
    * Size of Icon (changes based on scale)
    */
   size?: 'XXS' | 'XS' | 'S' | 'M' | 'L' |'XL' | 'XXL',
-  /**
-   * TODO
-   */
-  scale?: Scale,
-  /**
-   * TODO
-   */
-  color?: string,
   /**
    * A slot to place the icon in.
    * @default 'icon'
@@ -58,9 +50,6 @@ export function Icon(props: IconProps) {
   props = useSlotProps(props, 'icon');
   let {
     children,
-    alt,
-    scale,
-    color,
     size,
     'aria-label': ariaLabel,
     'aria-hidden': ariaHidden,
@@ -69,17 +58,9 @@ export function Icon(props: IconProps) {
   let {styleProps} = useStyleProps(otherProps);
 
   let provider = useProvider();
-  let pscale = 'M';
-  let pcolor = 'LIGHT';
+  let scale = 'M';
   if (provider !== null) {
-    pscale = provider.scale === 'large' ? 'L' : 'M';
-    pcolor = provider.colorScheme === 'dark' ? 'DARK' : 'LIGHT';
-  }
-  if (scale === undefined) {
-    scale = pscale as Scale;
-  }
-  if (color === undefined) {
-    color = pcolor;
+    scale = provider.scale === 'large' ? 'L' : 'M';
   }
   if (!ariaHidden) {
     ariaHidden = undefined;
@@ -91,11 +72,9 @@ export function Icon(props: IconProps) {
   return React.cloneElement(children, {
     ...filterDOMProps(otherProps),
     ...styleProps,
-    scale: 'M',
-    color,
     focusable: 'false',
-    'aria-label': ariaLabel || alt,
-    'aria-hidden': (ariaLabel || alt ? (ariaHidden || undefined) : true),
+    'aria-label': ariaLabel,
+    'aria-hidden': (ariaLabel ? (ariaHidden || undefined) : true),
     role: 'img',
     className: classNames(
       styles,

--- a/packages/@react-spectrum/icon/src/UIIcon.tsx
+++ b/packages/@react-spectrum/icon/src/UIIcon.tsx
@@ -18,7 +18,6 @@ import styles from '@adobe/spectrum-css-temp/components/icon/vars.css';
 import {useProvider} from '@react-spectrum/provider';
 
 interface IconProps extends DOMProps, AriaLabelingProps, StyleProps {
-  alt?: string,
   children: ReactElement,
   slot?: string,
   /**
@@ -30,7 +29,6 @@ interface IconProps extends DOMProps, AriaLabelingProps, StyleProps {
 export function UIIcon(props: IconProps) {
   props = useSlotProps(props, 'icon');
   let {
-    alt,
     children,
     'aria-label': ariaLabel,
     'aria-hidden': ariaHidden,
@@ -53,8 +51,8 @@ export function UIIcon(props: IconProps) {
     ...styleProps,
     scale,
     focusable: 'false',
-    'aria-label': ariaLabel || alt,
-    'aria-hidden': (ariaLabel || alt ? (ariaHidden || undefined) : true),
+    'aria-label': ariaLabel,
+    'aria-hidden': (ariaLabel ? (ariaHidden || undefined) : true),
     role: 'img',
     className: classNames(
       styles,

--- a/packages/@react-spectrum/icon/test/Icon.test.js
+++ b/packages/@react-spectrum/icon/test/Icon.test.js
@@ -20,16 +20,12 @@ describe('Icon', function () {
   it.each`
     Name      | Component
     ${'Icon'} | ${Icon}
-  `('$Name handles alt texts', function ({Component}) {
+  `('$Name handles aria label', function ({Component}) {
     let {getByRole, rerender} = render(<Component aria-label="workflow icon"><FakeIcon /></Component>);
 
     let icon = getByRole('img');
     expect(icon).toHaveAttribute('focusable', 'false');
     expect(icon).toHaveAttribute('aria-label', 'workflow icon');
-
-    rerender(<Component alt="workflow alt"><FakeIcon /></Component>);
-    icon = getByRole('img');
-    expect(icon).toHaveAttribute('aria-label', 'workflow alt');
 
     rerender(<Component><FakeIcon /></Component>);
     icon = getByRole('img', {hidden: true});
@@ -50,10 +46,10 @@ describe('Icon', function () {
     Name      | Component
     ${'Icon'} | ${Icon}
   `('$Name supports aria-hidden prop', function ({Component}) {
-    let {getByRole, rerender} = render(<Component alt="explicitly hidden alt" aria-hidden><FakeIcon /></Component>);
+    let {getByRole, rerender} = render(<Component aria-label="explicitly hidden aria-label" aria-hidden><FakeIcon /></Component>);
 
     let icon = getByRole('img', {hidden: true});
-    expect(icon).toHaveAttribute('aria-label', 'explicitly hidden alt');
+    expect(icon).toHaveAttribute('aria-label', 'explicitly hidden aria-label');
     expect(icon).toHaveAttribute('aria-hidden', 'true');
 
     rerender(<Component aria-label="explicitly not hidden aria-label" aria-hidden={false}><FakeIcon /></Component>);

--- a/packages/@react-spectrum/icon/test/UIIcon.test.js
+++ b/packages/@react-spectrum/icon/test/UIIcon.test.js
@@ -27,10 +27,6 @@ describe('UIIcon', function () {
     expect(icon).toHaveAttribute('focusable', 'false');
     expect(icon).toHaveAttribute('aria-label', 'labelled icon');
 
-    rerender(<Component alt="workflow alt"><FakeIcon /></Component>);
-    icon = getByRole('img');
-    expect(icon).toHaveAttribute('aria-label', 'workflow alt');
-
     rerender(<Component><FakeIcon /></Component>);
     icon = getByRole('img', {hidden: true});
     expect(icon).not.toHaveAttribute('aria-label');
@@ -41,10 +37,10 @@ describe('UIIcon', function () {
     Name        | Component
     ${'UIIcon'} | ${UIIcon}
   `('$Name supports aria-hidden prop', function ({Component}) {
-    let {getByRole, rerender} = render(<Component alt="explicitly hidden alt" aria-hidden><FakeIcon /></Component>);
+    let {getByRole, rerender} = render(<Component aria-label="explicitly hidden aria-label" aria-hidden><FakeIcon /></Component>);
 
     let icon = getByRole('img', {hidden: true});
-    expect(icon).toHaveAttribute('aria-label', 'explicitly hidden alt');
+    expect(icon).toHaveAttribute('aria-label', 'explicitly hidden aria-label');
     expect(icon).toHaveAttribute('aria-hidden', 'true');
 
     rerender(<Component aria-label="explicitly not hidden aria-label" aria-hidden={false}><FakeIcon /></Component>);

--- a/packages/@react-spectrum/label/src/Label.tsx
+++ b/packages/@react-spectrum/label/src/Label.tsx
@@ -45,7 +45,7 @@ function Label(props: SpectrumLabelProps, ref: DOMRef<HTMLLabelElement>) {
   let icon = (
     <Asterisk
       UNSAFE_className={classNames(styles, 'spectrum-FieldLabel-requiredIcon')}
-      alt={includeNecessityIndicatorInAccessibilityName ? formatMessage('(required)') : undefined}
+      aria-label={includeNecessityIndicatorInAccessibilityName ? formatMessage('(required)') : undefined}
       size="S" />
   );
 

--- a/packages/@spectrum-icons/color/stories/IconsColor.stories.tsx
+++ b/packages/@spectrum-icons/color/stories/IconsColor.stories.tsx
@@ -17,7 +17,7 @@ import {storiesOf} from '@storybook/react';
 storiesOf('Icons/Color', module)
   .add(
     'Color icon with sizes',
-    () => renderIconSizes(CalendarCheckColor, {alt: 'Adobe Analytics Color'})
+    () => renderIconSizes(CalendarCheckColor, {'aria-label': 'Adobe Analytics Color'})
   );
 
 function renderIconSizes(Component, props) {

--- a/packages/@spectrum-icons/workflow/stories/IconsWorkflow.stories.tsx
+++ b/packages/@spectrum-icons/workflow/stories/IconsWorkflow.stories.tsx
@@ -19,16 +19,16 @@ import {storiesOf} from '@storybook/react';
 storiesOf('Icons/Workflow', module)
   .add(
     'icon: Add with sizes',
-    () => renderIconSizes(Add, {alt: 'Add'})
+    () => renderIconSizes(Add, {'aria-label': 'Add'})
   )
   .add(
     'icon: Bell with sizes',
-    () => renderIconSizes(Bell, {alt: 'Bell'})
+    () => renderIconSizes(Bell, {'aria-label': 'Bell'})
   )
   .add(
     'icon: _3DMaterials with sizes',
 
-    () => renderIconSizes(Icon3DMaterials, {alt: '3D Materials'})
+    () => renderIconSizes(Icon3DMaterials, {'aria-label': '3D Materials'})
   );
 
 function renderIconSizes(Component, props) {

--- a/packages/dev/docs/src/Layout.js
+++ b/packages/dev/docs/src/Layout.js
@@ -249,7 +249,7 @@ function Nav({currentPageName, pages}) {
       <header>
         {currentParts.length > 1 &&
           <a href="../index.html" className={docStyles.backBtn}>
-            <ChevronLeft alt="Back" />
+            <ChevronLeft aria-label="Back" />
           </a>
         }
         <a href="./index.html" className={docStyles.homeBtn}>

--- a/packages/dev/docs/src/types.js
+++ b/packages/dev/docs/src/types.js
@@ -427,7 +427,7 @@ export function InterfaceType({description, properties: props, showRequired, sho
                     <span className={`token ${isComponent ? 'hljs-attr' : 'hljs-variable'}`}>{prop.name}</span>
                   </code>
                   {!prop.optional && showRequired
-                    ? <Asterisk size="XXS" UNSAFE_className={styles.requiredIcon} alt="Required" />
+                    ? <Asterisk size="XXS" UNSAFE_className={styles.requiredIcon} aria-label="Required" />
                     : null
                   }
                 </td>

--- a/specs/api/Icon.md
+++ b/specs/api/Icon.md
@@ -11,13 +11,13 @@ governing permissions and limitations under the License. -->
 
 ```typescript
 interface Icon extends DOMProps, StyleProps {
-  alt?: string,
+  'aria-label'?: string,
   children: ReactElement,
   size?: 'XXS' | 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL'
 }
 
 interface UIIcon extends DOMProps, StyleProps {
-  alt?: string,
+  'aria-label'?: string,
   children: ReactElement
 }
 ```


### PR DESCRIPTION
Replaced alt prop with aria-label only.
Removed color as it is not supported.
Use scale from Provider.