### PR TITLE
Fix class of error No visible label

### DIFF
--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -437,7 +437,7 @@ describe('Shared TextField behavior', () => {
     ${'v3 TextArea'}    | ${TextArea}
     ${'v3 SearchField'} | ${SearchField}
   `('$Name supports excludeFromTabOrder', ({Name, Component}) => {
-    let tree = renderComponent(Component, {excludeFromTabOrder: true});
+    let tree = renderComponent(Component, {excludeFromTabOrder: true, 'aria-label': 'mandatory label});
     let input = tree.getByTestId(testId);
     expect(input).toHaveAttribute('tabIndex', '-1');
   });

--- a/packages/@react-spectrum/textfield/test/TextField.test.js
+++ b/packages/@react-spectrum/textfield/test/TextField.test.js
@@ -437,7 +437,7 @@ describe('Shared TextField behavior', () => {
     ${'v3 TextArea'}    | ${TextArea}
     ${'v3 SearchField'} | ${SearchField}
   `('$Name supports excludeFromTabOrder', ({Name, Component}) => {
-    let tree = renderComponent(Component, {excludeFromTabOrder: true, 'aria-label': 'mandatory label});
+    let tree = renderComponent(Component, {excludeFromTabOrder: true, 'aria-label': 'mandatory label'});
     let input = tree.getByTestId(testId);
     expect(input).toHaveAttribute('tabIndex', '-1');
   });


### PR DESCRIPTION
A new test was added that caused this warning   'If you do not provide a visible label, you must specify an aria-label or aria-labelledby attribute for accessibility'


Closes https://github.com/adobe-private/react-spectrum-v3/pull/502

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
