### PR TITLE
Fix error class both value and defaultValue props

### DIFF
--- a/packages/@react-aria/textfield/src/useTextField.ts
+++ b/packages/@react-aria/textfield/src/useTextField.ts
@@ -57,7 +57,7 @@ export function useTextField(
       'aria-autocomplete': props['aria-autocomplete'],
       'aria-haspopup': props['aria-haspopup'],
       value: props.value,
-      defaultValue: props.defaultValue,
+      defaultValue: props.value ? undefined : props.defaultValue,
       onChange: (e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value),
       autoComplete: props.autoComplete,
       maxLength: props.maxLength,


### PR DESCRIPTION
SearchField is causing this message anytime a defaultValue is specified on it because it just goes right through all the props and through the useTextField aria hook.

Fix error class   '%s contains an input of type %s with both value and defaultValue props',
I'm not sure this is the best way to do it, because this will silently protect people from having both value and defaultValue
I don't want to remove defaultValue because aria should view that as an acceptable prop
Maybe useControlledValue should export a function to remove the defaultValue and we call that in the component? seems like a lot to remember :(


Closes https://github.com/adobe-private/react-spectrum-v3/pull/502

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
