### PR TITLE
Move jsdoc descriptions to forwardRef

### DIFF
--- a/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
+++ b/packages/@react-spectrum/actiongroup/src/ActionGroup.tsx
@@ -25,9 +25,6 @@ import {useActionGroup} from '@react-aria/actiongroup';
 import {useActionGroupItem} from '@react-aria/actiongroup';
 import {useProviderProps} from '@react-spectrum/provider';
 
-/**
-* An ActionGroup is a grouping of ActionButtons that are related to one another.
-*/
 function ActionGroup<T extends object>(props: SpectrumActionGroupProps<T>, ref: DOMRef<HTMLDivElement>) {
   props = useProviderProps(props);
 
@@ -84,6 +81,9 @@ function ActionGroup<T extends object>(props: SpectrumActionGroupProps<T>, ref: 
   );
 }
 
+/**
+ * An ActionGroup is a grouping of ActionButtons that are related to one another.
+ */
 const _ActionGroup = forwardRef(ActionGroup) as <T>(props: SpectrumActionGroupProps<T> & {ref?: DOMRef<HTMLDivElement>}) => ReactElement;
 export {_ActionGroup as ActionGroup};
 

--- a/packages/@react-spectrum/layout/src/Flex.tsx
+++ b/packages/@react-spectrum/layout/src/Flex.tsx
@@ -25,10 +25,6 @@ export const flexStyleProps: StyleHandlers = {
   alignContent: ['alignContent', flexAlignValue]
 };
 
-/**
- * A layout container using flexbox. Provides Spectrum dimension values, and supports the gap
- * property to define consistent spacing between items.
- */
 function Flex(props: FlexProps, ref: DOMRef<HTMLDivElement>) {
   let {
     children,
@@ -141,5 +137,9 @@ function isFlexGapSupported() {
   return _isFlexGapSupported;
 }
 
+/**
+ * A layout container using flexbox. Provides Spectrum dimension values, and supports the gap
+ * property to define consistent spacing between items.
+ */
 const _Flex = forwardRef(Flex);
 export {_Flex as Flex};

--- a/packages/@react-spectrum/layout/src/Grid.tsx
+++ b/packages/@react-spectrum/layout/src/Grid.tsx
@@ -40,10 +40,6 @@ export const gridStyleProps: StyleHandlers = {
   alignContent: ['alignContent', passthroughStyle]
 };
 
-/**
- * A layout container using CSS grid. Supports Spectrum dimensions as values to
- * ensure consistent and adaptive sizing and spacing.
- */
 function Grid(props: GridProps, ref: DOMRef<HTMLDivElement>) {
   let {
     children,
@@ -109,5 +105,9 @@ function gridTemplateValue(value) {
   return gridDimensionValue(value);
 }
 
+/**
+ * A layout container using CSS grid. Supports Spectrum dimensions as values to
+ * ensure consistent and adaptive sizing and spacing.
+ */
 const _Grid = forwardRef(Grid);
 export {_Grid as Grid};

--- a/packages/@react-spectrum/radio/src/Radio.tsx
+++ b/packages/@react-spectrum/radio/src/Radio.tsx
@@ -78,6 +78,7 @@ function Radio(props: SpectrumRadioProps, ref: FocusableRef<HTMLLabelElement>) {
     </label>
   );
 }
+
 /**
  * Radio buttons allow users to select a single option from a list of mutually exclusive options.
  * All possible options are exposed up front for users to compare.

--- a/packages/@react-spectrum/radio/src/RadioGroup.tsx
+++ b/packages/@react-spectrum/radio/src/RadioGroup.tsx
@@ -103,5 +103,9 @@ function RadioGroup(props: SpectrumRadioGroupProps, ref: DOMRef<HTMLDivElement>)
   );
 }
 
+/**
+ * Radio groups allow users to select a single option from a list of mutually exclusive options.
+ * All possible options are exposed up front for users to compare.
+ */
 const _RadioGroup = React.forwardRef(RadioGroup);
 export {_RadioGroup as RadioGroup};

--- a/packages/@react-spectrum/statuslight/src/StatusLight.tsx
+++ b/packages/@react-spectrum/statuslight/src/StatusLight.tsx
@@ -61,6 +61,5 @@ function StatusLight(props: SpectrumStatusLightProps, ref: DOMRef<HTMLDivElement
  * Status lights are used to color code categories and labels commonly found in data visualization.
  * When status lights have a semantic meaning, they should use semantic variant colors.
  */
-
 let _StatusLight = forwardRef(StatusLight);
 export {_StatusLight as StatusLight};


### PR DESCRIPTION
The descriptions must be on the forwardRef assignment, not on the original function for TS to pick them up when generating d.ts files for publishing.