### PR TITLE
changing the provider nested lang check to a dir check

### DIFF
--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -149,10 +149,10 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(props: Provide
   let hasWarned = useRef(false);
   useEffect(() => {
     if (locale && domRef.current) {
-      let closestLang = domRef.current.parentElement.closest('[lang]');
-      let lang = closestLang && closestLang.getAttribute('lang');
-      if (lang && lang !== locale && !hasWarned.current) {
-        console.warn(`Locales cannot be nested. ${locale} inside ${lang}.`);
+      let closestDir = domRef.current.parentElement.closest('[dir]');
+      let dir = closestDir && closestDir.getAttribute('dir');
+      if (dir && dir !== direction && !hasWarned.current) {
+        console.warn(`Dir's cannot be nested. ${direction} inside ${dir}.`);
         hasWarned.current = true;
       }
     }

--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -148,7 +148,7 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(props: Provide
 
   let hasWarned = useRef(false);
   useEffect(() => {
-    if (locale && domRef.current) {
+    if (direction && domRef.current) {
       let closestDir = domRef.current.parentElement.closest('[dir]');
       let dir = closestDir && closestDir.getAttribute('dir');
       if (dir && dir !== direction && !hasWarned.current) {
@@ -156,7 +156,7 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(props: Provide
         hasWarned.current = true;
       }
     }
-  }, [locale, domRef, hasWarned]);
+  }, [direction, domRef, hasWarned]);
 
 
   return (

--- a/packages/@react-spectrum/provider/src/Provider.tsx
+++ b/packages/@react-spectrum/provider/src/Provider.tsx
@@ -152,7 +152,7 @@ const ProviderWrapper = React.forwardRef(function ProviderWrapper(props: Provide
       let closestDir = domRef.current.parentElement.closest('[dir]');
       let dir = closestDir && closestDir.getAttribute('dir');
       if (dir && dir !== direction && !hasWarned.current) {
-        console.warn(`Dir's cannot be nested. ${direction} inside ${dir}.`);
+        console.warn(`Language directions cannot be nested. ${direction} inside ${dir}.`);
         hasWarned.current = true;
       }
     }


### PR DESCRIPTION
Closes https://jira.corp.adobe.com/browse/RSP-1846

## 📝 Test Instructions:

The nested provider message goes away on the false positives and is a dir message is there with nested dir's.

## 🧢 Your Project:
RSP
