### PR TITLE
Fix error class React does not recognize the prop on a DOM element

### DIFF
--- a/packages/@react-aria/interactions/test/usePress.test.js
+++ b/packages/@react-aria/interactions/test/usePress.test.js
@@ -16,7 +16,7 @@ import {usePress} from '../';
 
 function Example(props) {
   let {elementType: ElementType = 'div', ...otherProps} = props;
-  let {pressProps} = usePress(props);
+  let {pressProps} = usePress(otherProps);
   return <ElementType {...otherProps} {...pressProps}>test</ElementType>;
 }
 


### PR DESCRIPTION
As noted https://github.com/adobe-private/react-spectrum-v3/pull/502


Closes <!-- Github issue # here -->

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [Issue](https://github.com/adobe-private/react-spectrum-v3/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [ ] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [ ] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

<!--- Include instructions to test this pull request -->

## 🧢 Your Project:

<!--- Company/project for pull request -->
