### PR TITLE
Declare CSS files in the sideEffects field

### DIFF
--- a/lint-packages.js
+++ b/lint-packages.js
@@ -59,7 +59,11 @@ for (let pkg of packages) {
     softAssert(json.source, `${pkg} did not have "source"`);
     softAssert.equal(json.source, "src/index.ts", `${pkg} did not match "src/index.ts"`);
     softAssert.deepEqual(json.files, ['dist', 'src'], `${pkg} did not match "files"`);
-    softAssert.equal(json.sideEffects, false, `${pkg} is missing sideEffects: false`);
+    if (pkg.includes('@react-spectrum')){
+      softAssert.deepEqual(json.sideEffects, ['*.css'], `${pkg} is missing sideEffects: [ '*.css' ]`);
+    } else {
+      softAssert.equal(json.sideEffects, false, `${pkg} is missing sideEffects: false`);
+    }
     softAssert(!json.dependencies || !json.dependencies['@adobe/spectrum-css-temp'], `${pkg} has @adobe/spectrum-css-temp in dependencies instead of devDependencies`);
     softAssert(json.dependencies && json.dependencies['@babel/runtime'], `${pkg} is missing a dependency on @babel/runtime`);
     softAssert(!json.dependencies || !json.dependencies['@react-spectrum/test-utils'], '@react-spectrum/test-utils should be a devDependency');

--- a/packages/@react-spectrum/actiongroup/package.json
+++ b/packages/@react-spectrum/actiongroup/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/alert/package.json
+++ b/packages/@react-spectrum/alert/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/breadcrumbs/package.json
+++ b/packages/@react-spectrum/breadcrumbs/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/button/package.json
+++ b/packages/@react-spectrum/button/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/buttongroup/package.json
+++ b/packages/@react-spectrum/buttongroup/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/calendar/package.json
+++ b/packages/@react-spectrum/calendar/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/checkbox/package.json
+++ b/packages/@react-spectrum/checkbox/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/datepicker/package.json
+++ b/packages/@react-spectrum/datepicker/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/dialog/package.json
+++ b/packages/@react-spectrum/dialog/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/divider/package.json
+++ b/packages/@react-spectrum/divider/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/form/package.json
+++ b/packages/@react-spectrum/form/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/icon/package.json
+++ b/packages/@react-spectrum/icon/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/illustratedmessage/package.json
+++ b/packages/@react-spectrum/illustratedmessage/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/image/package.json
+++ b/packages/@react-spectrum/image/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/label/package.json
+++ b/packages/@react-spectrum/label/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/layout/package.json
+++ b/packages/@react-spectrum/layout/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/link/package.json
+++ b/packages/@react-spectrum/link/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/listbox/package.json
+++ b/packages/@react-spectrum/listbox/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/menu/package.json
+++ b/packages/@react-spectrum/menu/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/meter/package.json
+++ b/packages/@react-spectrum/meter/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/numberfield/package.json
+++ b/packages/@react-spectrum/numberfield/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/overlays/package.json
+++ b/packages/@react-spectrum/overlays/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/pagination/package.json
+++ b/packages/@react-spectrum/pagination/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/picker/package.json
+++ b/packages/@react-spectrum/picker/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/progress/package.json
+++ b/packages/@react-spectrum/progress/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/provider/package.json
+++ b/packages/@react-spectrum/provider/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/radio/package.json
+++ b/packages/@react-spectrum/radio/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/searchfield/package.json
+++ b/packages/@react-spectrum/searchfield/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/sidenav/package.json
+++ b/packages/@react-spectrum/sidenav/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/splitview/package.json
+++ b/packages/@react-spectrum/splitview/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/statuslight/package.json
+++ b/packages/@react-spectrum/statuslight/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/switch/package.json
+++ b/packages/@react-spectrum/switch/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/table/package.json
+++ b/packages/@react-spectrum/table/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/tabs/package.json
+++ b/packages/@react-spectrum/tabs/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/tag/package.json
+++ b/packages/@react-spectrum/tag/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/test-utils/package.json
+++ b/packages/@react-spectrum/test-utils/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/text/package.json
+++ b/packages/@react-spectrum/text/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/textfield/package.json
+++ b/packages/@react-spectrum/textfield/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/theme-dark/package.json
+++ b/packages/@react-spectrum/theme-dark/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/theme-default/package.json
+++ b/packages/@react-spectrum/theme-default/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/toast/package.json
+++ b/packages/@react-spectrum/toast/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/tooltip/package.json
+++ b/packages/@react-spectrum/tooltip/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/tree/package.json
+++ b/packages/@react-spectrum/tree/package.json
@@ -12,7 +12,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/utils/package.json
+++ b/packages/@react-spectrum/utils/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe-private/react-spectrum-v3"

--- a/packages/@react-spectrum/view/package.json
+++ b/packages/@react-spectrum/view/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/packages/@react-spectrum/well/package.json
+++ b/packages/@react-spectrum/well/package.json
@@ -11,7 +11,9 @@
     "dist",
     "src"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": [

--- a/plop-templates/@react-spectrum/package.json.hbs
+++ b/plop-templates/@react-spectrum/package.json.hbs
@@ -9,7 +9,9 @@
   "types": "dist/types.d.ts",
   "source": "src/index.ts",
   "files": ["dist"],
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "targets": {
     "main": {
       "includeNodeModules": ["@adobe/spectrum-css-temp"]


### PR DESCRIPTION
To make sure that bundler don't try to remove CSS imports from JS by marking them as side-effect-ful.

Changed every package.json in `@react-spectrum/*`, the corresponding template and the lint packages script. Are there other packages which have CSS imports?

 ## 📝 Test Instructions:

Build an app with a minimal webpack config:
```js
const path = require("path");

module.exports = {
	entry: "./index.js",
	output: {
		filename: "index.js",
		path: path.resolve(__dirname, "public"),
	},
	mode: "production",
	module: {
		rules: [
			{
				test: /\.m?js$/,
				exclude: /(node_modules|bower_components)/,
				use: {
					loader: "babel-loader",
					options: {
						presets: ["@babel/preset-react"],
					},
				},
			},
			{
				test: /\.css$/i,
				use: ["style-loader", "css-loader"],
				// this was previously necessary:
				// sideEffects: true
			},
		],
	},
};
```

Previously: no CSS at all
Now: works as expected
