### PR TITLE
fix RSP-1859 Clicking Breadcrumb MenuItem within Popover in Documentation closes Popover

### DIFF
--- a/packages/@react-aria/interactions/src/useInteractOutside.ts
+++ b/packages/@react-aria/interactions/src/useInteractOutside.ts
@@ -91,5 +91,13 @@ function isValidEvent(event, ref) {
     return false;
   }
 
+  // if the event target is no longer in the document
+  if (event.target) {
+    const ownerDocument = event.target.ownerDocument;
+    if (!ownerDocument || !ownerDocument.body.contains(event.target)) {
+      return false;
+    }
+  }
+
   return ref.current && !ref.current.contains(event.target);
 }

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -61,15 +61,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   }, [isOpen, ref]);
 
   // Only hide the overlay when it is the topmost visible overlay in the stack.
-  let onHide = (e) => {
-    // if the event target is no longer in the document
-    if (e && e.target) {
-      const ownerDocument = e.target.ownerDocument;
-      if (!ownerDocument || !ownerDocument.body.contains(e.target)) {
-        return;
-      }
-    }
-
+  let onHide = () => {
     if (visibleOverlays[visibleOverlays.length - 1] === ref && onClose) {
       onClose();
     }
@@ -79,7 +71,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   let onKeyDown = (e) => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      onHide(e);
+      onHide();
     }
   };
 

--- a/packages/@react-aria/overlays/src/useOverlay.ts
+++ b/packages/@react-aria/overlays/src/useOverlay.ts
@@ -61,7 +61,15 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   }, [isOpen, ref]);
 
   // Only hide the overlay when it is the topmost visible overlay in the stack.
-  let onHide = () => {
+  let onHide = (e) => {
+    // if the event target is no longer in the document
+    if (e && e.target) {
+      const ownerDocument = e.target.ownerDocument;
+      if (!ownerDocument || !ownerDocument.body.contains(e.target)) {
+        return;
+      }
+    }
+
     if (visibleOverlays[visibleOverlays.length - 1] === ref && onClose) {
       onClose();
     }
@@ -71,7 +79,7 @@ export function useOverlay(props: OverlayProps, ref: RefObject<HTMLElement>): Ov
   let onKeyDown = (e) => {
     if (e.key === 'Escape') {
       e.preventDefault();
-      onHide();
+      onHide(e);
     }
   };
 


### PR DESCRIPTION
Closes [RSP-1859](https://jira.corp.adobe.com/browse/RSP-1859)

## ✅ Pull Request Checklist:

- [x] Included link to corresponding [RSP-1859](https://jira.corp.adobe.com/browse/RSP-1859).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [ ] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## 📝 Test Instructions:

Steps to reproduce:
 1. open docs site to [https://react-spectrum.adobe.com/react-aria/useListBox.html]
 2. click code example link: labelled "AriaListBoxOptions" to open popover
 3. within Popover, click "CollectionChildren" link
 4. within Popover, click "CollectionElement" link
 5. within Popover, click "SectionElement" link
 6. within Popover, click "SectionProps" link, Breadcrumbs will collapse to show menu button
 7. click Breadcrumbs menu button to expand menu
 8. using mouse, click a menu item before the current selection

Expected behavior:
 Menu should close without also closing the Popover, and the contents of the Popover should update based on the selected breadcrumb.

Actual behavior:
 Both the Menu and the Popover close, and focus is not restored correctly to the AriaListBoxOptions link.

Diagnosis:
 The `onHide` method for the `Popover` gets called when a `Breadcrumb` `Menu` `MenuItem` is clicked, because `onPointerUp` on the `MenuItem` is interpreted as `onInteractionOutside` the `Popover`.

One possible solution would be to make sure the event target passed to `onHide` by `onInteractionOutside` is still in the document before closing the `Popover` with `onClose`.

## 🧢 Your Project:

Accessibility